### PR TITLE
Add bridge backend profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- Added named bridge backend profiles and a settings dialog for switching the active backend.
 - Added a bridge capabilities endpoint so the web app can discover supported commands without
   sending probe commands to Herdr.
 - Added pane context-menu actions to move a pane into a new tab or a new workspace when the bridge

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  currentConnectionSnapshot,
+  isConnectionResultCurrent,
+} from "./connectionState";
+
+describe("App connection guards", () => {
+  it("hides snapshots from stale backend connections", () => {
+    const snapshot = { panes: ["pane-a"] };
+
+    expect(currentConnectionSnapshot(snapshot, "same-origin", "same-origin")).toBe(snapshot);
+    expect(currentConnectionSnapshot(snapshot, "configured:a", "configured:b")).toBeNull();
+  });
+
+  it("rejects async results from stale backend connections", () => {
+    expect(isConnectionResultCurrent("configured:a", "configured:a")).toBe(true);
+    expect(isConnectionResultCurrent("configured:b", "configured:a")).toBe(false);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,13 +3,16 @@ import {
   PanelLeft,
   Plus,
   RefreshCw,
+  Settings,
   SplitSquareHorizontal,
   SplitSquareVertical,
 } from "lucide-react";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { AgentIcon, agentIconKind } from "./AgentIcon";
-import { commands, createdPaneId, probeSupportedCommands } from "./commands";
+import { BackendSettingsDialog } from "./BackendSettingsDialog";
+import { useBridge } from "./bridge";
+import { createCommands, createdPaneId } from "./commands";
 import type { LaunchSpec, PaneFocusDirection, SplitDirection } from "./commands";
 import { LaunchDialog } from "./LaunchDialog";
 import { resolveLaunchSpec } from "./launch";
@@ -182,8 +185,11 @@ function stripMobileHistoryState(value: unknown) {
 }
 
 export function App() {
+  const bridge = useBridge();
+  const commands = useMemo(() => createCommands(bridge.httpUrl), [bridge.httpUrl]);
   const initialPrefs = useMemo(readDisplayPrefs, []);
-  const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
+  const [snapshotState, setSnapshot] = useState<Snapshot | null>(null);
+  const [snapshotConnectionKey, setSnapshotConnectionKey] = useState(bridge.connectionKey);
   const [selectedPaneId, setSelectedPaneId] = useState<string | null>(initialPrefs.selectedPaneId);
   const [activeSpaceId, setActiveSpaceId] = useState<string | null>(initialPrefs.activeSpaceId);
   const [scope, setScope] = useState<Scope>(initialPrefs.scope);
@@ -197,12 +203,10 @@ export function App() {
   const [showDetail, setShowDetail] = useState(false);
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [dialog, setDialog] = useState<DialogState | null>(null);
+  const [backendSettingsOpen, setBackendSettingsOpen] = useState(false);
   const [launchTarget, setLaunchTarget] = useState<LaunchTarget | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [splitSupported, setSplitSupported] = useState(false);
-  const [paneFocusSupported, setPaneFocusSupported] = useState(false);
-  const [paneMoveSupported, setPaneMoveSupported] = useState(false);
   const [refitToken, setRefitToken] = useState(0);
   const [terminalFocusToken, setTerminalFocusToken] = useState(0);
   const isCompactLayout = useIsCompactLayout();
@@ -210,6 +214,7 @@ export function App() {
   const snapshotRef = useRef<Snapshot | null>(null);
   const isCompactLayoutRef = useRef(isCompactLayout);
   const showDetailRef = useRef(showDetail);
+  const connectionKeyRef = useRef(bridge.connectionKey);
   const mobileSidebarHistoryRef = useRef(false);
   const mobileDetailHistoryRef = useRef(false);
   const sidebarResizePressRef = useRef<{
@@ -220,7 +225,12 @@ export function App() {
     target: HTMLDivElement;
   } | null>(null);
 
+  const snapshot = snapshotConnectionKey === bridge.connectionKey ? snapshotState : null;
   const resolvedPaneId = chooseSelectedPane(snapshot, selectedPaneId);
+  const supportedCommands = bridge.capabilities?.commands ?? [];
+  const splitSupported = supportedCommands.includes("pane.split");
+  const paneFocusSupported = supportedCommands.includes("pane.focus_direction");
+  const paneMoveSupported = supportedCommands.includes("pane.move");
 
   const ensureMobileSidebarHistory = () => {
     if (!isCompactLayoutRef.current || isMobileDetailHistoryState(window.history.state)) {
@@ -343,11 +353,33 @@ export function App() {
 
   useEffect(() => {
     let disposed = false;
-    const refresh = () => refreshSnapshot(setSnapshot, setLoadState, () => disposed);
+    if (connectionKeyRef.current !== bridge.connectionKey) {
+      connectionKeyRef.current = bridge.connectionKey;
+      setSnapshot(null);
+      setSnapshotConnectionKey(bridge.connectionKey);
+      setSelectedPaneId(null);
+      setActiveSpaceId(null);
+    }
+    if (!bridge.canConnect) {
+      setLoadState("ready");
+      return () => {
+        disposed = true;
+      };
+    }
+    const refresh = () =>
+      refreshSnapshot(
+        bridge.httpUrl,
+        (next) => {
+          setSnapshot(next);
+          setSnapshotConnectionKey(bridge.connectionKey);
+        },
+        setLoadState,
+        () => disposed,
+      );
     void refresh();
     const interval = window.setInterval(refresh, 10000);
-    const events = openEventsSocket("/ws/events", () => void refresh());
-    const uiEvents = openEventsSocket("/ws/ui-events", (event) => {
+    const events = openEventsSocket(bridge.wsUrl, "/ws/events", () => void refresh());
+    const uiEvents = openEventsSocket(bridge.wsUrl, "/ws/ui-events", (event) => {
       const paneId = selectionPaneId(event);
       if (paneId) {
         setSelectedPaneId(paneId);
@@ -364,7 +396,7 @@ export function App() {
       uiEvents?.close();
       window.clearInterval(interval);
     };
-  }, []);
+  }, [bridge.canConnect, bridge.connectionKey, bridge.httpUrl, bridge.wsUrl]);
 
   useEffect(() => {
     if (!error) {
@@ -373,21 +405,6 @@ export function App() {
     const timer = window.setTimeout(() => setError(null), 4500);
     return () => window.clearTimeout(timer);
   }, [error]);
-
-  // Feature-detect bridge-gated commands so controls only appear when they work.
-  useEffect(() => {
-    let cancelled = false;
-    void probeSupportedCommands().then((supportedCommands) => {
-      if (!cancelled) {
-        setSplitSupported(supportedCommands.has("pane.split"));
-        setPaneFocusSupported(supportedCommands.has("pane.focus_direction"));
-        setPaneMoveSupported(supportedCommands.has("pane.move"));
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   useEffect(() => {
     const onPopState = (event: PopStateEvent) => {
@@ -538,7 +555,7 @@ export function App() {
   const openPane = (pane: PaneInfo) => {
     setSelectedPaneId(pane.pane_id);
     setActiveSpaceId(pane.workspace_id);
-    void syncSelectedPane(pane.pane_id).catch(() => {});
+    void syncSelectedPane(bridge.httpUrl, pane.pane_id).catch(() => {});
     pushFocus(pane.tab_id, pane.workspace_id);
     if (isCompactLayout) {
       openMobileDetail();
@@ -554,7 +571,7 @@ export function App() {
       if (paneId) {
         setSelectedPaneId(paneId);
         const pane = snapshot.panes.find((item) => item.pane_id === paneId);
-        void syncSelectedPane(paneId).catch(() => {});
+        void syncSelectedPane(bridge.httpUrl, paneId).catch(() => {});
         pushFocus(pane?.tab_id, workspaceId);
         return;
       }
@@ -759,21 +776,39 @@ export function App() {
   ]);
 
   const refreshNow = () => {
+    if (!bridge.canConnect) {
+      setBackendSettingsOpen(true);
+      return;
+    }
+    const requestConnectionKey = bridge.connectionKey;
     setLoadState("loading");
-    void fetchSnapshot()
+    void fetchSnapshot(bridge.httpUrl)
       .then((next) => {
+        if (connectionKeyRef.current !== requestConnectionKey) {
+          return;
+        }
         setSnapshot(next);
+        setSnapshotConnectionKey(requestConnectionKey);
         setLoadState("ready");
       })
-      .catch(() => setLoadState("error"));
+      .catch(() => {
+        if (connectionKeyRef.current === requestConnectionKey) {
+          setLoadState("error");
+        }
+      });
   };
 
   async function exec(action: () => Promise<{ [key: string]: unknown }>, selectCreated = false) {
+    const requestConnectionKey = bridge.connectionKey;
     setBusy(true);
     try {
       const result = await action();
-      const next = await fetchSnapshot();
+      const next = await fetchSnapshot(bridge.httpUrl);
+      if (connectionKeyRef.current !== requestConnectionKey) {
+        return false;
+      }
       setSnapshot(next);
+      setSnapshotConnectionKey(requestConnectionKey);
       setLoadState("ready");
       if (selectCreated) {
         const paneId = createdPaneId(result);
@@ -781,7 +816,7 @@ export function App() {
         if (created) {
           setSelectedPaneId(created.pane_id);
           setActiveSpaceId(created.workspace_id);
-          void syncSelectedPane(created.pane_id).catch(() => {});
+          void syncSelectedPane(bridge.httpUrl, created.pane_id).catch(() => {});
           if (isCompactLayout) {
             openMobileDetail();
           }
@@ -898,6 +933,9 @@ export function App() {
         <Switcher
           snapshot={snapshot}
           loadState={loadState}
+          bridgeLabel={bridge.activeBackend?.name ?? "same-origin"}
+          bridgeMode={bridge.mode}
+          capabilityState={bridge.capabilityState}
           scope={scope}
           sidebarView={sidebarView}
           agentSort={agentSort}
@@ -912,6 +950,7 @@ export function App() {
           onSelectTab={selectTab}
           onSelectPane={openPane}
           onRefresh={refreshNow}
+          onBackendSettings={() => setBackendSettingsOpen(true)}
           onCreateSpace={() => void exec(() => commands.createWorkspace(), true)}
           onCreateTab={(workspaceId) => setLaunchTarget({ mode: "tab", workspaceId })}
           onMenu={(kind, id, label, x, y, clearable) =>
@@ -1065,10 +1104,16 @@ export function App() {
             refitToken={refitToken}
             focusToken={terminalFocusToken}
             touchInput={isTouchInput}
+            connectionKey={bridge.connectionKey}
+            httpUrl={bridge.httpUrl}
+            wsUrl={bridge.wsUrl}
           />
         ) : renderTerminal ? (
           <TerminalView
             pane={selectedPane}
+            connectionKey={bridge.connectionKey}
+            httpUrl={bridge.httpUrl}
+            wsUrl={bridge.wsUrl}
             autoFocus={!isTouchInput}
             scrollSensitivity={isTouchInput ? 2 : 0.4}
             mobileControls={isTouchInput}
@@ -1121,6 +1166,10 @@ export function App() {
           onCancel={() => setLaunchTarget(null)}
           onSubmit={submitLaunch}
         />
+      ) : null}
+
+      {backendSettingsOpen ? (
+        <BackendSettingsDialog onClose={() => setBackendSettingsOpen(false)} />
       ) : null}
 
       {error ? (
@@ -1274,6 +1323,9 @@ function SplitGrid({
   refitToken,
   focusToken,
   touchInput,
+  connectionKey,
+  httpUrl,
+  wsUrl,
 }: {
   cells: { pane: PaneInfo; style: CSSProperties }[];
   selectedPaneId: string | null;
@@ -1281,6 +1333,9 @@ function SplitGrid({
   refitToken: number;
   focusToken: number;
   touchInput: boolean;
+  connectionKey: string;
+  httpUrl: (path: string, query?: URLSearchParams) => string;
+  wsUrl: (path: string, query?: URLSearchParams) => string;
 }) {
   return (
     <div className="pane-grid" aria-label="Split panes">
@@ -1296,6 +1351,9 @@ function SplitGrid({
           >
             <TerminalView
               pane={pane}
+              connectionKey={connectionKey}
+              httpUrl={httpUrl}
+              wsUrl={wsUrl}
               autoFocus={selected && !touchInput}
               scrollSensitivity={touchInput ? 2 : 0.4}
               mobileControls={selected && touchInput}
@@ -1381,6 +1439,9 @@ function TabBar({
 function Switcher({
   snapshot,
   loadState,
+  bridgeLabel,
+  bridgeMode,
+  capabilityState,
   scope,
   sidebarView,
   agentSort,
@@ -1395,12 +1456,16 @@ function Switcher({
   onSelectTab,
   onSelectPane,
   onRefresh,
+  onBackendSettings,
   onCreateSpace,
   onCreateTab,
   onMenu,
 }: {
   snapshot: Snapshot | null;
   loadState: LoadState;
+  bridgeLabel: string;
+  bridgeMode: "same-origin" | "configured" | "disconnected";
+  capabilityState: "idle" | "probing" | "ready" | "error";
   scope: Scope;
   sidebarView: SidebarView;
   agentSort: AgentSort;
@@ -1415,6 +1480,7 @@ function Switcher({
   onSelectTab: (tabId: string) => void;
   onSelectPane: (pane: PaneInfo) => void;
   onRefresh: () => void;
+  onBackendSettings: () => void;
   onCreateSpace: () => void;
   onCreateTab: (workspaceId: string) => void;
   onMenu: (
@@ -1492,8 +1558,20 @@ function Switcher({
             <span className="brand-sub">
               <b>{headerSummary}</b>
             </span>
+          ) : bridgeMode === "configured" ? (
+            <span className="brand-sub">{bridgeLabel}</span>
           ) : null}
         </div>
+        <button
+          className="icon-btn"
+          type="button"
+          aria-label="Bridge settings"
+          title={`Bridge: ${bridgeLabel}`}
+          data-spin={capabilityState === "probing" ? "" : undefined}
+          onClick={onBackendSettings}
+        >
+          <Settings size={16} />
+        </button>
         <button
           className="icon-btn"
           type="button"
@@ -2141,16 +2219,19 @@ function stageBreadcrumb(snapshot: Snapshot | null, pane: PaneInfo | null, loadS
   return [workspace?.label, tabLabel].filter(Boolean).join(" · ") || pane.pane_id;
 }
 
-async function fetchSnapshot() {
-  const response = await fetch("/api/snapshot");
+async function fetchSnapshot(httpUrl: (path: string, query?: URLSearchParams) => string) {
+  const response = await fetch(httpUrl("/api/snapshot"));
   if (!response.ok) {
     throw new Error(`snapshot failed: ${response.status}`);
   }
   return (await response.json()) as Snapshot;
 }
 
-async function syncSelectedPane(paneId: string) {
-  const response = await fetch("/api/selection", {
+async function syncSelectedPane(
+  httpUrl: (path: string, query?: URLSearchParams) => string,
+  paneId: string,
+) {
+  const response = await fetch(httpUrl("/api/selection"), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ pane_id: paneId }),
@@ -2161,12 +2242,13 @@ async function syncSelectedPane(paneId: string) {
 }
 
 async function refreshSnapshot(
+  httpUrl: (path: string, query?: URLSearchParams) => string,
   setSnapshot: (snapshot: Snapshot) => void,
   setLoadState: (state: LoadState) => void,
   isDisposed: () => boolean,
 ) {
   try {
-    const next = await fetchSnapshot();
+    const next = await fetchSnapshot(httpUrl);
     if (!isDisposed()) {
       setSnapshot(next);
       setLoadState("ready");
@@ -2192,9 +2274,12 @@ function selectionPaneId(event: MessageEvent) {
   }
 }
 
-function openEventsSocket(path: string, onEvent: (event: MessageEvent) => void) {
-  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-  const url = `${protocol}//${window.location.host}${path}`;
+function openEventsSocket(
+  wsUrl: (path: string, query?: URLSearchParams) => string,
+  path: string,
+  onEvent: (event: MessageEvent) => void,
+) {
+  const url = wsUrl(path);
   let socket: WebSocket | null = null;
   let closed = false;
   let reconnectTimer: number | null = null;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,10 @@ import { BackendSettingsDialog } from "./BackendSettingsDialog";
 import { useBridge } from "./bridge";
 import { createCommands, createdPaneId } from "./commands";
 import type { LaunchSpec, PaneFocusDirection, SplitDirection } from "./commands";
+import {
+  currentConnectionSnapshot,
+  isConnectionResultCurrent,
+} from "./connectionState";
 import { LaunchDialog } from "./LaunchDialog";
 import { resolveLaunchSpec } from "./launch";
 import type { LaunchTarget } from "./launch";
@@ -80,6 +84,7 @@ const MOBILE_DETAIL_HISTORY_KEY = "herdrWebMobileDetail";
 const DEFAULT_SIDEBAR_WIDTH = 320;
 const MIN_SIDEBAR_WIDTH = 260;
 const MAX_SIDEBAR_WIDTH = 560;
+
 function readDisplayPrefs(): DisplayPrefs {
   const fallback: DisplayPrefs = {
     scope: "space",
@@ -225,7 +230,11 @@ export function App() {
     target: HTMLDivElement;
   } | null>(null);
 
-  const snapshot = snapshotConnectionKey === bridge.connectionKey ? snapshotState : null;
+  const snapshot = currentConnectionSnapshot(
+    snapshotState,
+    snapshotConnectionKey,
+    bridge.connectionKey,
+  );
   const resolvedPaneId = chooseSelectedPane(snapshot, selectedPaneId);
   const supportedCommands = bridge.capabilities?.commands ?? [];
   const splitSupported = supportedCommands.includes("pane.split");
@@ -361,6 +370,10 @@ export function App() {
       setActiveSpaceId(null);
     }
     if (!bridge.canConnect) {
+      setSnapshot(null);
+      setSnapshotConnectionKey(bridge.connectionKey);
+      setSelectedPaneId(null);
+      setActiveSpaceId(null);
       setLoadState("ready");
       return () => {
         disposed = true;
@@ -784,7 +797,7 @@ export function App() {
     setLoadState("loading");
     void fetchSnapshot(bridge.httpUrl)
       .then((next) => {
-        if (connectionKeyRef.current !== requestConnectionKey) {
+        if (!isConnectionResultCurrent(connectionKeyRef.current, requestConnectionKey)) {
           return;
         }
         setSnapshot(next);
@@ -804,7 +817,7 @@ export function App() {
     try {
       const result = await action();
       const next = await fetchSnapshot(bridge.httpUrl);
-      if (connectionKeyRef.current !== requestConnectionKey) {
+      if (!isConnectionResultCurrent(connectionKeyRef.current, requestConnectionKey)) {
         return false;
       }
       setSnapshot(next);
@@ -933,6 +946,8 @@ export function App() {
         <Switcher
           snapshot={snapshot}
           loadState={loadState}
+          bridgeCanConnect={bridge.canConnect}
+          bridgeError={bridge.capabilityError}
           bridgeLabel={bridge.activeBackend?.name ?? "same-origin"}
           bridgeMode={bridge.mode}
           capabilityState={bridge.capabilityState}
@@ -1047,7 +1062,7 @@ export function App() {
           <div className="stage-id" {...selectedPaneMenuPress}>
             <span className="stage-title">{selectedPane ? paneTitle(selectedPane) : "herdr-web"}</span>
             <span className="stage-sub mono">
-              {stageBreadcrumb(snapshot, selectedPane, loadState)}
+              {stageBreadcrumb(snapshot, selectedPane, loadState, bridge.canConnect)}
             </span>
           </div>
           {splitSupported && selectedPane && !isCompactLayout ? (
@@ -1439,6 +1454,8 @@ function TabBar({
 function Switcher({
   snapshot,
   loadState,
+  bridgeCanConnect,
+  bridgeError,
   bridgeLabel,
   bridgeMode,
   capabilityState,
@@ -1463,6 +1480,8 @@ function Switcher({
 }: {
   snapshot: Snapshot | null;
   loadState: LoadState;
+  bridgeCanConnect: boolean;
+  bridgeError: string | null;
   bridgeLabel: string;
   bridgeMode: "same-origin" | "configured" | "disconnected";
   capabilityState: "idle" | "probing" | "ready" | "error";
@@ -1495,6 +1514,7 @@ function Switcher({
   const panes = snapshot?.panes ?? [];
   const roll = aggregateStatus(panes);
   const headerSummary = summary(panes);
+  const bridgeBlocked = !bridgeCanConnect;
 
   const agentPanes = useMemo(() => {
     if (!snapshot) {
@@ -1624,8 +1644,25 @@ function Switcher({
       <div className="list">
         {!snapshot ? (
           <div className="empty">
-            <strong>{loadState === "error" ? "Bridge unavailable" : "Connecting…"}</strong>
-            <span>{loadState === "error" ? "Could not reach the herdr bridge." : ""}</span>
+            <strong>
+              {bridgeBlocked
+                ? "Bridge disconnected"
+                : loadState === "error"
+                  ? "Bridge unavailable"
+                  : "Connecting…"}
+            </strong>
+            <span>
+              {bridgeBlocked
+                ? bridgeError || "Choose a usable bridge backend."
+                : loadState === "error"
+                  ? "Could not reach the herdr bridge."
+                  : ""}
+            </span>
+            {bridgeBlocked ? (
+              <button type="button" className="btn" onClick={onBackendSettings}>
+                Bridge settings
+              </button>
+            ) : null}
           </div>
         ) : (
           <>
@@ -2206,8 +2243,16 @@ function summary(panes: PaneInfo[]) {
         : null;
 }
 
-function stageBreadcrumb(snapshot: Snapshot | null, pane: PaneInfo | null, loadState: LoadState) {
+function stageBreadcrumb(
+  snapshot: Snapshot | null,
+  pane: PaneInfo | null,
+  loadState: LoadState,
+  bridgeCanConnect: boolean,
+) {
   if (!pane) {
+    if (!bridgeCanConnect) {
+      return "bridge disconnected";
+    }
     if (loadState === "error") {
       return "bridge unavailable";
     }

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -28,6 +28,7 @@ const emptyForm: FormState = {
 export function BackendSettingsDialog({ onClose }: Props) {
   const bridge = useBridge();
   const titleId = useId();
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const nameInputRef = useRef<HTMLInputElement | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
   const [selectionMode, setSelectionMode] = useState<SelectionMode>(
@@ -44,8 +45,12 @@ export function BackendSettingsDialog({ onClose }: Props) {
   );
 
   useEffect(() => {
+    if (selectionMode === "same-origin") {
+      closeButtonRef.current?.focus();
+      return;
+    }
     nameInputRef.current?.focus();
-  }, []);
+  }, [selectionMode]);
 
   useEffect(() => {
     if (selectionMode !== "backend" || form.id || bridge.store.backends.length === 0) {
@@ -55,12 +60,16 @@ export function BackendSettingsDialog({ onClose }: Props) {
     setForm({ id: backend.id, name: backend.name, baseUrl: backend.baseUrl });
   }, [activeBackend, bridge.store.backends, form.id, selectionMode]);
 
-  const useSameOrigin = () => {
-    bridge.clearActiveBackend();
+  const selectSameOrigin = () => {
     setSelectionMode("same-origin");
     setForm(emptyForm);
-    setMessage("Using the same-origin bridge.");
+    setMessage(null);
     setDuplicate(null);
+  };
+
+  const useSameOrigin = () => {
+    bridge.clearActiveBackend();
+    onClose();
   };
 
   const startNew = () => {
@@ -181,6 +190,7 @@ export function BackendSettingsDialog({ onClose }: Props) {
       >
         <button
           className="modal-close icon-btn"
+          ref={closeButtonRef}
           type="button"
           aria-label="Close"
           title="Close"
@@ -195,7 +205,7 @@ export function BackendSettingsDialog({ onClose }: Props) {
               className="backend-row"
               type="button"
               data-active={selectionMode === "same-origin" ? "true" : undefined}
-              onClick={useSameOrigin}
+              onClick={selectSameOrigin}
             >
               {!bridge.store.activeBackendId ? <Check size={14} /> : <span />}
               <span>
@@ -270,7 +280,7 @@ export function BackendSettingsDialog({ onClose }: Props) {
               </>
             )}
             {selectionMode === "same-origin" && bridge.store.activeBackendId ? (
-              <div className="backend-warning">Select this row to switch back to same origin.</div>
+              <div className="backend-note">Use switches back from the active saved bridge.</div>
             ) : null}
             {duplicate ? (
               <div className="backend-warning">This URL is already saved as {duplicate.name}.</div>
@@ -282,6 +292,11 @@ export function BackendSettingsDialog({ onClose }: Props) {
           {canDelete ? (
             <button type="button" className="btn btn-danger" disabled={busy} onClick={deleteBackend}>
               Delete
+            </button>
+          ) : null}
+          {selectionMode === "same-origin" && bridge.store.activeBackendId ? (
+            <button type="button" className="btn btn-primary" onClick={useSameOrigin}>
+              Use
             </button>
           ) : null}
           {editingBackend ? (

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -17,6 +17,8 @@ type FormState = {
   baseUrl: string;
 };
 
+type SelectionMode = "same-origin" | "new" | "backend";
+
 const emptyForm: FormState = {
   id: null,
   name: "",
@@ -28,7 +30,9 @@ export function BackendSettingsDialog({ onClose }: Props) {
   const titleId = useId();
   const nameInputRef = useRef<HTMLInputElement | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
-  const [creating, setCreating] = useState(false);
+  const [selectionMode, setSelectionMode] = useState<SelectionMode>(
+    bridge.activeBackend ? "backend" : "same-origin",
+  );
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [duplicate, setDuplicate] = useState<BridgeBackendProfile | null>(null);
@@ -44,22 +48,30 @@ export function BackendSettingsDialog({ onClose }: Props) {
   }, []);
 
   useEffect(() => {
-    if (creating || form.id || bridge.store.backends.length === 0) {
+    if (selectionMode !== "backend" || form.id || bridge.store.backends.length === 0) {
       return;
     }
     const backend = activeBackend ?? bridge.store.backends[0];
     setForm({ id: backend.id, name: backend.name, baseUrl: backend.baseUrl });
-  }, [activeBackend, bridge.store.backends, creating, form.id]);
+  }, [activeBackend, bridge.store.backends, form.id, selectionMode]);
+
+  const useSameOrigin = () => {
+    bridge.clearActiveBackend();
+    setSelectionMode("same-origin");
+    setForm(emptyForm);
+    setMessage("Using the bridge that served this page.");
+    setDuplicate(null);
+  };
 
   const startNew = () => {
-    setCreating(true);
+    setSelectionMode("new");
     setForm(emptyForm);
     setMessage(null);
     setDuplicate(null);
   };
 
   const editBackend = (backend: BridgeBackendProfile) => {
-    setCreating(false);
+    setSelectionMode("backend");
     setForm({ id: backend.id, name: backend.name, baseUrl: backend.baseUrl });
     setMessage(null);
     setDuplicate(null);
@@ -119,7 +131,7 @@ export function BackendSettingsDialog({ onClose }: Props) {
       if (activate && form.id) {
         bridge.setActiveBackend(profile.id);
       }
-      setCreating(false);
+      setSelectionMode("backend");
       setForm({ id: profile.id, name: profile.name, baseUrl: profile.baseUrl });
       setMessage(probeWarning ? `Backend saved. ${probeWarning}` : "Backend saved.");
       if (activate) {
@@ -141,7 +153,8 @@ export function BackendSettingsDialog({ onClose }: Props) {
   };
 
   const canDelete = Boolean(form.id && bridge.activeBackend?.id !== form.id);
-  const canUseSameOrigin = bridge.mode === "configured" || bridge.store.activeBackendId !== null;
+  const editingBackend = selectionMode !== "same-origin";
+  const sameOriginUrl = sameOriginDisplayUrl();
 
   return (
     <div className="overlay-root">
@@ -160,6 +173,9 @@ export function BackendSettingsDialog({ onClose }: Props) {
         }}
         onSubmit={(event) => {
           event.preventDefault();
+          if (!editingBackend) {
+            return;
+          }
           void saveBackend(true);
         }}
       >
@@ -169,7 +185,19 @@ export function BackendSettingsDialog({ onClose }: Props) {
             <button
               className="backend-row"
               type="button"
-              data-active={!form.id ? "true" : undefined}
+              data-active={selectionMode === "same-origin" ? "true" : undefined}
+              onClick={useSameOrigin}
+            >
+              {!bridge.store.activeBackendId ? <Check size={14} /> : <span />}
+              <span>
+                <strong>Same-origin bridge</strong>
+                <small>{sameOriginUrl}</small>
+              </span>
+            </button>
+            <button
+              className="backend-row"
+              type="button"
+              data-active={selectionMode === "new" ? "true" : undefined}
               onClick={startNew}
             >
               <Plus size={14} />
@@ -192,33 +220,52 @@ export function BackendSettingsDialog({ onClose }: Props) {
             ))}
           </div>
           <div className="backend-form">
-            <label className="field-label">
-              <span>Display name</span>
-              <input
-                ref={nameInputRef}
-                className="field"
-                value={form.name}
-                placeholder="Home workstation"
-                autoComplete="off"
-                onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
-              />
-            </label>
-            <label className="field-label">
-              <span>Bridge URL</span>
-              <input
-                className="field"
-                value={form.baseUrl}
-                placeholder="http://192.168.1.20:4000"
-                autoComplete="off"
-                spellCheck={false}
-                onBlur={validateDuplicate}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, baseUrl: event.target.value }))
-                }
-              />
-            </label>
-            {selectedBackend?.lastConnectedAt ? (
-              <div className="backend-note">Last used {formatDate(selectedBackend.lastConnectedAt)}</div>
+            {selectionMode === "same-origin" ? (
+              <>
+                <label className="field-label">
+                  <span>Display name</span>
+                  <input className="field" value="Same-origin bridge" readOnly />
+                </label>
+                <label className="field-label">
+                  <span>Bridge URL</span>
+                  <input className="field" value={sameOriginUrl} readOnly />
+                </label>
+                <div className="backend-note">This built-in backend uses the bridge that served the web app.</div>
+              </>
+            ) : (
+              <>
+                <label className="field-label">
+                  <span>Display name</span>
+                  <input
+                    ref={nameInputRef}
+                    className="field"
+                    value={form.name}
+                    placeholder="Home workstation"
+                    autoComplete="off"
+                    onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+                  />
+                </label>
+                <label className="field-label">
+                  <span>Bridge URL</span>
+                  <input
+                    className="field"
+                    value={form.baseUrl}
+                    placeholder="http://192.168.1.20:4000"
+                    autoComplete="off"
+                    spellCheck={false}
+                    onBlur={validateDuplicate}
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, baseUrl: event.target.value }))
+                    }
+                  />
+                </label>
+                {selectedBackend?.lastConnectedAt ? (
+                  <div className="backend-note">Last used {formatDate(selectedBackend.lastConnectedAt)}</div>
+                ) : null}
+              </>
+            )}
+            {selectionMode === "same-origin" && bridge.store.activeBackendId ? (
+              <div className="backend-warning">Select this row to switch back to the serving bridge.</div>
             ) : null}
             {duplicate ? (
               <div className="backend-warning">This URL is already saved as {duplicate.name}.</div>
@@ -227,11 +274,6 @@ export function BackendSettingsDialog({ onClose }: Props) {
           </div>
         </div>
         <div className="modal-actions">
-          {canUseSameOrigin ? (
-            <button type="button" className="btn btn-clear" onClick={bridge.clearActiveBackend}>
-              Use same-origin
-            </button>
-          ) : null}
           {canDelete ? (
             <button type="button" className="btn btn-danger" disabled={busy} onClick={deleteBackend}>
               <Trash2 size={14} />
@@ -241,24 +283,36 @@ export function BackendSettingsDialog({ onClose }: Props) {
           <button type="button" className="btn" onClick={onClose}>
             Close
           </button>
-          <button type="button" className="btn" disabled={busy || !form.baseUrl.trim()} onClick={testBackend}>
-            Test
-          </button>
-          <button
-            type="button"
-            className="btn"
-            disabled={busy || !form.baseUrl.trim()}
-            onClick={() => void saveBackend(false)}
-          >
-            Save
-          </button>
-          <button type="submit" className="btn btn-primary" disabled={busy || !form.baseUrl.trim()}>
-            Save & use
-          </button>
+          {editingBackend ? (
+            <>
+              <button type="button" className="btn" disabled={busy || !form.baseUrl.trim()} onClick={testBackend}>
+                Test
+              </button>
+              <button
+                type="button"
+                className="btn"
+                disabled={busy || !form.baseUrl.trim()}
+                onClick={() => void saveBackend(false)}
+              >
+                Save
+              </button>
+              <button type="submit" className="btn btn-primary" disabled={busy || !form.baseUrl.trim()}>
+                Save & use
+              </button>
+            </>
+          ) : null}
         </div>
       </form>
     </div>
   );
+}
+
+function sameOriginDisplayUrl() {
+  const location = globalThis.location;
+  if (!location?.origin || location.origin === "null") {
+    return "same-origin";
+  }
+  return location.origin;
 }
 
 function formatDate(value: string) {

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { Check, Plus, Trash2 } from "lucide-react";
+import { Check, Plus, X } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   duplicateBackend,
@@ -179,6 +179,15 @@ export function BackendSettingsDialog({ onClose }: Props) {
           void saveBackend(true);
         }}
       >
+        <button
+          className="modal-close icon-btn"
+          type="button"
+          aria-label="Close"
+          title="Close"
+          onClick={onClose}
+        >
+          <X size={15} />
+        </button>
         <div id={titleId} className="modal-title">Bridges</div>
         <div className="backend-layout">
           <div className="backend-list" role="list" aria-label="Saved bridges">
@@ -272,13 +281,9 @@ export function BackendSettingsDialog({ onClose }: Props) {
         <div className="modal-actions">
           {canDelete ? (
             <button type="button" className="btn btn-danger" disabled={busy} onClick={deleteBackend}>
-              <Trash2 size={14} />
               Delete
             </button>
           ) : null}
-          <button type="button" className="btn" onClick={onClose}>
-            Close
-          </button>
           {editingBackend ? (
             <>
               <button type="button" className="btn" disabled={busy || !form.baseUrl.trim()} onClick={testBackend}>

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -1,0 +1,247 @@
+import { Check, Plus, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  duplicateBackend,
+  normalizeBridgeBaseUrl,
+  useBridge,
+} from "./bridge";
+import type { BridgeBackendProfile } from "./bridge";
+
+type Props = {
+  onClose: () => void;
+};
+
+type FormState = {
+  id: string | null;
+  name: string;
+  baseUrl: string;
+};
+
+const emptyForm: FormState = {
+  id: null,
+  name: "",
+  baseUrl: "",
+};
+
+export function BackendSettingsDialog({ onClose }: Props) {
+  const bridge = useBridge();
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [creating, setCreating] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [duplicate, setDuplicate] = useState<BridgeBackendProfile | null>(null);
+
+  const activeBackend = bridge.activeBackend;
+  const selectedBackend = useMemo(
+    () => bridge.store.backends.find((backend) => backend.id === form.id) ?? null,
+    [bridge.store.backends, form.id],
+  );
+
+  useEffect(() => {
+    if (creating || form.id || bridge.store.backends.length === 0) {
+      return;
+    }
+    const backend = activeBackend ?? bridge.store.backends[0];
+    setForm({ id: backend.id, name: backend.name, baseUrl: backend.baseUrl });
+  }, [activeBackend, bridge.store.backends, creating, form.id]);
+
+  const startNew = () => {
+    setCreating(true);
+    setForm(emptyForm);
+    setMessage(null);
+    setDuplicate(null);
+  };
+
+  const editBackend = (backend: BridgeBackendProfile) => {
+    setCreating(false);
+    setForm({ id: backend.id, name: backend.name, baseUrl: backend.baseUrl });
+    setMessage(null);
+    setDuplicate(null);
+  };
+
+  const validateDuplicate = () => {
+    try {
+      const found = duplicateBackend(bridge.store.backends, form.baseUrl, form.id ?? undefined);
+      setDuplicate(found);
+      return found;
+    } catch {
+      setDuplicate(null);
+      return null;
+    }
+  };
+
+  const testBackend = async () => {
+    setBusy(true);
+    setMessage(null);
+    setDuplicate(null);
+    try {
+      const baseUrl = normalizeBridgeBaseUrl(form.baseUrl);
+      const found = duplicateBackend(bridge.store.backends, baseUrl, form.id ?? undefined);
+      setDuplicate(found);
+      await bridge.probeBackend(baseUrl);
+      setMessage(found ? `Reachable; same URL as ${found.name}.` : "Backend reachable.");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Backend test failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveBackend = async (activate: boolean) => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const baseUrl = normalizeBridgeBaseUrl(form.baseUrl);
+      const found = duplicateBackend(bridge.store.backends, baseUrl, form.id ?? undefined);
+      if (found) {
+        setDuplicate(found);
+        setMessage(`This URL is already saved as ${found.name}.`);
+        return;
+      }
+      await bridge.probeBackend(baseUrl);
+      const profile = form.id
+        ? await bridge.updateBackend(form.id, { name: form.name, baseUrl })
+        : await bridge.addBackend({ name: form.name, baseUrl }, activate);
+      if (activate && form.id) {
+        bridge.setActiveBackend(profile.id);
+      }
+      setCreating(false);
+      setForm({ id: profile.id, name: profile.name, baseUrl: profile.baseUrl });
+      setMessage("Backend saved.");
+      if (activate) {
+        onClose();
+      }
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not save backend");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const deleteBackend = () => {
+    if (!form.id || bridge.activeBackend?.id === form.id) {
+      return;
+    }
+    bridge.deleteBackend(form.id);
+    startNew();
+  };
+
+  const canDelete = Boolean(form.id && bridge.activeBackend?.id !== form.id);
+  const canUseSameOrigin = bridge.mode === "configured" || bridge.store.activeBackendId !== null;
+
+  return (
+    <div className="overlay-root">
+      <button className="overlay-scrim" type="button" aria-label="Close settings" onClick={onClose} />
+      <form
+        className="modal backend-modal"
+        role="dialog"
+        aria-modal="true"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void saveBackend(true);
+        }}
+      >
+        <div className="modal-title">Bridge backends</div>
+        <div className="backend-layout">
+          <div className="backend-list" role="list" aria-label="Saved bridge backends">
+            <button
+              className="backend-row"
+              type="button"
+              data-active={!form.id ? "true" : undefined}
+              onClick={startNew}
+            >
+              <Plus size={14} />
+              <span>New backend</span>
+            </button>
+            {bridge.store.backends.map((backend) => (
+              <button
+                key={backend.id}
+                className="backend-row"
+                type="button"
+                data-active={backend.id === form.id ? "true" : undefined}
+                onClick={() => editBackend(backend)}
+              >
+                {backend.id === bridge.store.activeBackendId ? <Check size={14} /> : <span />}
+                <span>
+                  <strong>{backend.name}</strong>
+                  <small>{backend.baseUrl}</small>
+                </span>
+              </button>
+            ))}
+          </div>
+          <div className="backend-form">
+            <label className="field-label">
+              <span>Display name</span>
+              <input
+                className="field"
+                value={form.name}
+                placeholder="Home workstation"
+                autoComplete="off"
+                onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+              />
+            </label>
+            <label className="field-label">
+              <span>Bridge URL</span>
+              <input
+                className="field"
+                value={form.baseUrl}
+                placeholder="http://192.168.1.20:4000"
+                autoComplete="off"
+                spellCheck={false}
+                onBlur={validateDuplicate}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, baseUrl: event.target.value }))
+                }
+              />
+            </label>
+            {selectedBackend?.lastConnectedAt ? (
+              <div className="backend-note">Last used {formatDate(selectedBackend.lastConnectedAt)}</div>
+            ) : null}
+            {duplicate ? (
+              <div className="backend-warning">This URL is already saved as {duplicate.name}.</div>
+            ) : null}
+            {message ? <div className="modal-message">{message}</div> : null}
+          </div>
+        </div>
+        <div className="modal-actions">
+          {canUseSameOrigin ? (
+            <button type="button" className="btn btn-clear" onClick={bridge.clearActiveBackend}>
+              Use same-origin
+            </button>
+          ) : null}
+          {canDelete ? (
+            <button type="button" className="btn btn-danger" disabled={busy} onClick={deleteBackend}>
+              <Trash2 size={14} />
+              Delete
+            </button>
+          ) : null}
+          <button type="button" className="btn" onClick={onClose}>
+            Close
+          </button>
+          <button type="button" className="btn" disabled={busy || !form.baseUrl.trim()} onClick={testBackend}>
+            Test
+          </button>
+          <button
+            type="button"
+            className="btn"
+            disabled={busy || !form.baseUrl.trim()}
+            onClick={() => void saveBackend(false)}
+          >
+            Save
+          </button>
+          <button type="submit" className="btn btn-primary" disabled={busy || !form.baseUrl.trim()}>
+            Save & use
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -59,7 +59,7 @@ export function BackendSettingsDialog({ onClose }: Props) {
     bridge.clearActiveBackend();
     setSelectionMode("same-origin");
     setForm(emptyForm);
-    setMessage("Using the bridge that served this page.");
+    setMessage("Using the same-origin bridge.");
     setDuplicate(null);
   };
 
@@ -179,9 +179,9 @@ export function BackendSettingsDialog({ onClose }: Props) {
           void saveBackend(true);
         }}
       >
-        <div id={titleId} className="modal-title">Bridge backends</div>
+        <div id={titleId} className="modal-title">Bridges</div>
         <div className="backend-layout">
-          <div className="backend-list" role="list" aria-label="Saved bridge backends">
+          <div className="backend-list" role="list" aria-label="Saved bridges">
             <button
               className="backend-row"
               type="button"
@@ -190,18 +190,9 @@ export function BackendSettingsDialog({ onClose }: Props) {
             >
               {!bridge.store.activeBackendId ? <Check size={14} /> : <span />}
               <span>
-                <strong>Same-origin bridge</strong>
+                <strong>Same origin</strong>
                 <small>{sameOriginUrl}</small>
               </span>
-            </button>
-            <button
-              className="backend-row"
-              type="button"
-              data-active={selectionMode === "new" ? "true" : undefined}
-              onClick={startNew}
-            >
-              <Plus size={14} />
-              <span>New backend</span>
             </button>
             {bridge.store.backends.map((backend) => (
               <button
@@ -218,20 +209,25 @@ export function BackendSettingsDialog({ onClose }: Props) {
                 </span>
               </button>
             ))}
+            <button
+              className="backend-row"
+              type="button"
+              data-active={selectionMode === "new" ? "true" : undefined}
+              onClick={startNew}
+            >
+              <Plus size={14} />
+              <span>
+                <strong>Add bridge</strong>
+                <small>Save another bridge URL</small>
+              </span>
+            </button>
           </div>
           <div className="backend-form">
             {selectionMode === "same-origin" ? (
-              <>
-                <label className="field-label">
-                  <span>Display name</span>
-                  <input className="field" value="Same-origin bridge" readOnly />
-                </label>
-                <label className="field-label">
-                  <span>Bridge URL</span>
-                  <input className="field" value={sameOriginUrl} readOnly />
-                </label>
-                <div className="backend-note">This built-in backend uses the bridge that served the web app.</div>
-              </>
+              <div className="backend-static">
+                <strong>Same origin</strong>
+                <span>Uses the server that delivered this web app.</span>
+              </div>
             ) : (
               <>
                 <label className="field-label">
@@ -265,7 +261,7 @@ export function BackendSettingsDialog({ onClose }: Props) {
               </>
             )}
             {selectionMode === "same-origin" && bridge.store.activeBackendId ? (
-              <div className="backend-warning">Select this row to switch back to the serving bridge.</div>
+              <div className="backend-warning">Select this row to switch back to same origin.</div>
             ) : null}
             {duplicate ? (
               <div className="backend-warning">This URL is already saved as {duplicate.name}.</div>

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { Check, Plus, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   duplicateBackend,
   normalizeBridgeBaseUrl,
@@ -25,6 +25,8 @@ const emptyForm: FormState = {
 
 export function BackendSettingsDialog({ onClose }: Props) {
   const bridge = useBridge();
+  const titleId = useId();
+  const nameInputRef = useRef<HTMLInputElement | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
   const [creating, setCreating] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -36,6 +38,10 @@ export function BackendSettingsDialog({ onClose }: Props) {
     () => bridge.store.backends.find((backend) => backend.id === form.id) ?? null,
     [bridge.store.backends, form.id],
   );
+
+  useEffect(() => {
+    nameInputRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     if (creating || form.id || bridge.store.backends.length === 0) {
@@ -98,7 +104,15 @@ export function BackendSettingsDialog({ onClose }: Props) {
         setMessage(`This URL is already saved as ${found.name}.`);
         return;
       }
-      await bridge.probeBackend(baseUrl);
+      let probeWarning: string | null = null;
+      try {
+        await bridge.probeBackend(baseUrl);
+      } catch (error) {
+        if (activate) {
+          throw error;
+        }
+        probeWarning = error instanceof Error ? error.message : "Backend could not be reached.";
+      }
       const profile = form.id
         ? await bridge.updateBackend(form.id, { name: form.name, baseUrl })
         : await bridge.addBackend({ name: form.name, baseUrl }, activate);
@@ -107,7 +121,7 @@ export function BackendSettingsDialog({ onClose }: Props) {
       }
       setCreating(false);
       setForm({ id: profile.id, name: profile.name, baseUrl: profile.baseUrl });
-      setMessage("Backend saved.");
+      setMessage(probeWarning ? `Backend saved. ${probeWarning}` : "Backend saved.");
       if (activate) {
         onClose();
       }
@@ -136,12 +150,20 @@ export function BackendSettingsDialog({ onClose }: Props) {
         className="modal backend-modal"
         role="dialog"
         aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onClose();
+          }
+        }}
         onSubmit={(event) => {
           event.preventDefault();
           void saveBackend(true);
         }}
       >
-        <div className="modal-title">Bridge backends</div>
+        <div id={titleId} className="modal-title">Bridge backends</div>
         <div className="backend-layout">
           <div className="backend-list" role="list" aria-label="Saved bridge backends">
             <button
@@ -173,6 +195,7 @@ export function BackendSettingsDialog({ onClose }: Props) {
             <label className="field-label">
               <span>Display name</span>
               <input
+                ref={nameInputRef}
                 className="field"
                 value={form.name}
                 placeholder="Home workstation"

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -9,6 +9,9 @@ import type { PaneInfo } from "./types";
 
 type Props = {
   pane: PaneInfo | null;
+  connectionKey: string;
+  httpUrl: (path: string, query?: URLSearchParams) => string;
+  wsUrl: (path: string, query?: URLSearchParams) => string;
   /** Whether to grab keyboard focus on attach. Off on mobile to avoid popping the keyboard. */
   autoFocus?: boolean;
   /** Wheel scroll speed multiplier; slower on desktop, faster on mobile. */
@@ -42,6 +45,9 @@ const MAX_UPLOAD_FILES = 8;
 
 export function TerminalView({
   pane,
+  connectionKey,
+  httpUrl,
+  wsUrl,
   autoFocus = true,
   scrollSensitivity = 1,
   mobileControls = false,
@@ -60,6 +66,8 @@ export function TerminalView({
   const uploadStatusTimerRef = useRef<number | null>(null);
   const uploadInFlightRef = useRef(false);
   const uploadConflictRef = useRef<UploadConflictState | null>(null);
+  const connectionKeyRef = useRef(connectionKey);
+  const terminalIdRef = useRef(pane?.terminal_id ?? null);
   const [connectionState, setConnectionState] = useState<ConnectionState>("idle");
   const [closeReason, setCloseReason] = useState<string | null>(null);
   const [uploadStatus, setUploadStatus] = useState<string | null>(null);
@@ -72,6 +80,8 @@ export function TerminalView({
   scrollSensitivityRef.current = scrollSensitivity;
   const mobileControlsRef = useRef(mobileControls);
   mobileControlsRef.current = mobileControls;
+  connectionKeyRef.current = connectionKey;
+  terminalIdRef.current = pane?.terminal_id ?? null;
 
   const focusMobileCommandInput = useCallback(() => {
     if (!mobileControlsRef.current) {
@@ -198,7 +208,7 @@ export function TerminalView({
           if (disposed) {
             return;
           }
-          const nextSocket = new WebSocket(terminalSocketUrl(pane.terminal_id, renderer.fit()));
+          const nextSocket = new WebSocket(terminalSocketUrl(wsUrl, pane.terminal_id, renderer.fit()));
           socket = nextSocket;
           socketRef.current = nextSocket;
           nextSocket.binaryType = "arraybuffer";
@@ -284,7 +294,7 @@ export function TerminalView({
       rendererRef.current = null;
       host.replaceChildren();
     };
-  }, [pane?.terminal_id]);
+  }, [connectionKey, pane?.terminal_id, wsUrl]);
 
   useEffect(() => {
     rendererRef.current?.setTapFocusHandler(mobileControls ? focusMobileCommandInput : null);
@@ -392,6 +402,8 @@ export function TerminalView({
     }
     uploadInFlightRef.current = true;
     setUploading(true);
+    const uploadConnectionKey = connectionKey;
+    const uploadTerminalId = pane.terminal_id;
     const uploadFiles = files.slice(0, MAX_UPLOAD_FILES);
     const skippedCount = files.length - uploadFiles.length;
     showUploadStatus(
@@ -402,7 +414,14 @@ export function TerminalView({
     try {
       const uploaded: UploadedFile[] = [];
       for (const file of uploadFiles) {
-        uploaded.push(await uploadWithOverwritePrompt(file, confirmUploadReplace));
+        uploaded.push(await uploadWithOverwritePrompt(httpUrl, file, confirmUploadReplace));
+      }
+      if (
+        connectionKeyRef.current !== uploadConnectionKey ||
+        terminalIdRef.current !== uploadTerminalId
+      ) {
+        showUploadStatus("Upload completed after terminal changed", 3000);
+        return;
       }
       if (uploaded.length > 0) {
         enqueueTerminalInput([uploaded.map((file) => shellQuote(file.path)).join(" ")]);
@@ -764,15 +783,18 @@ const SPECIAL_KEYS: TerminalKey[] = [
   { label: "}", data: "}" },
 ];
 
-function terminalSocketUrl(terminalId: string, size: TerminalSize) {
-  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+function terminalSocketUrl(
+  wsUrl: (path: string, query?: URLSearchParams) => string,
+  terminalId: string,
+  size: TerminalSize,
+) {
   const params = new URLSearchParams({
     terminal_id: terminalId,
     cols: String(size.cols),
     rows: String(size.rows),
     takeover: "false",
   });
-  return `${protocol}//${window.location.host}/ws/terminal?${params.toString()}`;
+  return wsUrl("/ws/terminal", params);
 }
 
 function parseCloseReason(message: string) {
@@ -841,11 +863,12 @@ function uploadCandidatesFromClipboard(data: DataTransfer): UploadCandidate[] {
 }
 
 async function uploadWithOverwritePrompt(
+  httpUrl: (path: string, query?: URLSearchParams) => string,
   file: UploadCandidate,
   confirmReplace: (error: UploadConflictError) => Promise<boolean>,
 ): Promise<UploadedFile> {
   try {
-    return await uploadFile(file, false);
+    return await uploadFile(httpUrl, file, false);
   } catch (error) {
     if (!(error instanceof UploadConflictError)) {
       throw error;
@@ -854,7 +877,7 @@ async function uploadWithOverwritePrompt(
     if (!replace) {
       throw new Error("Upload canceled");
     }
-    return uploadFile(file, true);
+    return uploadFile(httpUrl, file, true);
   }
 }
 
@@ -864,7 +887,11 @@ function uploadConflictMessage(conflict: UploadConflictState) {
     : `${conflict.name} already exists.`;
 }
 
-async function uploadFile(file: UploadCandidate, overwrite: boolean): Promise<UploadedFile> {
+async function uploadFile(
+  httpUrl: (path: string, query?: URLSearchParams) => string,
+  file: UploadCandidate,
+  overwrite: boolean,
+): Promise<UploadedFile> {
   const params = new URLSearchParams();
   if (file.name) {
     params.set("name", file.name);
@@ -872,7 +899,7 @@ async function uploadFile(file: UploadCandidate, overwrite: boolean): Promise<Up
   if (overwrite) {
     params.set("overwrite", "true");
   }
-  const response = await fetch(`/api/uploads?${params.toString()}`, {
+  const response = await fetch(httpUrl("/api/uploads", params), {
     method: "POST",
     headers: file.blob.type ? { "content-type": file.blob.type } : undefined,
     body: file.blob,

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildHttpUrl,
   buildWsUrl,
+  capabilityProbeFailure,
+  capabilityProbeSuccess,
+  capabilityRetryDelayMs,
   duplicateBackend,
   normalizeBridgeBaseUrl,
   parseBackendStore,
@@ -15,6 +18,10 @@ describe("bridge URL normalization", () => {
     expect(normalizeBridgeBaseUrl(" http://herdr-host.local:4000/ ")).toBe(
       "http://herdr-host.local:4000",
     );
+    expect(normalizeBridgeBaseUrl("https://herdr-host.local:443")).toBe(
+      "https://herdr-host.local",
+    );
+    expect(normalizeBridgeBaseUrl("http://192.168.1.20:80")).toBe("http://192.168.1.20");
     expect(normalizeBridgeBaseUrl("http://[fd00::1234]:4000")).toBe(
       "http://[fd00::1234]:4000",
     );
@@ -28,7 +35,6 @@ describe("bridge URL normalization", () => {
     expect(() => normalizeBridgeBaseUrl("http://192.168.1.20:4000/api")).toThrow(
       /path/iu,
     );
-    expect(() => normalizeBridgeBaseUrl("http://192.168.1.20")).toThrow(/port/iu);
     expect(() => normalizeBridgeBaseUrl("http://8.8.8.8:4000")).toThrow(/private/iu);
   });
 });
@@ -82,6 +88,37 @@ describe("backend store parsing", () => {
 });
 
 describe("capabilities", () => {
+  it("maps capability probe outcomes to connection blocking state", () => {
+    expect(capabilityProbeSuccess({ commands: ["pane.split"], web_compat: 1 })).toEqual({
+      blocked: false,
+      state: "ready",
+      capabilities: { commands: ["pane.split"], web_compat: 1 },
+      error: null,
+      retry: false,
+    });
+    expect(capabilityProbeSuccess({ commands: [], web_compat: 0 })).toEqual({
+      blocked: true,
+      state: "error",
+      capabilities: null,
+      error: "Bridge is not compatible with this web app",
+      retry: false,
+    });
+    expect(capabilityProbeFailure(new Error("network down"))).toEqual({
+      blocked: false,
+      state: "error",
+      capabilities: null,
+      error: "network down",
+      retry: true,
+    });
+  });
+
+  it("backs off capability retry delays", () => {
+    expect(capabilityRetryDelayMs(0)).toBe(5000);
+    expect(capabilityRetryDelayMs(1)).toBe(10000);
+    expect(capabilityRetryDelayMs(3)).toBe(40000);
+    expect(capabilityRetryDelayMs(10)).toBe(60000);
+  });
+
   it("parses optional compatibility fields", () => {
     expect(
       parseCapabilities({

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildHttpUrl,
+  buildWsUrl,
+  duplicateBackend,
+  normalizeBridgeBaseUrl,
+  parseBackendStore,
+  parseCapabilities,
+  probeBridgeBaseUrl,
+} from "./bridge";
+
+describe("bridge URL normalization", () => {
+  it("normalizes origin-only bridge URLs", () => {
+    expect(normalizeBridgeBaseUrl("192.168.1.20:4000")).toBe("http://192.168.1.20:4000");
+    expect(normalizeBridgeBaseUrl(" http://herdr-host.local:4000/ ")).toBe(
+      "http://herdr-host.local:4000",
+    );
+    expect(normalizeBridgeBaseUrl("http://[fd00::1234]:4000")).toBe(
+      "http://[fd00::1234]:4000",
+    );
+  });
+
+  it("rejects unsupported URL shapes", () => {
+    expect(() => normalizeBridgeBaseUrl("ftp://192.168.1.20:4000")).toThrow(/http or https/iu);
+    expect(() => normalizeBridgeBaseUrl("http://user@192.168.1.20:4000")).toThrow(
+      /credentials/iu,
+    );
+    expect(() => normalizeBridgeBaseUrl("http://192.168.1.20:4000/api")).toThrow(
+      /path/iu,
+    );
+    expect(() => normalizeBridgeBaseUrl("http://192.168.1.20")).toThrow(/port/iu);
+    expect(() => normalizeBridgeBaseUrl("http://8.8.8.8:4000")).toThrow(/private/iu);
+  });
+});
+
+describe("bridge URL builders", () => {
+  it("builds same-origin HTTP and WebSocket URLs", () => {
+    vi.stubGlobal("location", { protocol: "https:", host: "app.local:8787" });
+
+    expect(buildHttpUrl(null, "/api/snapshot")).toBe("/api/snapshot");
+    expect(buildWsUrl(null, "/ws/events")).toBe("wss://app.local:8787/ws/events");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("builds configured HTTP and WebSocket URLs", () => {
+    const query = new URLSearchParams({ terminal_id: "term-1" });
+
+    expect(buildHttpUrl("http://192.168.1.20:4000", "/api/snapshot")).toBe(
+      "http://192.168.1.20:4000/api/snapshot",
+    );
+    expect(buildWsUrl("http://192.168.1.20:4000", "/ws/terminal", query)).toBe(
+      "ws://192.168.1.20:4000/ws/terminal?terminal_id=term-1",
+    );
+  });
+});
+
+describe("backend store parsing", () => {
+  it("keeps valid profiles and clears invalid active ids", () => {
+    expect(
+      parseBackendStore({
+        version: 1,
+        activeBackendId: "missing",
+        backends: [
+          { id: "one", name: "Home", baseUrl: "http://192.168.1.20:4000" },
+          { id: "bad", name: "Bad", baseUrl: "http://8.8.8.8:4000" },
+        ],
+      }),
+    ).toEqual({
+      version: 1,
+      activeBackendId: null,
+      backends: [{ id: "one", name: "Home", baseUrl: "http://192.168.1.20:4000" }],
+    });
+  });
+
+  it("detects duplicate normalized backend URLs", () => {
+    const backends = [{ id: "one", name: "Home", baseUrl: "http://192.168.1.20:4000" }];
+
+    expect(duplicateBackend(backends, "192.168.1.20:4000")?.id).toBe("one");
+    expect(duplicateBackend(backends, "192.168.1.20:4000", "one")).toBeNull();
+  });
+});
+
+describe("capabilities", () => {
+  it("parses optional compatibility fields", () => {
+    expect(
+      parseCapabilities({
+        commands: ["pane.split", 42],
+        bridge_version: "1.2.3",
+        web_compat: 1,
+        min_android_app_compat: 2,
+      }),
+    ).toEqual({
+      commands: ["pane.split"],
+      bridge_version: "1.2.3",
+      web_compat: 1,
+      min_android_app_compat: 2,
+    });
+  });
+
+  it("probes configured bridge capabilities", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ commands: ["pane.move"] }), { status: 200 }),
+    );
+
+    await expect(probeBridgeBaseUrl("192.168.1.20:4000")).resolves.toEqual({
+      commands: ["pane.move"],
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://192.168.1.20:4000/api/capabilities");
+
+    fetchMock.mockRestore();
+  });
+
+  it("rejects incompatible configured bridge capabilities", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ commands: [], web_compat: 0 }), { status: 200 }),
+    );
+
+    await expect(probeBridgeBaseUrl("192.168.1.20:4000")).rejects.toThrow(/not compatible/iu);
+
+    fetchMock.mockRestore();
+  });
+});

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -72,6 +72,8 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
   const [capabilities, setCapabilities] = useState<BridgeCapabilities | null>(null);
   const [capabilityState, setCapabilityState] = useState<CapabilityState>("idle");
   const [capabilityError, setCapabilityError] = useState<string | null>(null);
+  const [connectionBlocked, setConnectionBlocked] = useState(false);
+  const [capabilityRetry, setCapabilityRetry] = useState(0);
 
   const activeBackend = store.activeBackendId
     ? (store.backends.find((backend) => backend.id === store.activeBackendId) ?? null)
@@ -79,7 +81,7 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
   const mode: BridgeMode = activeBackend ? "configured" : defaultBridgeMode();
   const connectionKey = activeBackend ? `configured:${activeBackend.id}:${activeBackend.baseUrl}` : "same-origin";
   const canProbe = mode !== "disconnected";
-  const canConnect = canProbe && capabilityState !== "error";
+  const canConnect = canProbe && !connectionBlocked;
 
   useEffect(() => {
     writeBackendStore(store);
@@ -98,9 +100,15 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
   const probeBackend = useCallback((baseUrl: string) => probeBridgeBaseUrl(baseUrl), []);
 
   useEffect(() => {
+    setCapabilityRetry(0);
+  }, [connectionKey]);
+
+  useEffect(() => {
     let cancelled = false;
+    let retryTimer: number | null = null;
     setCapabilities(null);
     setCapabilityError(null);
+    setConnectionBlocked(false);
     if (!canProbe) {
       setCapabilityState("idle");
       return;
@@ -111,27 +119,34 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
         if (cancelled) {
           return;
         }
-        const error = compatibilityError(next);
-        if (error) {
-          setCapabilityError(error);
-          setCapabilities(null);
-          setCapabilityState("error");
-          return;
-        }
-        setCapabilities(next);
-        setCapabilityState("ready");
+        const outcome = capabilityProbeSuccess(next);
+        setCapabilityError(outcome.error);
+        setCapabilities(outcome.capabilities);
+        setConnectionBlocked(outcome.blocked);
+        setCapabilityState(outcome.state);
       })
       .catch((error: unknown) => {
         if (!cancelled) {
-          setCapabilityError(error instanceof Error ? error.message : "Bridge unavailable");
-          setCapabilities(null);
-          setCapabilityState("error");
+          const outcome = capabilityProbeFailure(error);
+          setCapabilityError(outcome.error);
+          setCapabilities(outcome.capabilities);
+          setConnectionBlocked(outcome.blocked);
+          setCapabilityState(outcome.state);
+          if (outcome.retry) {
+            const retryDelay = capabilityRetryDelayMs(capabilityRetry);
+            retryTimer = window.setTimeout(() => {
+              setCapabilityRetry((current) => current + 1);
+            }, retryDelay);
+          }
         }
       });
     return () => {
       cancelled = true;
+      if (retryTimer !== null) {
+        window.clearTimeout(retryTimer);
+      }
     };
-  }, [canProbe, connectionKey, httpUrl]);
+  }, [canProbe, capabilityRetry, connectionKey, httpUrl]);
 
   const addBackend = useCallback(async (input: BackendInput, activate = true) => {
     const baseUrl = normalizeBridgeBaseUrl(input.baseUrl);
@@ -333,9 +348,6 @@ export function normalizeBridgeBaseUrl(input: string): string {
   if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
     throw new Error("Bridge URL must not include a path, query, or fragment");
   }
-  if (!url.port) {
-    throw new Error("Bridge URL must include a port");
-  }
   validateBridgeHost(url.hostname, url.protocol);
   return url.origin;
 }
@@ -426,6 +438,50 @@ export async function probeBridgeBaseUrl(baseUrl: string): Promise<BridgeCapabil
     throw new Error(error);
   }
   return capabilities;
+}
+
+export type CapabilityProbeOutcome = {
+  blocked: boolean;
+  state: CapabilityState;
+  capabilities: BridgeCapabilities | null;
+  error: string | null;
+  retry: boolean;
+};
+
+export function capabilityProbeSuccess(
+  capabilities: BridgeCapabilities,
+): CapabilityProbeOutcome {
+  const error = compatibilityError(capabilities);
+  if (error) {
+    return {
+      blocked: true,
+      state: "error",
+      capabilities: null,
+      error,
+      retry: false,
+    };
+  }
+  return {
+    blocked: false,
+    state: "ready",
+    capabilities,
+    error: null,
+    retry: false,
+  };
+}
+
+export function capabilityProbeFailure(error: unknown): CapabilityProbeOutcome {
+  return {
+    blocked: false,
+    state: "error",
+    capabilities: null,
+    error: error instanceof Error ? error.message : "Bridge unavailable",
+    retry: true,
+  };
+}
+
+export function capabilityRetryDelayMs(attempt: number) {
+  return Math.min(5000 * 2 ** Math.max(0, attempt), 60000);
 }
 
 export function parseCapabilities(value: unknown): BridgeCapabilities {

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -1,0 +1,552 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+
+export type BridgeBackendProfile = {
+  id: string;
+  name: string;
+  baseUrl: string;
+  lastConnectedAt?: string;
+};
+
+export type BridgeBackendStore = {
+  version: 1;
+  activeBackendId: string | null;
+  backends: BridgeBackendProfile[];
+};
+
+export type BridgeMode = "same-origin" | "configured" | "disconnected";
+
+export type BridgeCapabilities = {
+  commands: string[];
+  bridge_version?: string;
+  web_compat?: number;
+  min_android_app_compat?: number;
+};
+
+export type CapabilityState = "idle" | "probing" | "ready" | "error";
+
+export type BridgeRuntime = {
+  mode: BridgeMode;
+  store: BridgeBackendStore;
+  activeBackend: BridgeBackendProfile | null;
+  connectionKey: string;
+  capabilities: BridgeCapabilities | null;
+  capabilityState: CapabilityState;
+  capabilityError: string | null;
+  canConnect: boolean;
+  httpUrl: (path: string, query?: URLSearchParams) => string;
+  wsUrl: (path: string, query?: URLSearchParams) => string;
+  addBackend: (input: BackendInput, activate?: boolean) => Promise<BridgeBackendProfile>;
+  updateBackend: (id: string, input: BackendInput) => Promise<BridgeBackendProfile>;
+  deleteBackend: (id: string) => void;
+  setActiveBackend: (id: string) => void;
+  clearActiveBackend: () => void;
+  probeBackend: (baseUrl: string) => Promise<BridgeCapabilities>;
+};
+
+export type BackendInput = {
+  name?: string;
+  baseUrl: string;
+};
+
+const STORE_KEY = "herdrWeb.bridgeBackends.v1";
+const STORE_VERSION = 1;
+const APP_MIN_WEB_COMPAT = 1;
+const fallbackStore: BridgeBackendStore = {
+  version: STORE_VERSION,
+  activeBackendId: null,
+  backends: [],
+};
+
+const BridgeContext = createContext<BridgeRuntime | null>(null);
+
+export function BridgeProvider({ children }: { children: ReactNode }) {
+  const [store, setStore] = useState<BridgeBackendStore>(readBackendStore);
+  const [capabilities, setCapabilities] = useState<BridgeCapabilities | null>(null);
+  const [capabilityState, setCapabilityState] = useState<CapabilityState>("idle");
+  const [capabilityError, setCapabilityError] = useState<string | null>(null);
+
+  const activeBackend = store.activeBackendId
+    ? (store.backends.find((backend) => backend.id === store.activeBackendId) ?? null)
+    : null;
+  const mode: BridgeMode = activeBackend ? "configured" : defaultBridgeMode();
+  const connectionKey = activeBackend ? `configured:${activeBackend.id}:${activeBackend.baseUrl}` : "same-origin";
+  const canProbe = mode !== "disconnected";
+  const canConnect = canProbe && capabilityState !== "error";
+
+  useEffect(() => {
+    writeBackendStore(store);
+  }, [store]);
+
+  const httpUrl = useCallback(
+    (path: string, query?: URLSearchParams) => buildHttpUrl(activeBackend?.baseUrl ?? null, path, query),
+    [activeBackend?.baseUrl],
+  );
+
+  const wsUrl = useCallback(
+    (path: string, query?: URLSearchParams) => buildWsUrl(activeBackend?.baseUrl ?? null, path, query),
+    [activeBackend?.baseUrl],
+  );
+
+  const probeBackend = useCallback((baseUrl: string) => probeBridgeBaseUrl(baseUrl), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCapabilities(null);
+    setCapabilityError(null);
+    if (!canProbe) {
+      setCapabilityState("idle");
+      return;
+    }
+    setCapabilityState("probing");
+    void fetchCapabilities(httpUrl)
+      .then((next) => {
+        if (cancelled) {
+          return;
+        }
+        const error = compatibilityError(next);
+        if (error) {
+          setCapabilityError(error);
+          setCapabilities(null);
+          setCapabilityState("error");
+          return;
+        }
+        setCapabilities(next);
+        setCapabilityState("ready");
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setCapabilityError(error instanceof Error ? error.message : "Bridge unavailable");
+          setCapabilities(null);
+          setCapabilityState("error");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [canProbe, connectionKey, httpUrl]);
+
+  const addBackend = useCallback(async (input: BackendInput, activate = true) => {
+    const baseUrl = normalizeBridgeBaseUrl(input.baseUrl);
+    const profile: BridgeBackendProfile = {
+      id: createBackendId(),
+      name: backendDisplayName(input.name, baseUrl, store.backends),
+      baseUrl,
+      lastConnectedAt: activate ? new Date().toISOString() : undefined,
+    };
+    const nextProfile = { ...profile };
+    setStore((current) => ({
+      version: STORE_VERSION,
+      activeBackendId: activate ? nextProfile.id : current.activeBackendId,
+      backends: [...current.backends, nextProfile],
+    }));
+    return nextProfile;
+  }, [store.backends]);
+
+  const updateBackend = useCallback(async (id: string, input: BackendInput) => {
+    const existing = store.backends.find((backend) => backend.id === id);
+    if (!existing) {
+      throw new Error("Backend not found");
+    }
+    const baseUrl = normalizeBridgeBaseUrl(input.baseUrl);
+    const otherBackends = store.backends.filter((backend) => backend.id !== id);
+    const updated: BridgeBackendProfile = {
+      ...existing,
+      name: backendDisplayName(input.name, baseUrl, otherBackends),
+      baseUrl,
+      lastConnectedAt:
+        store.activeBackendId === id ? new Date().toISOString() : existing.lastConnectedAt,
+    };
+    setStore((current) => ({
+      version: STORE_VERSION,
+      activeBackendId: current.activeBackendId,
+      backends: current.backends.map((backend) => (backend.id === id ? updated : backend)),
+    }));
+    return updated;
+  }, [store.activeBackendId, store.backends]);
+
+  const deleteBackend = useCallback((id: string) => {
+    setStore((current) => ({
+      version: STORE_VERSION,
+      activeBackendId: current.activeBackendId === id ? null : current.activeBackendId,
+      backends: current.backends.filter((backend) => backend.id !== id),
+    }));
+  }, []);
+
+  const setActiveBackend = useCallback((id: string) => {
+    setStore((current) => {
+      if (!current.backends.some((backend) => backend.id === id)) {
+        return current;
+      }
+      return {
+        ...current,
+        activeBackendId: id,
+        backends: current.backends.map((backend) =>
+          backend.id === id ? { ...backend, lastConnectedAt: new Date().toISOString() } : backend,
+        ),
+      };
+    });
+  }, []);
+
+  const clearActiveBackend = useCallback(() => {
+    setStore((current) => ({ ...current, activeBackendId: null }));
+  }, []);
+
+  const value = useMemo<BridgeRuntime>(
+    () => ({
+      mode,
+      store,
+      activeBackend,
+      connectionKey,
+      capabilities,
+      capabilityState,
+      capabilityError,
+      canConnect,
+      httpUrl,
+      wsUrl,
+      addBackend,
+      updateBackend,
+      deleteBackend,
+      setActiveBackend,
+      clearActiveBackend,
+      probeBackend,
+    }),
+    [
+      activeBackend,
+      addBackend,
+      canConnect,
+      capabilities,
+      capabilityError,
+      capabilityState,
+      clearActiveBackend,
+      connectionKey,
+      deleteBackend,
+      httpUrl,
+      mode,
+      probeBackend,
+      setActiveBackend,
+      store,
+      updateBackend,
+      wsUrl,
+    ],
+  );
+
+  return <BridgeContext.Provider value={value}>{children}</BridgeContext.Provider>;
+}
+
+export function useBridge() {
+  const value = useContext(BridgeContext);
+  if (!value) {
+    throw new Error("useBridge must be used inside BridgeProvider");
+  }
+  return value;
+}
+
+export function readBackendStore(): BridgeBackendStore {
+  try {
+    const raw = window.localStorage.getItem(STORE_KEY);
+    if (!raw) {
+      return fallbackStore;
+    }
+    return parseBackendStore(JSON.parse(raw));
+  } catch {
+    return fallbackStore;
+  }
+}
+
+export function writeBackendStore(store: BridgeBackendStore) {
+  try {
+    window.localStorage.setItem(STORE_KEY, JSON.stringify(store));
+  } catch {
+    // Storage can be unavailable in private or locked-down browser contexts.
+  }
+}
+
+export function parseBackendStore(value: unknown): BridgeBackendStore {
+  if (!isRecord(value) || value.version !== STORE_VERSION || !Array.isArray(value.backends)) {
+    return fallbackStore;
+  }
+  const backends = value.backends
+    .map(parseBackendProfile)
+    .filter((backend): backend is BridgeBackendProfile => backend !== null);
+  const activeBackendId =
+    typeof value.activeBackendId === "string" &&
+    backends.some((backend) => backend.id === value.activeBackendId)
+      ? value.activeBackendId
+      : null;
+  return { version: STORE_VERSION, activeBackendId, backends };
+}
+
+function parseBackendProfile(value: unknown): BridgeBackendProfile | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (
+    typeof value.id !== "string" ||
+    typeof value.name !== "string" ||
+    typeof value.baseUrl !== "string"
+  ) {
+    return null;
+  }
+  try {
+    const baseUrl = normalizeBridgeBaseUrl(value.baseUrl);
+    return {
+      id: value.id,
+      name: value.name.trim() || displayNameFromUrl(baseUrl),
+      baseUrl,
+      lastConnectedAt: typeof value.lastConnectedAt === "string" ? value.lastConnectedAt : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function defaultBridgeMode(): BridgeMode {
+  return "same-origin";
+}
+
+export function normalizeBridgeBaseUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Enter a bridge URL");
+  }
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//iu.test(trimmed) ? trimmed : `http://${trimmed}`;
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    throw new Error("Bridge URL is invalid");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Bridge URL must use http or https");
+  }
+  if (url.username || url.password) {
+    throw new Error("Bridge URL must not include credentials");
+  }
+  if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
+    throw new Error("Bridge URL must not include a path, query, or fragment");
+  }
+  if (!url.port) {
+    throw new Error("Bridge URL must include a port");
+  }
+  validateBridgeHost(url.hostname, url.protocol);
+  return url.origin;
+}
+
+function validateBridgeHost(hostname: string, protocol: string) {
+  const host = stripIpv6Brackets(hostname).toLowerCase();
+  if (!host) {
+    throw new Error("Bridge URL must include a host");
+  }
+  const ipv4 = parseIpv4(host);
+  if (ipv4) {
+    if (protocol === "http:" && !isPrivateIpv4(ipv4)) {
+      throw new Error("HTTP bridge URLs must use a private or local address");
+    }
+    return;
+  }
+  if (isIpv6Literal(host)) {
+    if (protocol === "http:" && !isPrivateIpv6(host)) {
+      throw new Error("HTTP bridge URLs must use a private or local address");
+    }
+    return;
+  }
+  if (!isValidHostname(host)) {
+    throw new Error("Bridge hostname is invalid");
+  }
+}
+
+export function buildHttpUrl(
+  baseUrl: string | null,
+  path: string,
+  query?: URLSearchParams,
+): string {
+  const normalizedPath = normalizeEndpointPath(path);
+  const suffix = query && query.toString() ? `?${query.toString()}` : "";
+  if (!baseUrl) {
+    return `${normalizedPath}${suffix}`;
+  }
+  const url = new URL(normalizedPath, baseUrl);
+  if (query) {
+    url.search = query.toString();
+  }
+  return url.toString();
+}
+
+export function buildWsUrl(
+  baseUrl: string | null,
+  path: string,
+  query?: URLSearchParams,
+): string {
+  const normalizedPath = normalizeEndpointPath(path);
+  const suffix = query && query.toString() ? `?${query.toString()}` : "";
+  if (!baseUrl) {
+    const location = globalThis.location;
+    const protocol = location?.protocol === "https:" ? "wss:" : "ws:";
+    const host = location?.host || "localhost";
+    return `${protocol}//${host}${normalizedPath}${suffix}`;
+  }
+  const url = new URL(normalizedPath, baseUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  if (query) {
+    url.search = query.toString();
+  }
+  return url.toString();
+}
+
+function normalizeEndpointPath(path: string) {
+  if (!path.startsWith("/")) {
+    throw new Error("Bridge endpoint path must start with /");
+  }
+  return path;
+}
+
+export async function fetchCapabilities(
+  httpUrl: (path: string, query?: URLSearchParams) => string,
+): Promise<BridgeCapabilities> {
+  const response = await fetch(httpUrl("/api/capabilities"));
+  if (!response.ok) {
+    throw new Error(`capabilities failed: ${response.status}`);
+  }
+  return parseCapabilities(await response.json());
+}
+
+export async function probeBridgeBaseUrl(baseUrl: string): Promise<BridgeCapabilities> {
+  const normalized = normalizeBridgeBaseUrl(baseUrl);
+  const capabilities = await fetchCapabilities((path, query) => buildHttpUrl(normalized, path, query));
+  const error = compatibilityError(capabilities);
+  if (error) {
+    throw new Error(error);
+  }
+  return capabilities;
+}
+
+export function parseCapabilities(value: unknown): BridgeCapabilities {
+  if (!isRecord(value)) {
+    return { commands: [] };
+  }
+  return {
+    commands: Array.isArray(value.commands)
+      ? value.commands.filter((command): command is string => typeof command === "string")
+      : [],
+    bridge_version: typeof value.bridge_version === "string" ? value.bridge_version : undefined,
+    web_compat: typeof value.web_compat === "number" ? value.web_compat : undefined,
+    min_android_app_compat:
+      typeof value.min_android_app_compat === "number" ? value.min_android_app_compat : undefined,
+  };
+}
+
+function compatibilityError(capabilities: BridgeCapabilities) {
+  if (
+    typeof capabilities.web_compat === "number" &&
+    capabilities.web_compat < APP_MIN_WEB_COMPAT
+  ) {
+    return "Bridge is not compatible with this web app";
+  }
+  return null;
+}
+
+function backendDisplayName(
+  name: string | undefined,
+  baseUrl: string,
+  existing: readonly BridgeBackendProfile[],
+) {
+  const requested = name?.trim() || displayNameFromUrl(baseUrl);
+  const names = new Set(existing.map((backend) => backend.name));
+  if (!names.has(requested)) {
+    return requested;
+  }
+  let index = 2;
+  while (names.has(`${requested} ${index}`)) {
+    index += 1;
+  }
+  return `${requested} ${index}`;
+}
+
+function displayNameFromUrl(baseUrl: string) {
+  const url = new URL(baseUrl);
+  return url.host;
+}
+
+function createBackendId() {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi?.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+  return `backend-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function duplicateBackend(
+  backends: readonly BridgeBackendProfile[],
+  baseUrl: string,
+  ignoreId?: string,
+) {
+  const normalized = normalizeBridgeBaseUrl(baseUrl);
+  return (
+    backends.find((backend) => backend.id !== ignoreId && backend.baseUrl === normalized) ?? null
+  );
+}
+
+function parseIpv4(host: string): [number, number, number, number] | null {
+  const parts = host.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+  const bytes = parts.map((part) => {
+    if (!/^\d{1,3}$/u.test(part)) {
+      return Number.NaN;
+    }
+    const value = Number(part);
+    return value >= 0 && value <= 255 ? value : Number.NaN;
+  });
+  return bytes.some(Number.isNaN) ? null : (bytes as [number, number, number, number]);
+}
+
+function isPrivateIpv4([a, b]: [number, number, number, number]) {
+  return (
+    a === 10 ||
+    a === 127 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254)
+  );
+}
+
+function stripIpv6Brackets(host: string) {
+  return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+}
+
+function isIpv6Literal(host: string) {
+  return host.includes(":");
+}
+
+function isPrivateIpv6(host: string) {
+  return host === "::1" || host.startsWith("fe80:") || /^[fu][cd][0-9a-f]{0,2}:/iu.test(host);
+}
+
+function isValidHostname(host: string) {
+  if (host === "localhost") {
+    return true;
+  }
+  if (host.length > 253 || host.endsWith(".")) {
+    return false;
+  }
+  return host.split(".").every((label) => {
+    return (
+      label.length > 0 &&
+      label.length <= 63 &&
+      /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/iu.test(label)
+    );
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/web/src/commands.test.ts
+++ b/web/src/commands.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   commands,
+  createCommands,
   createdPaneId,
   probeSupportedCommands,
 } from "./commands";
@@ -27,6 +28,25 @@ describe("command helpers", () => {
 
     await expect(probeSupportedCommands()).resolves.toEqual(new Set(["pane.split", "pane.move"]));
     expect(fetch).toHaveBeenCalledWith("/api/capabilities");
+  });
+
+  it("uses injected bridge URLs for commands and capability probes", async () => {
+    const httpUrl = (path: string) => `http://192.168.1.20:4000${path}`;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ commands: ["pane.split"], type: "ok" }), {
+        status: 200,
+      }),
+    );
+
+    await createCommands(httpUrl).closePane("pane-1");
+    await probeSupportedCommands(httpUrl);
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      "http://192.168.1.20:4000/api/command",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(2, "http://192.168.1.20:4000/api/capabilities");
   });
 
   it("creates launch tabs without a tab label and renames the root pane", async () => {

--- a/web/src/commands.ts
+++ b/web/src/commands.ts
@@ -7,12 +7,19 @@ import { shellCommand } from "./shell";
 export type CommandResult = { type?: string; [key: string]: unknown };
 export type PaneFocusDirection = "left" | "right" | "up" | "down";
 export type { LaunchSpec, SplitDirection };
+export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
+
+const sameOriginHttpUrl: BridgeHttpUrl = (path, query) => {
+  const suffix = query && query.toString() ? `?${query.toString()}` : "";
+  return `${path}${suffix}`;
+};
 
 async function runCommand(
+  httpUrl: BridgeHttpUrl,
   method: string,
   params: Record<string, unknown>,
 ): Promise<CommandResult> {
-  const response = await fetch("/api/command", {
+  const response = await fetch(httpUrl("/api/command"), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ method, params }),
@@ -49,91 +56,98 @@ export function createdPaneId(result: CommandResult): string | null {
   );
 }
 
-export const commands = {
-  createWorkspace: () => runCommand("workspace.create", { focus: true }),
-  renameWorkspace: (workspaceId: string, label: string | null) =>
-    runCommand("workspace.rename", { workspace_id: workspaceId, label }),
-  closeWorkspace: (workspaceId: string) =>
-    runCommand("workspace.close", { workspace_id: workspaceId }),
-  focusWorkspace: (workspaceId: string) =>
-    runCommand("workspace.focus", { workspace_id: workspaceId }),
+export function createCommands(httpUrl: BridgeHttpUrl = sameOriginHttpUrl) {
+  const api = {
+    createWorkspace: () => runCommand(httpUrl, "workspace.create", { focus: true }),
+    renameWorkspace: (workspaceId: string, label: string | null) =>
+      runCommand(httpUrl, "workspace.rename", { workspace_id: workspaceId, label }),
+    closeWorkspace: (workspaceId: string) =>
+      runCommand(httpUrl, "workspace.close", { workspace_id: workspaceId }),
+    focusWorkspace: (workspaceId: string) =>
+      runCommand(httpUrl, "workspace.focus", { workspace_id: workspaceId }),
 
-  createTab: (workspaceId: string, label?: string) =>
-    runCommand("tab.create", { workspace_id: workspaceId, focus: true, label }),
-  renameTab: (tabId: string, label: string | null) =>
-    runCommand("tab.rename", { tab_id: tabId, label }),
-  closeTab: (tabId: string) => runCommand("tab.close", { tab_id: tabId }),
-  focusTab: (tabId: string) => runCommand("tab.focus", { tab_id: tabId }),
+    createTab: (workspaceId: string, label?: string) =>
+      runCommand(httpUrl, "tab.create", { workspace_id: workspaceId, focus: true, label }),
+    renameTab: (tabId: string, label: string | null) =>
+      runCommand(httpUrl, "tab.rename", { tab_id: tabId, label }),
+    closeTab: (tabId: string) => runCommand(httpUrl, "tab.close", { tab_id: tabId }),
+    focusTab: (tabId: string) => runCommand(httpUrl, "tab.focus", { tab_id: tabId }),
 
-  renamePane: (paneId: string, label: string) =>
-    runCommand("pane.rename", { pane_id: paneId, label }),
-  closePane: (paneId: string) => runCommand("pane.close", { pane_id: paneId }),
-  runPaneCommand: (paneId: string, command: string) =>
-    runCommand("pane.send_input", { pane_id: paneId, text: command, keys: ["Enter"] }),
-  // Layout-mutating: requires the bridge allow-list to include `pane.split`.
-  splitPane: (targetPaneId: string, direction: SplitDirection) =>
-    runCommand("pane.split", { target_pane_id: targetPaneId, direction, focus: true }),
-  focusPaneDirection: (paneId: string, direction: PaneFocusDirection) =>
-    runCommand("pane.focus_direction", { pane_id: paneId, direction }),
-  movePaneToNewTab: (paneId: string, workspaceId: string, label?: string) =>
-    runCommand("pane.move", {
-      pane_id: paneId,
-      destination: { type: "new_tab", workspace_id: workspaceId, label },
-      focus: true,
-    }),
-  movePaneToNewWorkspace: (paneId: string, label?: string) =>
-    runCommand("pane.move", {
-      pane_id: paneId,
-      destination: { type: "new_workspace", label },
-      focus: true,
-    }),
+    renamePane: (paneId: string, label: string) =>
+      runCommand(httpUrl, "pane.rename", { pane_id: paneId, label }),
+    closePane: (paneId: string) => runCommand(httpUrl, "pane.close", { pane_id: paneId }),
+    runPaneCommand: (paneId: string, command: string) =>
+      runCommand(httpUrl, "pane.send_input", { pane_id: paneId, text: command, keys: ["Enter"] }),
+    // Layout-mutating: requires the bridge allow-list to include `pane.split`.
+    splitPane: (targetPaneId: string, direction: SplitDirection) =>
+      runCommand(httpUrl, "pane.split", { target_pane_id: targetPaneId, direction, focus: true }),
+    focusPaneDirection: (paneId: string, direction: PaneFocusDirection) =>
+      runCommand(httpUrl, "pane.focus_direction", { pane_id: paneId, direction }),
+    movePaneToNewTab: (paneId: string, workspaceId: string, label?: string) =>
+      runCommand(httpUrl, "pane.move", {
+        pane_id: paneId,
+        destination: { type: "new_tab", workspace_id: workspaceId, label },
+        focus: true,
+      }),
+    movePaneToNewWorkspace: (paneId: string, label?: string) =>
+      runCommand(httpUrl, "pane.move", {
+        pane_id: paneId,
+        destination: { type: "new_workspace", label },
+        focus: true,
+      }),
 
-  startAgentSplit: (tabId: string, direction: SplitDirection, spec: LaunchSpec) =>
-    runCommand("agent.start", {
-      name: spec.title,
-      tab_id: tabId,
-      split: direction,
-      focus: true,
-      argv: agentArgv(spec.kind),
-    }),
+    startAgentSplit: (tabId: string, direction: SplitDirection, spec: LaunchSpec) =>
+      runCommand(httpUrl, "agent.start", {
+        name: spec.title,
+        tab_id: tabId,
+        split: direction,
+        focus: true,
+        argv: agentArgv(spec.kind),
+      }),
 
-  createLaunchTab: async (workspaceId: string, spec: LaunchSpec) => {
-    const result = await commands.createTab(workspaceId);
-    const paneId = createdPaneId(result);
-    if (!paneId) {
-      throw new Error("new tab did not return a root pane");
-    }
-    const title = spec.title.trim();
-    if (title) {
-      await commands.renamePane(paneId, title);
-    }
-    if (spec.kind !== "shell") {
-      await commands.runPaneCommand(paneId, shellCommand(agentArgv(spec.kind)));
-    }
-    return result;
-  },
+    createLaunchTab: async (workspaceId: string, spec: LaunchSpec) => {
+      const result = await api.createTab(workspaceId);
+      const paneId = createdPaneId(result);
+      if (!paneId) {
+        throw new Error("new tab did not return a root pane");
+      }
+      const title = spec.title.trim();
+      if (title) {
+        await api.renamePane(paneId, title);
+      }
+      if (spec.kind !== "shell") {
+        await api.runPaneCommand(paneId, shellCommand(agentArgv(spec.kind)));
+      }
+      return result;
+    },
 
-  splitLaunchPane: async (
-    targetPaneId: string,
-    tabId: string,
-    direction: SplitDirection,
-    spec: LaunchSpec,
-  ) => {
-    if (spec.kind !== "shell") {
-      return commands.startAgentSplit(tabId, direction, spec);
-    }
-    const result = await commands.splitPane(targetPaneId, direction);
-    const paneId = createdPaneId(result);
-    if (paneId && spec.title.trim()) {
-      await commands.renamePane(paneId, spec.title.trim());
-    }
-    return result;
-  },
-};
+    splitLaunchPane: async (
+      targetPaneId: string,
+      tabId: string,
+      direction: SplitDirection,
+      spec: LaunchSpec,
+    ) => {
+      if (spec.kind !== "shell") {
+        return api.startAgentSplit(tabId, direction, spec);
+      }
+      const result = await api.splitPane(targetPaneId, direction);
+      const paneId = createdPaneId(result);
+      if (paneId && spec.title.trim()) {
+        await api.renamePane(paneId, spec.title.trim());
+      }
+      return result;
+    },
+  };
+  return api;
+}
 
-export async function probeSupportedCommands(): Promise<Set<string>> {
+export const commands = createCommands();
+
+export async function probeSupportedCommands(
+  httpUrl: BridgeHttpUrl = sameOriginHttpUrl,
+): Promise<Set<string>> {
   try {
-    const response = await fetch("/api/capabilities");
+    const response = await fetch(httpUrl("/api/capabilities"));
     if (!response.ok) {
       return new Set();
     }

--- a/web/src/connectionState.ts
+++ b/web/src/connectionState.ts
@@ -1,0 +1,14 @@
+export function currentConnectionSnapshot<T>(
+  snapshot: T | null,
+  snapshotConnectionKey: string,
+  connectionKey: string,
+) {
+  return snapshotConnectionKey === connectionKey ? snapshot : null;
+}
+
+export function isConnectionResultCurrent(
+  currentConnectionKey: string,
+  requestConnectionKey: string,
+) {
+  return currentConnectionKey === requestConnectionKey;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import "@fontsource-variable/geist/wght.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { BridgeProvider } from "./bridge";
 import "./styles.css";
 
 const root = document.getElementById("root");
@@ -12,6 +13,8 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <BridgeProvider>
+      <App />
+    </BridgeProvider>
   </StrictMode>,
 );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1328,6 +1328,12 @@ button {
   color: var(--text);
 }
 
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
 .modal-message {
   margin-top: -6px;
   font-size: 13px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1456,6 +1456,21 @@ button {
   gap: 12px;
 }
 
+.backend-static {
+  display: grid;
+  gap: 6px;
+  padding-top: 2px;
+  color: var(--subtext0);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.backend-static strong {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
 .backend-note,
 .backend-warning {
   font-size: 12px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1380,6 +1380,96 @@ button {
   white-space: nowrap;
 }
 
+.backend-modal {
+  width: min(720px, 100%);
+}
+
+.backend-layout {
+  display: grid;
+  grid-template-columns: minmax(170px, 0.8fr) minmax(0, 1.2fr);
+  gap: 14px;
+  min-height: 260px;
+}
+
+.backend-list {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.backend-row {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  color: var(--subtext0);
+  background: transparent;
+  text-align: left;
+}
+
+.backend-row:hover {
+  color: var(--text);
+  background: var(--row-hover);
+}
+
+.backend-row[data-active="true"] {
+  border-color: var(--line);
+  color: var(--text);
+  background: var(--row-active);
+}
+
+.backend-row span {
+  min-width: 0;
+}
+
+.backend-row strong,
+.backend-row small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.backend-row strong {
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.backend-row small {
+  margin-top: 2px;
+  color: var(--overlay0);
+  font-family: var(--mono);
+  font-size: 10.5px;
+}
+
+.backend-form {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.backend-note,
+.backend-warning {
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.backend-note {
+  color: var(--overlay1);
+}
+
+.backend-warning {
+  color: var(--peach);
+}
+
 .field-label {
   display: grid;
   gap: 6px;
@@ -1594,6 +1684,15 @@ button {
 
   .sidebar-resizer {
     display: none;
+  }
+
+  .backend-layout {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .backend-list {
+    max-height: 190px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add named bridge backend profiles with same-origin default and backend settings UI
- route app commands, snapshots, websockets, terminal attach, and uploads through the active bridge runtime
- add capability probing, compatibility handling, connection guards, and retry behavior
- refine the bridge settings dialog after Claude review

## Verification
- npm run test:web
- npm run lint:web
- npm run build:web
- npm run check attempted; bridge:test cannot complete because zig is not available for the vendored Herdr/libghostty build

## Review
- Claude iterative review completed cleanly with findings: []