### PR TITLE
Add mobile terminal input actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   release uploads.
 - Added a run-focused README for desktop tarball distributions.
 - Added top-level agent onboarding guidance for web app, bridge, vendoring, testing, and release work.
-- Added a mobile terminal tap-focus setting and a stage-only command input action.
+- Added a mobile terminal tap-focus setting and a stage-only text input action.
 
 ### Changed
 
@@ -54,7 +54,7 @@
 - Disabled Android cloud backup for the shell and removed unused Capacitor mixed-content/deprecated
   runtime config.
 - Included Rust formatting checks for the bridge in the root lint command.
-- Changed mobile terminal taps to focus the command input by default, with raw terminal focus behind
+- Changed mobile terminal taps to focus the text input by default, with raw terminal focus behind
   a keyboard-row button.
 - Moved mobile arrow keys into the expanded keyboard and added separate `1`, `2`, and `3` quick keys.
 - Changed new-tab launches so the entered title names the created pane while default-looking single-pane tabs display that pane title.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Added a run-focused README for desktop tarball distributions.
 - Added top-level agent onboarding guidance for web app, bridge, vendoring, testing, and release work.
 - Added a mobile terminal tap-focus setting and a stage-only text input action.
+- Added a mobile `Alt+Up` quick key after `Tab`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@
 - Added a run-focused README for desktop tarball distributions.
 - Added top-level agent onboarding guidance for web app, bridge, vendoring, testing, and release work.
 - Added a mobile terminal tap-focus setting and a stage-only text input action.
-- Added a mobile `Alt+Up` quick key after `Tab`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   release uploads.
 - Added a run-focused README for desktop tarball distributions.
 - Added top-level agent onboarding guidance for web app, bridge, vendoring, testing, and release work.
+- Added a mobile terminal tap-focus setting and a stage-only command input action.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ navigation, multi-client viewing, mobile input controls, and synchronized pane s
 ## Highlights
 
 - Shared browser terminal viewing with synchronized pane selection across desktop and mobile.
-- Mobile-friendly command input with stage/send actions, configurable tap focus, and extended
+- Mobile-friendly text input with stage/send actions, configurable tap focus, and extended
   terminal key controls.
 - Agent-focused sidebar with styled icons for detected Codex/OpenAI, Claude, and Pi panes.
 - Image and file uploads from the terminal toolbar, paste, or drag/drop, with uploaded paths inserted

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ navigation, multi-client viewing, mobile input controls, and synchronized pane s
 ## Highlights
 
 - Shared browser terminal viewing with synchronized pane selection across desktop and mobile.
-- Mobile-friendly command input and extended terminal key controls.
+- Mobile-friendly command input with stage/send actions, configurable tap focus, and extended
+  terminal key controls.
 - Agent-focused sidebar with styled icons for detected Codex/OpenAI, Claude, and Pi panes.
 - Image and file uploads from the terminal toolbar, paste, or drag/drop, with uploaded paths inserted
   into the active terminal input.

--- a/docs/android.md
+++ b/docs/android.md
@@ -179,8 +179,8 @@ On a trusted LAN:
 5. Add a backend such as `http://192.168.1.20:4000`.
 6. Use `Test` and confirm it reports reachable.
 7. Use `Save & use`.
-8. Confirm snapshot, event updates, terminal attach, command input, stage-only input, uploads, and pane controls work.
-9. Toggle the mobile terminal tap setting and confirm terminal taps can focus either the command input or terminal.
+8. Confirm snapshot, event updates, terminal attach, text input, stage-only input, uploads, and pane controls work.
+9. Toggle the mobile terminal tap setting and confirm terminal taps can focus either the text input or terminal.
 10. Force-close and reopen the app; confirm the active backend persists.
 11. Test Android back behavior from the mobile sidebar/detail views.
 12. Test an unreachable backend and confirm the app stays usable enough to edit settings.

--- a/docs/android.md
+++ b/docs/android.md
@@ -179,10 +179,11 @@ On a trusted LAN:
 5. Add a backend such as `http://192.168.1.20:4000`.
 6. Use `Test` and confirm it reports reachable.
 7. Use `Save & use`.
-8. Confirm snapshot, event updates, terminal attach, command input, uploads, and pane controls work.
-9. Force-close and reopen the app; confirm the active backend persists.
-10. Test Android back behavior from the mobile sidebar/detail views.
-11. Test an unreachable backend and confirm the app stays usable enough to edit settings.
+8. Confirm snapshot, event updates, terminal attach, command input, stage-only input, uploads, and pane controls work.
+9. Toggle the mobile terminal tap setting and confirm terminal taps can focus either the command input or terminal.
+10. Force-close and reopen the app; confirm the active backend persists.
+11. Test Android back behavior from the mobile sidebar/detail views.
+12. Test an unreachable backend and confirm the app stays usable enough to edit settings.
 
 ## Release Notes
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -93,7 +93,7 @@ Open `http://127.0.0.1:8787` and verify:
 - The app loads the workspace, tab, pane, and split layout snapshot.
 - Multiple browser clients can attach to the same terminal.
 - Pane selection syncs between browser clients.
-- Typing, mobile command input, stage-only input, tap-focus setting, scrolling, and refit work.
+- Typing, mobile text input, stage-only input, tap-focus setting, scrolling, and refit work.
 - New tabs can launch Shell, Codex, Claude, and pi.
 - Split right/down can launch Shell, Codex, Claude, and pi.
 - Upload button, paste upload, and drop upload place shell-quoted file paths in the terminal.

--- a/docs/release.md
+++ b/docs/release.md
@@ -93,7 +93,7 @@ Open `http://127.0.0.1:8787` and verify:
 - The app loads the workspace, tab, pane, and split layout snapshot.
 - Multiple browser clients can attach to the same terminal.
 - Pane selection syncs between browser clients.
-- Typing, mobile command input, scrolling, and refit work.
+- Typing, mobile command input, stage-only input, tap-focus setting, scrolling, and refit work.
 - New tabs can launch Shell, Codex, Claude, and pi.
 - Split right/down can launch Shell, Codex, Claude, and pi.
 - Upload button, paste upload, and drop upload place shell-quoted file paths in the terminal.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1225,6 +1225,7 @@ export function App() {
 
       {backendSettingsOpen ? (
         <BackendSettingsDialog
+          showMobileTerminalSettings={isTouchInput}
           mobileTerminalTapTarget={mobileTerminalTapTarget}
           onMobileTerminalTapTarget={setMobileTerminalTapTarget}
           onClose={() => setBackendSettingsOpen(false)}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1713,7 +1713,7 @@ function Switcher({
             </span>
             {bridgeBlocked ? (
               <button type="button" className="btn" onClick={onBackendSettings}>
-                Bridge settings
+                Settings
               </button>
             ) : null}
           </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,11 @@ import {
 import { LaunchDialog } from "./LaunchDialog";
 import { resolveLaunchSpec } from "./launch";
 import type { LaunchTarget } from "./launch";
+import {
+  DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
+  parseMobileTerminalTapTarget,
+} from "./mobileTerminalPrefs";
+import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
 import { addNativeBackHandler } from "./native";
 import { ActionMenu, ConfirmDialog, RenameDialog, useLongPress } from "./overlays";
 import type { MenuItem } from "./overlays";
@@ -75,6 +80,7 @@ type DisplayPrefs = {
   sidebarOpen: boolean;
   activeSpaceId: string | null;
   selectedPaneId: string | null;
+  mobileTerminalTapTarget: MobileTerminalTapTarget;
 };
 
 const COMPACT_LAYOUT_QUERY = "(max-width: 820px)";
@@ -96,6 +102,7 @@ function readDisplayPrefs(): DisplayPrefs {
     sidebarOpen: true,
     activeSpaceId: null,
     selectedPaneId: null,
+    mobileTerminalTapTarget: DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
   };
   try {
     const raw = window.localStorage.getItem(DISPLAY_PREFS_KEY);
@@ -129,6 +136,7 @@ function readDisplayPrefs(): DisplayPrefs {
         typeof parsed.activeSpaceId === "string" ? parsed.activeSpaceId : fallback.activeSpaceId,
       selectedPaneId:
         typeof parsed.selectedPaneId === "string" ? parsed.selectedPaneId : fallback.selectedPaneId,
+      mobileTerminalTapTarget: parseMobileTerminalTapTarget(parsed.mobileTerminalTapTarget),
     };
   } catch {
     return fallback;
@@ -210,6 +218,9 @@ export function App() {
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [backendSettingsOpen, setBackendSettingsOpen] = useState(false);
+  const [mobileTerminalTapTarget, setMobileTerminalTapTarget] = useState(
+    initialPrefs.mobileTerminalTapTarget,
+  );
   const [launchTarget, setLaunchTarget] = useState<LaunchTarget | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -318,6 +329,7 @@ export function App() {
       sidebarOpen,
       activeSpaceId,
       selectedPaneId,
+      mobileTerminalTapTarget,
     });
   }, [
     scope,
@@ -328,6 +340,7 @@ export function App() {
     sidebarOpen,
     activeSpaceId,
     selectedPaneId,
+    mobileTerminalTapTarget,
   ]);
 
   useEffect(() => {
@@ -1142,6 +1155,7 @@ export function App() {
             refitToken={refitToken}
             focusToken={terminalFocusToken}
             touchInput={isTouchInput}
+            mobileTapTarget={mobileTerminalTapTarget}
             connectionKey={bridge.connectionKey}
             resumeToken={bridge.resumeToken}
             httpUrl={bridge.httpUrl}
@@ -1157,6 +1171,7 @@ export function App() {
             autoFocus={!isTouchInput}
             scrollSensitivity={isTouchInput ? 2 : 0.4}
             mobileControls={isTouchInput}
+            mobileTapTarget={mobileTerminalTapTarget}
             refitToken={refitToken}
             focusToken={terminalFocusToken}
           />
@@ -1209,7 +1224,11 @@ export function App() {
       ) : null}
 
       {backendSettingsOpen ? (
-        <BackendSettingsDialog onClose={() => setBackendSettingsOpen(false)} />
+        <BackendSettingsDialog
+          mobileTerminalTapTarget={mobileTerminalTapTarget}
+          onMobileTerminalTapTarget={setMobileTerminalTapTarget}
+          onClose={() => setBackendSettingsOpen(false)}
+        />
       ) : null}
 
       {error ? (
@@ -1363,6 +1382,7 @@ function SplitGrid({
   refitToken,
   focusToken,
   touchInput,
+  mobileTapTarget,
   connectionKey,
   resumeToken,
   httpUrl,
@@ -1374,6 +1394,7 @@ function SplitGrid({
   refitToken: number;
   focusToken: number;
   touchInput: boolean;
+  mobileTapTarget: MobileTerminalTapTarget;
   connectionKey: string;
   resumeToken: number;
   httpUrl: (path: string, query?: URLSearchParams) => string;
@@ -1400,6 +1421,7 @@ function SplitGrid({
               autoFocus={selected && !touchInput}
               scrollSensitivity={touchInput ? 2 : 0.4}
               mobileControls={selected && touchInput}
+              mobileTapTarget={mobileTapTarget}
               refitToken={selected ? refitToken : 0}
               focusToken={selected ? focusToken : 0}
             />
@@ -1616,8 +1638,8 @@ function Switcher({
         <button
           className="icon-btn"
           type="button"
-          aria-label="Bridge settings"
-          title={`Bridge: ${bridgeLabel}`}
+          aria-label="Settings"
+          title={`Settings; bridge: ${bridgeLabel}`}
           data-spin={capabilityState === "probing" ? "" : undefined}
           onClick={onBackendSettings}
         >

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -310,7 +310,7 @@ export function BackendSettingsDialog({
                       aria-pressed={mobileTerminalTapTarget === "command-input"}
                       onClick={() => onMobileTerminalTapTarget("command-input")}
                     >
-                      Command input
+                      Text input
                     </button>
                     <button
                       type="button"

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -9,6 +9,7 @@ import type { BridgeBackendProfile } from "./bridge";
 import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
 
 type Props = {
+  showMobileTerminalSettings: boolean;
   mobileTerminalTapTarget: MobileTerminalTapTarget;
   onMobileTerminalTapTarget: (target: MobileTerminalTapTarget) => void;
   onClose: () => void;
@@ -29,6 +30,7 @@ const emptyForm: FormState = {
 };
 
 export function BackendSettingsDialog({
+  showMobileTerminalSettings,
   mobileTerminalTapTarget,
   onMobileTerminalTapTarget,
   onClose,
@@ -296,30 +298,32 @@ export function BackendSettingsDialog({
               <div className="backend-warning">This URL is already saved as {duplicate.name}.</div>
             ) : null}
             {message ? <div className="modal-message">{message}</div> : null}
-            <div className="settings-section">
-              <div className="settings-label">Mobile terminal</div>
-              <div className="settings-row">
-                <span>Terminal tap</span>
-                <div className="segmented-control" role="group" aria-label="Terminal tap target">
-                  <button
-                    type="button"
-                    data-on={mobileTerminalTapTarget === "command-input"}
-                    aria-pressed={mobileTerminalTapTarget === "command-input"}
-                    onClick={() => onMobileTerminalTapTarget("command-input")}
-                  >
-                    Command input
-                  </button>
-                  <button
-                    type="button"
-                    data-on={mobileTerminalTapTarget === "terminal"}
-                    aria-pressed={mobileTerminalTapTarget === "terminal"}
-                    onClick={() => onMobileTerminalTapTarget("terminal")}
-                  >
-                    Terminal
-                  </button>
+            {showMobileTerminalSettings ? (
+              <div className="settings-section">
+                <div className="settings-label">Mobile terminal</div>
+                <div className="settings-row">
+                  <span>Terminal tap</span>
+                  <div className="segmented-control" role="group" aria-label="Terminal tap target">
+                    <button
+                      type="button"
+                      data-on={mobileTerminalTapTarget === "command-input"}
+                      aria-pressed={mobileTerminalTapTarget === "command-input"}
+                      onClick={() => onMobileTerminalTapTarget("command-input")}
+                    >
+                      Command input
+                    </button>
+                    <button
+                      type="button"
+                      data-on={mobileTerminalTapTarget === "terminal"}
+                      aria-pressed={mobileTerminalTapTarget === "terminal"}
+                      onClick={() => onMobileTerminalTapTarget("terminal")}
+                    >
+                      Terminal
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
+            ) : null}
           </div>
         </div>
         <div className="modal-actions">

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -6,8 +6,11 @@ import {
   useBridge,
 } from "./bridge";
 import type { BridgeBackendProfile } from "./bridge";
+import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
 
 type Props = {
+  mobileTerminalTapTarget: MobileTerminalTapTarget;
+  onMobileTerminalTapTarget: (target: MobileTerminalTapTarget) => void;
   onClose: () => void;
 };
 
@@ -25,7 +28,11 @@ const emptyForm: FormState = {
   baseUrl: "",
 };
 
-export function BackendSettingsDialog({ onClose }: Props) {
+export function BackendSettingsDialog({
+  mobileTerminalTapTarget,
+  onMobileTerminalTapTarget,
+  onClose,
+}: Props) {
   const bridge = useBridge();
   const titleId = useId();
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -199,7 +206,7 @@ export function BackendSettingsDialog({ onClose }: Props) {
         >
           <X size={15} />
         </button>
-        <div id={titleId} className="modal-title">Bridges</div>
+        <div id={titleId} className="modal-title">Settings</div>
         <div className="backend-layout">
           <div className="backend-list" role="list" aria-label="Saved bridges">
             {showSameOrigin ? (
@@ -289,6 +296,30 @@ export function BackendSettingsDialog({ onClose }: Props) {
               <div className="backend-warning">This URL is already saved as {duplicate.name}.</div>
             ) : null}
             {message ? <div className="modal-message">{message}</div> : null}
+            <div className="settings-section">
+              <div className="settings-label">Mobile terminal</div>
+              <div className="settings-row">
+                <span>Terminal tap</span>
+                <div className="segmented-control" role="group" aria-label="Terminal tap target">
+                  <button
+                    type="button"
+                    data-on={mobileTerminalTapTarget === "command-input"}
+                    aria-pressed={mobileTerminalTapTarget === "command-input"}
+                    onClick={() => onMobileTerminalTapTarget("command-input")}
+                  >
+                    Command input
+                  </button>
+                  <button
+                    type="button"
+                    data-on={mobileTerminalTapTarget === "terminal"}
+                    aria-pressed={mobileTerminalTapTarget === "terminal"}
+                    onClick={() => onMobileTerminalTapTarget("terminal")}
+                  >
+                    Terminal
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div className="modal-actions">

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -832,6 +832,7 @@ type TerminalKey = {
 
 const COMMON_KEYS: TerminalKey[] = [
   { label: "Tab", data: "\t" },
+  { label: "A-↑", data: "\x1B[1;3A" },
   { label: "C-c", data: "\x03" },
   { label: "C-d", data: "\x04" },
 ];

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -1,10 +1,11 @@
-import { Keyboard, Paperclip, Send, SquareTerminal } from "lucide-react";
+import { Keyboard, Paperclip, Send, SquareTerminal, TextCursorInput } from "lucide-react";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent, RefObject } from "react";
 import { ConfirmDialog } from "./overlays";
 import { shellQuote } from "./shell";
 import { GhosttyRenderer } from "./terminalRenderer";
 import type { TerminalRenderer, TerminalSize } from "./terminalRenderer";
+import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
 import type { PaneInfo } from "./types";
 
 type Props = {
@@ -19,6 +20,8 @@ type Props = {
   scrollSensitivity?: number;
   /** Supplemental browser-native input controls for narrow touch screens. */
   mobileControls?: boolean;
+  /** Where terminal taps should send focus on mobile. */
+  mobileTapTarget?: MobileTerminalTapTarget;
   /** Incrementing token from the parent that requests an immediate fit+resize. */
   refitToken?: number;
   /** Incrementing token from the parent that requests focus on the preferred terminal input. */
@@ -54,6 +57,7 @@ export function TerminalView({
   autoFocus = true,
   scrollSensitivity = 1,
   mobileControls = false,
+  mobileTapTarget = "command-input",
   refitToken = 0,
   focusToken = 0,
 }: Props) {
@@ -83,6 +87,8 @@ export function TerminalView({
   scrollSensitivityRef.current = scrollSensitivity;
   const mobileControlsRef = useRef(mobileControls);
   mobileControlsRef.current = mobileControls;
+  const mobileTapTargetRef = useRef(mobileTapTarget);
+  mobileTapTargetRef.current = mobileTapTarget;
   connectionKeyRef.current = connectionKey;
   terminalIdRef.current = pane?.terminal_id ?? null;
 
@@ -161,7 +167,11 @@ export function TerminalView({
         }
 
         renderer.setScrollSensitivity(scrollSensitivityRef.current);
-        renderer.setTapFocusHandler(focusMobileCommandInput);
+        renderer.setTapFocusHandler(
+          mobileControlsRef.current && mobileTapTargetRef.current === "command-input"
+            ? focusMobileCommandInput
+            : null,
+        );
 
         disposeInput = renderer.onInput((data) => {
           if (socket?.readyState === WebSocket.OPEN) {
@@ -338,8 +348,10 @@ export function TerminalView({
   }, [connectionKey, pane?.terminal_id, resumeToken, wsUrl]);
 
   useEffect(() => {
-    rendererRef.current?.setTapFocusHandler(mobileControls ? focusMobileCommandInput : null);
-  }, [focusMobileCommandInput, mobileControls]);
+    rendererRef.current?.setTapFocusHandler(
+      mobileControls && mobileTapTarget === "command-input" ? focusMobileCommandInput : null,
+    );
+  }, [focusMobileCommandInput, mobileControls, mobileTapTarget]);
 
   useEffect(() => {
     return () => {
@@ -594,6 +606,7 @@ export function TerminalView({
           onInput={sendTerminalInput}
           onTerminalFocus={() => rendererRef.current?.focusTextInput()}
           onUpload={openFilePicker}
+          onStageCommand={(command) => enqueueTerminalInput([command])}
           onSubmitCommand={(command) => enqueueTerminalInput([command, "\r"])}
         />
       ) : null}
@@ -617,6 +630,7 @@ function MobileTerminalControls({
   onInput,
   onTerminalFocus,
   onUpload,
+  onStageCommand,
   onSubmitCommand,
 }: {
   commandInputRef: RefObject<HTMLInputElement | null>;
@@ -625,6 +639,7 @@ function MobileTerminalControls({
   onInput: (data: string) => void;
   onTerminalFocus: () => void;
   onUpload: () => void;
+  onStageCommand: (command: string) => void;
   onSubmitCommand: (command: string) => void;
 }) {
   const [value, setValue] = useState("");
@@ -632,6 +647,13 @@ function MobileTerminalControls({
   const [ctrlLatch, setCtrlLatch] = useState(false);
   const submit = () => {
     onSubmitCommand(value);
+    setValue("");
+  };
+  const stage = () => {
+    if (value.length === 0) {
+      return;
+    }
+    onStageCommand(value);
     setValue("");
   };
   const sendKey = (key: TerminalKey) => {
@@ -763,6 +785,16 @@ function MobileTerminalControls({
           value={value}
           onChange={(event) => setValue(event.target.value)}
         />
+        <button
+          className="term-send term-stage-command"
+          type="button"
+          disabled={disabled || value.length === 0}
+          aria-label="Stage command in terminal"
+          title="Stage"
+          onClick={stage}
+        >
+          <TextCursorInput size={16} />
+        </button>
         <button
           className="term-send"
           type="submit"

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -832,7 +832,6 @@ type TerminalKey = {
 
 const COMMON_KEYS: TerminalKey[] = [
   { label: "Tab", data: "\t" },
-  { label: "A-↑", data: "\x1B[1;3A" },
   { label: "C-c", data: "\x03" },
   { label: "C-d", data: "\x04" },
 ];

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -104,7 +104,16 @@ export function TerminalView({
     return true;
   }, []);
 
+  const focusTerminalKeyboardInput = useCallback(() => {
+    rendererRef.current?.focusTextInput();
+    return "terminal" as const;
+  }, []);
+
   const focusPreferredInput = useCallback(() => {
+    if (mobileControlsRef.current && mobileTapTargetRef.current === "terminal") {
+      rendererRef.current?.focusTextInput();
+      return;
+    }
     if (!focusMobileCommandInput()) {
       rendererRef.current?.focusTextInput();
     }
@@ -168,9 +177,11 @@ export function TerminalView({
 
         renderer.setScrollSensitivity(scrollSensitivityRef.current);
         renderer.setTapFocusHandler(
-          mobileControlsRef.current && mobileTapTargetRef.current === "command-input"
-            ? focusMobileCommandInput
-            : null,
+          !mobileControlsRef.current
+            ? null
+            : mobileTapTargetRef.current === "command-input"
+              ? focusMobileCommandInput
+              : focusTerminalKeyboardInput,
         );
 
         disposeInput = renderer.onInput((data) => {
@@ -349,9 +360,13 @@ export function TerminalView({
 
   useEffect(() => {
     rendererRef.current?.setTapFocusHandler(
-      mobileControls && mobileTapTarget === "command-input" ? focusMobileCommandInput : null,
+      !mobileControls
+        ? null
+        : mobileTapTarget === "command-input"
+          ? focusMobileCommandInput
+          : focusTerminalKeyboardInput,
     );
-  }, [focusMobileCommandInput, mobileControls, mobileTapTarget]);
+  }, [focusMobileCommandInput, focusTerminalKeyboardInput, mobileControls, mobileTapTarget]);
 
   useEffect(() => {
     return () => {

--- a/web/src/mobileTerminalPrefs.test.ts
+++ b/web/src/mobileTerminalPrefs.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
+  parseMobileTerminalTapTarget,
+} from "./mobileTerminalPrefs";
+
+describe("mobile terminal preferences", () => {
+  it("parses supported tap targets", () => {
+    expect(parseMobileTerminalTapTarget("command-input")).toBe("command-input");
+    expect(parseMobileTerminalTapTarget("terminal")).toBe("terminal");
+  });
+
+  it("falls back for unknown tap targets", () => {
+    expect(parseMobileTerminalTapTarget("native-input")).toBe(
+      DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
+    );
+    expect(parseMobileTerminalTapTarget(null)).toBe(DEFAULT_MOBILE_TERMINAL_TAP_TARGET);
+  });
+});

--- a/web/src/mobileTerminalPrefs.ts
+++ b/web/src/mobileTerminalPrefs.ts
@@ -1,0 +1,9 @@
+export type MobileTerminalTapTarget = "command-input" | "terminal";
+
+export const DEFAULT_MOBILE_TERMINAL_TAP_TARGET: MobileTerminalTapTarget = "command-input";
+
+export function parseMobileTerminalTapTarget(value: unknown): MobileTerminalTapTarget {
+  return value === "terminal" || value === "command-input"
+    ? value
+    : DEFAULT_MOBILE_TERMINAL_TAP_TARGET;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1539,6 +1539,7 @@ button {
 
 .segmented-control {
   display: inline-flex;
+  width: 100%;
   min-width: 0;
   padding: 3px;
   border: 1px solid var(--line);
@@ -1549,6 +1550,7 @@ button {
 .segmented-control button {
   min-width: 0;
   height: 28px;
+  flex: 1 1 0;
   padding: 0 10px;
   border: 0;
   border-radius: calc(var(--r-sm) - 2px);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1146,6 +1146,11 @@ button {
   color: var(--blue);
 }
 
+.term-stage-command {
+  background: var(--surface0);
+  color: var(--subtext1);
+}
+
 /* --------------------------------------------------------- split grid */
 
 .pane-grid {
@@ -1507,6 +1512,58 @@ button {
   color: var(--peach);
 }
 
+.settings-section {
+  display: grid;
+  gap: 8px;
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.settings-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--overlay1);
+  text-transform: uppercase;
+}
+
+.settings-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  color: var(--subtext0);
+  font-size: 12.5px;
+}
+
+.segmented-control {
+  display: inline-flex;
+  min-width: 0;
+  padding: 3px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--crust);
+}
+
+.segmented-control button {
+  min-width: 0;
+  height: 28px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: calc(var(--r-sm) - 2px);
+  color: var(--overlay1);
+  background: transparent;
+  font-size: 12px;
+  font-weight: 550;
+  white-space: nowrap;
+}
+
+.segmented-control button[data-on="true"] {
+  color: var(--text);
+  background: var(--surface1);
+}
+
 .field-label {
   display: grid;
   gap: 6px;
@@ -1730,6 +1787,10 @@ button {
 
   .backend-list {
     max-height: 190px;
+  }
+
+  .settings-row {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -1,4 +1,6 @@
 import { FitAddon, init, Terminal } from "ghostty-web";
+import { terminalTapFocusAction } from "./terminalTapFocus";
+import type { TerminalTapFocusResult } from "./terminalTapFocus";
 
 const TERMINAL_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace';
@@ -16,7 +18,7 @@ export type TerminalRenderer = {
   write(data: string | Uint8Array): void;
   onInput(callback: (data: string) => void): () => void;
   onScroll(callback: (lines: number) => void): () => void;
-  setTapFocusHandler(callback: (() => boolean | "terminal") | null): void;
+  setTapFocusHandler(callback: (() => TerminalTapFocusResult) | null): void;
   fit(): TerminalSize;
   refreshMetrics(): TerminalSize;
   focus(): void;
@@ -33,7 +35,7 @@ export class GhosttyRenderer implements TerminalRenderer {
   #scrollCallback: ((lines: number) => void) | null = null;
   #touchCleanup: (() => void) | null = null;
   #mobileInputCleanup: (() => void) | null = null;
-  #tapFocusHandler: (() => boolean | "terminal") | null = null;
+  #tapFocusHandler: (() => TerminalTapFocusResult) | null = null;
   #textInputTapGraceUntil = 0;
 
   async mount(container: HTMLElement) {
@@ -115,7 +117,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     };
   }
 
-  setTapFocusHandler(callback: (() => boolean | "terminal") | null) {
+  setTapFocusHandler(callback: (() => TerminalTapFocusResult) | null) {
     this.#tapFocusHandler = callback;
   }
 
@@ -211,14 +213,12 @@ export class GhosttyRenderer implements TerminalRenderer {
     let touchScrolled = false;
     let pendingTouchLines = 0;
     const redirectTapFocus = (event: TouchEvent | MouseEvent) => {
-      if (
+      const terminalHadFocusOrGrace =
         document.activeElement === terminal.textarea ||
-        performance.now() < this.#textInputTapGraceUntil
-      ) {
-        return false;
-      }
+        performance.now() < this.#textInputTapGraceUntil;
       const tapFocusResult = this.#tapFocusHandler?.();
-      if (!tapFocusResult) {
+      const action = terminalTapFocusAction(tapFocusResult, terminalHadFocusOrGrace);
+      if (action === "ignore") {
         return false;
       }
       event.preventDefault();
@@ -226,7 +226,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       if (typeof event.stopImmediatePropagation === "function") {
         event.stopImmediatePropagation();
       }
-      if (tapFocusResult !== "terminal") {
+      if (action === "redirect") {
         terminal.textarea?.blur();
       }
       return true;

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -16,7 +16,7 @@ export type TerminalRenderer = {
   write(data: string | Uint8Array): void;
   onInput(callback: (data: string) => void): () => void;
   onScroll(callback: (lines: number) => void): () => void;
-  setTapFocusHandler(callback: (() => boolean) | null): void;
+  setTapFocusHandler(callback: (() => boolean | "terminal") | null): void;
   fit(): TerminalSize;
   refreshMetrics(): TerminalSize;
   focus(): void;
@@ -33,7 +33,7 @@ export class GhosttyRenderer implements TerminalRenderer {
   #scrollCallback: ((lines: number) => void) | null = null;
   #touchCleanup: (() => void) | null = null;
   #mobileInputCleanup: (() => void) | null = null;
-  #tapFocusHandler: (() => boolean) | null = null;
+  #tapFocusHandler: (() => boolean | "terminal") | null = null;
   #textInputTapGraceUntil = 0;
 
   async mount(container: HTMLElement) {
@@ -115,7 +115,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     };
   }
 
-  setTapFocusHandler(callback: (() => boolean) | null) {
+  setTapFocusHandler(callback: (() => boolean | "terminal") | null) {
     this.#tapFocusHandler = callback;
   }
 
@@ -217,7 +217,8 @@ export class GhosttyRenderer implements TerminalRenderer {
       ) {
         return false;
       }
-      if (!this.#tapFocusHandler?.()) {
+      const tapFocusResult = this.#tapFocusHandler?.();
+      if (!tapFocusResult) {
         return false;
       }
       event.preventDefault();
@@ -225,7 +226,9 @@ export class GhosttyRenderer implements TerminalRenderer {
       if (typeof event.stopImmediatePropagation === "function") {
         event.stopImmediatePropagation();
       }
-      terminal.textarea?.blur();
+      if (tapFocusResult !== "terminal") {
+        terminal.textarea?.blur();
+      }
       return true;
     };
     const onTouchStart = (event: TouchEvent) => {

--- a/web/src/terminalTapFocus.test.ts
+++ b/web/src/terminalTapFocus.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { terminalTapFocusAction } from "./terminalTapFocus";
+
+describe("terminal tap focus action", () => {
+  it("ignores missing or false tap handlers", () => {
+    expect(terminalTapFocusAction(undefined, false)).toBe("ignore");
+    expect(terminalTapFocusAction(false, false)).toBe("ignore");
+  });
+
+  it("redirects command-input taps even when terminal focus is active", () => {
+    expect(terminalTapFocusAction(true, false)).toBe("redirect");
+    expect(terminalTapFocusAction(true, true)).toBe("redirect");
+  });
+
+  it("keeps terminal taps on the terminal path without repeatedly intercepting grace taps", () => {
+    expect(terminalTapFocusAction("terminal", false)).toBe("terminal");
+    expect(terminalTapFocusAction("terminal", true)).toBe("ignore");
+  });
+});

--- a/web/src/terminalTapFocus.ts
+++ b/web/src/terminalTapFocus.ts
@@ -1,0 +1,15 @@
+export type TerminalTapFocusResult = boolean | "terminal";
+export type TerminalTapFocusAction = "ignore" | "redirect" | "terminal";
+
+export function terminalTapFocusAction(
+  result: TerminalTapFocusResult | undefined,
+  terminalHadFocusOrGrace: boolean,
+): TerminalTapFocusAction {
+  if (!result) {
+    return "ignore";
+  }
+  if (result === "terminal" && terminalHadFocusOrGrace) {
+    return "ignore";
+  }
+  return result === "terminal" ? "terminal" : "redirect";
+}


### PR DESCRIPTION
## Summary
- add mobile terminal tap-focus preference in settings
- add separate stage/send mobile text input actions
- hide the mobile-only tap setting on desktop and tighten mobile settings layout
- rename the visible setting option to Text input

## Verification
- npm run check
- npm run android:build:debug
- local tmux bridge redeployed on port 4000