### PR TITLE
Improve terminal input settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 /dist-packages/
 .specs/
 *.log
+*.swp
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@
   status updates reach connected browsers without waiting for a full snapshot refresh; concepts
   derived from the @roy-levi-amazon fork. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
 - Added configurable terminal input transport, with binary payload concepts derived from the
-  @roy-levi-amazon fork.
+  @roy-levi-amazon fork. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
 - Added opt-in terminal input batching controls with a fixed 32-byte flush threshold for slow
-  connections.
+  connections. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
 - Added a Shift-Tab key to the expanded mobile terminal key panel. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
 
 ### Changed
 
 - Reworked Settings into Bridge, Terminal, and Mobile areas, with horizontal area tabs on narrow
-  screens.
+  screens. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
 - Improved browser startup by lazy-loading the terminal renderer with retry after load failures,
   adding installable mobile web app metadata and raster icons, and compressing static
   bridge-served web assets; concepts derived from the @roy-levi-amazon fork.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
 - Added a bridge-owned agent activity stream so pane status, title, display agent, and custom
   status updates reach connected browsers without waiting for a full snapshot refresh; concepts
   derived from the @roy-levi-amazon fork. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
-- Added configurable terminal input transport and opt-in input batching controls with a fixed
-  32-byte flush threshold for slow connections.
+- Added configurable terminal input transport, with binary payload concepts derived from the
+  @roy-levi-amazon fork.
+- Added opt-in terminal input batching controls with a fixed 32-byte flush threshold for slow
+  connections.
 - Added a Shift-Tab key to the expanded mobile terminal key panel. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@
 - Added a bridge-owned agent activity stream so pane status, title, display agent, and custom
   status updates reach connected browsers without waiting for a full snapshot refresh; concepts
   derived from the @roy-levi-amazon fork. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
+- Added configurable terminal input transport and opt-in input batching controls with a fixed
+  32-byte flush threshold for slow connections.
 - Added a Shift-Tab key to the expanded mobile terminal key panel. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
 
 ### Changed
 
+- Reworked Settings into Bridge, Terminal, and Mobile areas, with horizontal area tabs on narrow
+  screens.
 - Improved browser startup by lazy-loading the terminal renderer with retry after load failures,
   adding installable mobile web app metadata and raster icons, and compressing static
   bridge-served web assets; concepts derived from the @roy-levi-amazon fork.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ http://127.0.0.1:8787
 The desktop tarball includes the web assets and `herdr-web-bridge`; it does not include Herdr.
 Start or attach Herdr separately before running the bridge.
 
-For Android, install the APK from the same release and add the bridge URL in Bridges settings. LAN
-bridges must allow Android's app origin:
+For Android, install the APK from the same release and add the bridge URL in the Bridge area of
+Settings. LAN bridges must allow Android's app origin:
 
 ```bash
 bin/herdr-web --host 0.0.0.0 --port 4000 --allow-origin http://localhost
@@ -135,9 +135,22 @@ scripts/check-vendor.sh
 ```
 
 The Android app is a Capacitor shell around the bundled `web/dist` assets. It starts disconnected
-and uses the same Bridges settings UI to save one or more Herdr bridge URLs. Browser-served builds
+and uses the Bridge area in Settings to save one or more Herdr bridge URLs. Browser-served builds
 still default to the same-origin bridge that served the page. See [docs/android.md](docs/android.md)
 for HTTP/cleartext behavior, Android SDK setup, and APK verification notes.
+
+## Settings
+
+Settings are grouped by area:
+
+- Bridge: same-origin or saved bridge profiles, reachability testing, and the active backend.
+- Terminal: browser-to-bridge terminal input transport and input batching delay.
+- Mobile: touch-specific terminal behavior when running on a coarse pointer device.
+
+Terminal input payloads can be sent as JSON or binary WebSocket frames. JSON remains the default;
+binary is available for comparing terminal input performance. Terminal input batching is off by
+default. When enabled, short input chunks are coalesced for `32`, `64`, `128`, or `256` ms and are
+flushed early once the pending UTF-8 input reaches 32 bytes, so paste-like input bypasses the delay.
 
 ## Run Locally
 
@@ -219,6 +232,7 @@ The bridge exposes:
 - `POST /api/command`: allow-listed workspace/tab/pane commands
 - `POST /api/selection`: bridge-owned selected pane for syncing browser clients
 - `POST /api/uploads`: save uploaded files into the configured upload directory
+- `GET /ws/activity`: bridge-owned pane activity deltas
 - `GET /ws/events`: Herdr structural events
 - `GET /ws/ui-events`: bridge-local UI events such as selection changes
 - `GET /ws/terminal`: terminal attach stream

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use axum::body::Bytes;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
@@ -50,9 +50,6 @@ const DEFAULT_STATIC_DIR: &str = "web/dist";
 const MIN_TERMINAL_ATTACH_PROTOCOL: u32 = 13;
 const MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
 const MAX_TERMINAL_INPUT_CHUNK_BYTES: usize = 768 * 1024;
-const TERMINAL_IO_DIAGNOSTIC_MIN_INPUT_BYTES: usize = 64 * 1024;
-const TERMINAL_IO_DIAGNOSTIC_WINDOW: Duration = Duration::from_secs(30);
-const TERMINAL_IO_DIAGNOSTIC_REPORT_INTERVAL: Duration = Duration::from_secs(1);
 const DAEMON_STATUS_TIMEOUT: Duration = Duration::from_secs(5);
 const ACTIVITY_WATCHER_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const ACTIVITY_WATCHER_MAX_BACKOFF: Duration = Duration::from_secs(30);
@@ -1684,7 +1681,6 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
 
     let write_tx = session.write_tx.clone();
     let mut terminal_rx = session.output_tx.subscribe();
-    let mut output_diagnostic: Option<TerminalOutputDiagnostic> = None;
     let _ = write_tx.send(ClientMessage::Resize {
         cols,
         rows,
@@ -1698,16 +1694,9 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
                 match output {
                     Ok(output) => match output {
                     TerminalOutput::Bytes(bytes) => {
-                        let bytes_len = bytes.len();
-                        let send_started = Instant::now();
                         if ws_sender.send(Message::Binary(bytes.into())).await.is_err() {
                             break;
                         }
-                        record_terminal_output_diagnostic(
-                            &mut output_diagnostic,
-                            bytes_len,
-                            send_started.elapsed(),
-                        );
                     }
                     TerminalOutput::Close(reason) => {
                         let _ = ws_sender.send(Message::Text(close_message(&reason).into())).await;
@@ -1721,43 +1710,13 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
             Some(message) = ws_receiver.next() => {
                 match message {
                     Ok(Message::Text(text)) => {
-                        match handle_terminal_text_frame(&write_tx, text.as_str()) {
-                            Ok(Some(input)) => {
-                                start_terminal_output_diagnostic(&mut output_diagnostic, input);
-                            }
-                            Ok(None) => {}
-                            Err(_) => break,
+                        if handle_terminal_text_frame(&write_tx, text.as_str()).is_err() {
+                            break;
                         }
                     }
                     Ok(Message::Binary(bytes)) => {
-                        let started = Instant::now();
-                        let bytes_len = bytes.len();
-                        let send_result = send_terminal_input_chunks(&write_tx, &bytes);
-                        let forward_duration_us = started.elapsed().as_micros();
-                        info!(
-                            bytes = bytes_len,
-                            chunks = send_result
-                                .as_ref()
-                                .map(|stats| stats.chunks)
-                                .unwrap_or_default(),
-                            max_chunk_bytes = send_result
-                                .as_ref()
-                                .map(|stats| stats.max_chunk_bytes)
-                                .unwrap_or_default(),
-                            forward_duration_us,
-                            forwarded = send_result.is_ok(),
-                            "terminal binary input frame received"
-                        );
-                        match send_result {
-                            Ok(stats) => start_terminal_output_diagnostic(
-                                &mut output_diagnostic,
-                                TerminalInputForwardStats {
-                                    bytes: bytes_len,
-                                    chunks: stats.chunks,
-                                    max_chunk_bytes: stats.max_chunk_bytes,
-                                },
-                            ),
-                            Err(_) => break,
+                        if send_terminal_input_chunks(&write_tx, &bytes).is_err() {
+                            break;
                         }
                     }
                     Ok(Message::Close(_)) => break,
@@ -2171,126 +2130,6 @@ struct TerminalInputChunkStats {
     max_chunk_bytes: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct TerminalInputForwardStats {
-    bytes: usize,
-    chunks: usize,
-    max_chunk_bytes: usize,
-}
-
-#[derive(Debug)]
-struct TerminalOutputDiagnostic {
-    started_at: Instant,
-    report_at: Instant,
-    input: TerminalInputForwardStats,
-    output_frames: usize,
-    output_bytes: usize,
-    max_frame_bytes: usize,
-    total_send_duration_us: u128,
-    max_send_duration_us: u128,
-    first_output_us: Option<u128>,
-}
-
-fn start_terminal_output_diagnostic(
-    diagnostic: &mut Option<TerminalOutputDiagnostic>,
-    input: TerminalInputForwardStats,
-) {
-    if input.bytes < TERMINAL_IO_DIAGNOSTIC_MIN_INPUT_BYTES {
-        return;
-    }
-    let now = Instant::now();
-    *diagnostic = Some(TerminalOutputDiagnostic {
-        started_at: now,
-        report_at: now + TERMINAL_IO_DIAGNOSTIC_REPORT_INTERVAL,
-        input,
-        output_frames: 0,
-        output_bytes: 0,
-        max_frame_bytes: 0,
-        total_send_duration_us: 0,
-        max_send_duration_us: 0,
-        first_output_us: None,
-    });
-    info!(
-        input_bytes = input.bytes,
-        input_chunks = input.chunks,
-        max_chunk_bytes = input.max_chunk_bytes,
-        window_ms = TERMINAL_IO_DIAGNOSTIC_WINDOW.as_millis(),
-        "terminal output diagnostic started"
-    );
-}
-
-fn record_terminal_output_diagnostic(
-    diagnostic: &mut Option<TerminalOutputDiagnostic>,
-    bytes: usize,
-    send_duration: Duration,
-) {
-    let Some(active) = diagnostic.as_mut() else {
-        return;
-    };
-    let now = Instant::now();
-    if now.duration_since(active.started_at) > TERMINAL_IO_DIAGNOSTIC_WINDOW {
-        finish_terminal_output_diagnostic(diagnostic, now);
-        return;
-    }
-
-    active.output_frames += 1;
-    active.output_bytes += bytes;
-    active.max_frame_bytes = active.max_frame_bytes.max(bytes);
-    let send_duration_us = send_duration.as_micros();
-    active.total_send_duration_us += send_duration_us;
-    active.max_send_duration_us = active.max_send_duration_us.max(send_duration_us);
-
-    if active.first_output_us.is_none() {
-        let first_output_us = now.duration_since(active.started_at).as_micros();
-        active.first_output_us = Some(first_output_us);
-        info!(
-            input_bytes = active.input.bytes,
-            input_chunks = active.input.chunks,
-            first_output_us,
-            frame_bytes = bytes,
-            send_duration_us,
-            "terminal first output after input"
-        );
-    }
-
-    if now >= active.report_at {
-        active.report_at = now + TERMINAL_IO_DIAGNOSTIC_REPORT_INTERVAL;
-        info!(
-            input_bytes = active.input.bytes,
-            input_chunks = active.input.chunks,
-            output_frames = active.output_frames,
-            output_bytes = active.output_bytes,
-            max_frame_bytes = active.max_frame_bytes,
-            total_send_duration_us = active.total_send_duration_us,
-            max_send_duration_us = active.max_send_duration_us,
-            first_output_us = active.first_output_us.unwrap_or_default(),
-            elapsed_ms = now.duration_since(active.started_at).as_millis(),
-            "terminal output diagnostic"
-        );
-    }
-}
-
-fn finish_terminal_output_diagnostic(
-    diagnostic: &mut Option<TerminalOutputDiagnostic>,
-    now: Instant,
-) {
-    let Some(active) = diagnostic.take() else {
-        return;
-    };
-    info!(
-        input_bytes = active.input.bytes,
-        input_chunks = active.input.chunks,
-        output_frames = active.output_frames,
-        output_bytes = active.output_bytes,
-        max_frame_bytes = active.max_frame_bytes,
-        total_send_duration_us = active.total_send_duration_us,
-        max_send_duration_us = active.max_send_duration_us,
-        first_output_us = active.first_output_us.unwrap_or_default(),
-        elapsed_ms = now.duration_since(active.started_at).as_millis(),
-        "terminal output diagnostic finished"
-    );
-}
-
 fn send_terminal_input_chunks(
     write_tx: &mpsc::Sender<ClientMessage>,
     data: &[u8],
@@ -2324,43 +2163,12 @@ fn send_terminal_input_chunks(
 fn handle_terminal_text_frame(
     write_tx: &mpsc::Sender<ClientMessage>,
     text: &str,
-) -> Result<Option<TerminalInputForwardStats>, String> {
-    let parse_started = Instant::now();
+) -> Result<(), String> {
     let frame = parse_terminal_client_frame(text)?;
-    let parse_duration_us = parse_started.elapsed().as_micros();
     match frame {
         TerminalClientFrame::Input { data } => {
-            let chars = data.chars().count();
-            let bytes = data.len();
-            let forward_started = Instant::now();
-            let send_result = send_terminal_input_chunks(write_tx, data.as_bytes());
-            let forward_duration_us = forward_started.elapsed().as_micros();
-            let total_duration_us = parse_started.elapsed().as_micros();
-            info!(
-                chars,
-                bytes,
-                text_frame_bytes = text.len(),
-                chunks = send_result
-                    .as_ref()
-                    .map(|stats| stats.chunks)
-                    .unwrap_or_default(),
-                max_chunk_bytes = send_result
-                    .as_ref()
-                    .map(|stats| stats.max_chunk_bytes)
-                    .unwrap_or_default(),
-                parse_duration_us,
-                forward_duration_us,
-                total_duration_us,
-                forwarded = send_result.is_ok(),
-                "terminal text input frame received"
-            );
-            send_result.map(|stats| {
-                Some(TerminalInputForwardStats {
-                    bytes,
-                    chunks: stats.chunks,
-                    max_chunk_bytes: stats.max_chunk_bytes,
-                })
-            })
+            send_terminal_input_chunks(write_tx, data.as_bytes())?;
+            Ok(())
         }
         TerminalClientFrame::Resize {
             cols,
@@ -2374,7 +2182,7 @@ fn handle_terminal_text_frame(
                 cell_width_px,
                 cell_height_px,
             })
-            .map(|_| None)
+            .map(|_| ())
             .map_err(|_| "terminal writer closed".to_string()),
         TerminalClientFrame::Scroll { direction, lines } => write_tx
             .send(ClientMessage::AttachScroll {
@@ -2388,7 +2196,7 @@ fn handle_terminal_text_frame(
                 row: None,
                 modifiers: 0,
             })
-            .map(|_| None)
+            .map(|_| ())
             .map_err(|_| "terminal writer closed".to_string()),
     }
 }

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::body::Bytes;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
@@ -49,6 +49,10 @@ const DEFAULT_ROWS: u16 = 24;
 const DEFAULT_STATIC_DIR: &str = "web/dist";
 const MIN_TERMINAL_ATTACH_PROTOCOL: u32 = 13;
 const MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
+const MAX_TERMINAL_INPUT_CHUNK_BYTES: usize = 768 * 1024;
+const TERMINAL_IO_DIAGNOSTIC_MIN_INPUT_BYTES: usize = 64 * 1024;
+const TERMINAL_IO_DIAGNOSTIC_WINDOW: Duration = Duration::from_secs(30);
+const TERMINAL_IO_DIAGNOSTIC_REPORT_INTERVAL: Duration = Duration::from_secs(1);
 const DAEMON_STATUS_TIMEOUT: Duration = Duration::from_secs(5);
 const ACTIVITY_WATCHER_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const ACTIVITY_WATCHER_MAX_BACKOFF: Duration = Duration::from_secs(30);
@@ -1680,6 +1684,7 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
 
     let write_tx = session.write_tx.clone();
     let mut terminal_rx = session.output_tx.subscribe();
+    let mut output_diagnostic: Option<TerminalOutputDiagnostic> = None;
     let _ = write_tx.send(ClientMessage::Resize {
         cols,
         rows,
@@ -1693,9 +1698,16 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
                 match output {
                     Ok(output) => match output {
                     TerminalOutput::Bytes(bytes) => {
+                        let bytes_len = bytes.len();
+                        let send_started = Instant::now();
                         if ws_sender.send(Message::Binary(bytes.into())).await.is_err() {
                             break;
                         }
+                        record_terminal_output_diagnostic(
+                            &mut output_diagnostic,
+                            bytes_len,
+                            send_started.elapsed(),
+                        );
                     }
                     TerminalOutput::Close(reason) => {
                         let _ = ws_sender.send(Message::Text(close_message(&reason).into())).await;
@@ -1709,12 +1721,44 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
             Some(message) = ws_receiver.next() => {
                 match message {
                     Ok(Message::Text(text)) => {
-                        if handle_terminal_text_frame(&write_tx, text.as_str()).is_err() {
-                            break;
+                        match handle_terminal_text_frame(&write_tx, text.as_str()) {
+                            Ok(Some(input)) => {
+                                start_terminal_output_diagnostic(&mut output_diagnostic, input);
+                            }
+                            Ok(None) => {}
+                            Err(_) => break,
                         }
                     }
                     Ok(Message::Binary(bytes)) => {
-                        let _ = write_tx.send(ClientMessage::Input { data: bytes.to_vec() });
+                        let started = Instant::now();
+                        let bytes_len = bytes.len();
+                        let send_result = send_terminal_input_chunks(&write_tx, &bytes);
+                        let forward_duration_us = started.elapsed().as_micros();
+                        info!(
+                            bytes = bytes_len,
+                            chunks = send_result
+                                .as_ref()
+                                .map(|stats| stats.chunks)
+                                .unwrap_or_default(),
+                            max_chunk_bytes = send_result
+                                .as_ref()
+                                .map(|stats| stats.max_chunk_bytes)
+                                .unwrap_or_default(),
+                            forward_duration_us,
+                            forwarded = send_result.is_ok(),
+                            "terminal binary input frame received"
+                        );
+                        match send_result {
+                            Ok(stats) => start_terminal_output_diagnostic(
+                                &mut output_diagnostic,
+                                TerminalInputForwardStats {
+                                    bytes: bytes_len,
+                                    chunks: stats.chunks,
+                                    max_chunk_bytes: stats.max_chunk_bytes,
+                                },
+                            ),
+                            Err(_) => break,
+                        }
                     }
                     Ok(Message::Close(_)) => break,
                     Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {}
@@ -2121,16 +2165,203 @@ fn open_event_subscription(
     Ok(event_rx)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TerminalInputChunkStats {
+    chunks: usize,
+    max_chunk_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TerminalInputForwardStats {
+    bytes: usize,
+    chunks: usize,
+    max_chunk_bytes: usize,
+}
+
+#[derive(Debug)]
+struct TerminalOutputDiagnostic {
+    started_at: Instant,
+    report_at: Instant,
+    input: TerminalInputForwardStats,
+    output_frames: usize,
+    output_bytes: usize,
+    max_frame_bytes: usize,
+    total_send_duration_us: u128,
+    max_send_duration_us: u128,
+    first_output_us: Option<u128>,
+}
+
+fn start_terminal_output_diagnostic(
+    diagnostic: &mut Option<TerminalOutputDiagnostic>,
+    input: TerminalInputForwardStats,
+) {
+    if input.bytes < TERMINAL_IO_DIAGNOSTIC_MIN_INPUT_BYTES {
+        return;
+    }
+    let now = Instant::now();
+    *diagnostic = Some(TerminalOutputDiagnostic {
+        started_at: now,
+        report_at: now + TERMINAL_IO_DIAGNOSTIC_REPORT_INTERVAL,
+        input,
+        output_frames: 0,
+        output_bytes: 0,
+        max_frame_bytes: 0,
+        total_send_duration_us: 0,
+        max_send_duration_us: 0,
+        first_output_us: None,
+    });
+    info!(
+        input_bytes = input.bytes,
+        input_chunks = input.chunks,
+        max_chunk_bytes = input.max_chunk_bytes,
+        window_ms = TERMINAL_IO_DIAGNOSTIC_WINDOW.as_millis(),
+        "terminal output diagnostic started"
+    );
+}
+
+fn record_terminal_output_diagnostic(
+    diagnostic: &mut Option<TerminalOutputDiagnostic>,
+    bytes: usize,
+    send_duration: Duration,
+) {
+    let Some(active) = diagnostic.as_mut() else {
+        return;
+    };
+    let now = Instant::now();
+    if now.duration_since(active.started_at) > TERMINAL_IO_DIAGNOSTIC_WINDOW {
+        finish_terminal_output_diagnostic(diagnostic, now);
+        return;
+    }
+
+    active.output_frames += 1;
+    active.output_bytes += bytes;
+    active.max_frame_bytes = active.max_frame_bytes.max(bytes);
+    let send_duration_us = send_duration.as_micros();
+    active.total_send_duration_us += send_duration_us;
+    active.max_send_duration_us = active.max_send_duration_us.max(send_duration_us);
+
+    if active.first_output_us.is_none() {
+        let first_output_us = now.duration_since(active.started_at).as_micros();
+        active.first_output_us = Some(first_output_us);
+        info!(
+            input_bytes = active.input.bytes,
+            input_chunks = active.input.chunks,
+            first_output_us,
+            frame_bytes = bytes,
+            send_duration_us,
+            "terminal first output after input"
+        );
+    }
+
+    if now >= active.report_at {
+        active.report_at = now + TERMINAL_IO_DIAGNOSTIC_REPORT_INTERVAL;
+        info!(
+            input_bytes = active.input.bytes,
+            input_chunks = active.input.chunks,
+            output_frames = active.output_frames,
+            output_bytes = active.output_bytes,
+            max_frame_bytes = active.max_frame_bytes,
+            total_send_duration_us = active.total_send_duration_us,
+            max_send_duration_us = active.max_send_duration_us,
+            first_output_us = active.first_output_us.unwrap_or_default(),
+            elapsed_ms = now.duration_since(active.started_at).as_millis(),
+            "terminal output diagnostic"
+        );
+    }
+}
+
+fn finish_terminal_output_diagnostic(
+    diagnostic: &mut Option<TerminalOutputDiagnostic>,
+    now: Instant,
+) {
+    let Some(active) = diagnostic.take() else {
+        return;
+    };
+    info!(
+        input_bytes = active.input.bytes,
+        input_chunks = active.input.chunks,
+        output_frames = active.output_frames,
+        output_bytes = active.output_bytes,
+        max_frame_bytes = active.max_frame_bytes,
+        total_send_duration_us = active.total_send_duration_us,
+        max_send_duration_us = active.max_send_duration_us,
+        first_output_us = active.first_output_us.unwrap_or_default(),
+        elapsed_ms = now.duration_since(active.started_at).as_millis(),
+        "terminal output diagnostic finished"
+    );
+}
+
+fn send_terminal_input_chunks(
+    write_tx: &mpsc::Sender<ClientMessage>,
+    data: &[u8],
+) -> Result<TerminalInputChunkStats, String> {
+    if data.is_empty() {
+        write_tx
+            .send(ClientMessage::Input { data: Vec::new() })
+            .map_err(|_| "terminal writer closed".to_string())?;
+        return Ok(TerminalInputChunkStats {
+            chunks: 1,
+            max_chunk_bytes: 0,
+        });
+    }
+
+    let mut stats = TerminalInputChunkStats {
+        chunks: 0,
+        max_chunk_bytes: 0,
+    };
+    for chunk in data.chunks(MAX_TERMINAL_INPUT_CHUNK_BYTES) {
+        stats.chunks += 1;
+        stats.max_chunk_bytes = stats.max_chunk_bytes.max(chunk.len());
+        write_tx
+            .send(ClientMessage::Input {
+                data: chunk.to_vec(),
+            })
+            .map_err(|_| "terminal writer closed".to_string())?;
+    }
+    Ok(stats)
+}
+
 fn handle_terminal_text_frame(
     write_tx: &mpsc::Sender<ClientMessage>,
     text: &str,
-) -> Result<(), String> {
-    match parse_terminal_client_frame(text)? {
-        TerminalClientFrame::Input { data } => write_tx
-            .send(ClientMessage::Input {
-                data: data.into_bytes(),
+) -> Result<Option<TerminalInputForwardStats>, String> {
+    let parse_started = Instant::now();
+    let frame = parse_terminal_client_frame(text)?;
+    let parse_duration_us = parse_started.elapsed().as_micros();
+    match frame {
+        TerminalClientFrame::Input { data } => {
+            let chars = data.chars().count();
+            let bytes = data.len();
+            let forward_started = Instant::now();
+            let send_result = send_terminal_input_chunks(write_tx, data.as_bytes());
+            let forward_duration_us = forward_started.elapsed().as_micros();
+            let total_duration_us = parse_started.elapsed().as_micros();
+            info!(
+                chars,
+                bytes,
+                text_frame_bytes = text.len(),
+                chunks = send_result
+                    .as_ref()
+                    .map(|stats| stats.chunks)
+                    .unwrap_or_default(),
+                max_chunk_bytes = send_result
+                    .as_ref()
+                    .map(|stats| stats.max_chunk_bytes)
+                    .unwrap_or_default(),
+                parse_duration_us,
+                forward_duration_us,
+                total_duration_us,
+                forwarded = send_result.is_ok(),
+                "terminal text input frame received"
+            );
+            send_result.map(|stats| {
+                Some(TerminalInputForwardStats {
+                    bytes,
+                    chunks: stats.chunks,
+                    max_chunk_bytes: stats.max_chunk_bytes,
+                })
             })
-            .map_err(|_| "terminal writer closed".to_string()),
+        }
         TerminalClientFrame::Resize {
             cols,
             rows,
@@ -2143,6 +2374,7 @@ fn handle_terminal_text_frame(
                 cell_width_px,
                 cell_height_px,
             })
+            .map(|_| None)
             .map_err(|_| "terminal writer closed".to_string()),
         TerminalClientFrame::Scroll { direction, lines } => write_tx
             .send(ClientMessage::AttachScroll {
@@ -2156,6 +2388,7 @@ fn handle_terminal_text_frame(
                 row: None,
                 modifiers: 0,
             })
+            .map(|_| None)
             .map_err(|_| "terminal writer closed".to_string()),
     }
 }
@@ -2321,6 +2554,53 @@ mod tests {
             TerminalClientFrame::Input {
                 data: "ls\n".to_string()
             }
+        );
+    }
+
+    #[test]
+    fn chunks_terminal_input_below_daemon_limit() {
+        let (tx, rx) = mpsc::channel();
+        let data = vec![b'x'; MAX_TERMINAL_INPUT_CHUNK_BYTES * 2 + 17];
+
+        let stats = send_terminal_input_chunks(&tx, &data).unwrap();
+
+        assert_eq!(
+            stats,
+            TerminalInputChunkStats {
+                chunks: 3,
+                max_chunk_bytes: MAX_TERMINAL_INPUT_CHUNK_BYTES
+            }
+        );
+        let chunks: Vec<Vec<u8>> = rx
+            .try_iter()
+            .map(|message| match message {
+                ClientMessage::Input { data } => data,
+                other => panic!("unexpected terminal message: {other:?}"),
+            })
+            .collect();
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].len(), MAX_TERMINAL_INPUT_CHUNK_BYTES);
+        assert_eq!(chunks[1].len(), MAX_TERMINAL_INPUT_CHUNK_BYTES);
+        assert_eq!(chunks[2].len(), 17);
+        assert_eq!(chunks.concat(), data);
+    }
+
+    #[test]
+    fn forwards_empty_terminal_input_as_one_message() {
+        let (tx, rx) = mpsc::channel();
+
+        let stats = send_terminal_input_chunks(&tx, &[]).unwrap();
+
+        assert_eq!(
+            stats,
+            TerminalInputChunkStats {
+                chunks: 1,
+                max_chunk_bytes: 0
+            }
+        );
+        assert_eq!(
+            rx.recv().unwrap(),
+            ClientMessage::Input { data: Vec::new() }
         );
     }
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -30,7 +30,7 @@ Run `npm run android:sync` before opening or building Android from a fresh check
 
 The browser-served web app still defaults to the bridge that served the page. The bundled Android
 app has no serving bridge origin, so it starts disconnected until the user adds and activates a
-saved bridge in `Bridges` settings.
+saved bridge in the Bridge area of Settings.
 
 Supported backend examples:
 
@@ -83,6 +83,12 @@ store-distributed build, prefer HTTPS bridge URLs and revisit whether cleartext 
 
 Android cloud auto-backup is disabled for the shell, so saved bridge profiles are not copied into
 device backup storage.
+
+## Settings On Android
+
+The Android shell uses the same area-based Settings UI described in the project README. Android
+starts disconnected, so the Bridge area is required for selecting a backend. On narrow screens the
+area selector appears as horizontal tabs. Android-specific touch behavior lives in the Mobile area.
 
 ## Build Prerequisites
 
@@ -175,15 +181,18 @@ On a trusted LAN:
 
 2. Install the debug APK on an Android device.
 3. Open the app and confirm the shell loads without network access.
-4. Open `Bridges` settings.
+4. Open Settings and select the Bridge area.
 5. Add a backend such as `http://192.168.1.20:4000`.
 6. Use `Test` and confirm it reports reachable.
 7. Use `Save & use`.
 8. Confirm snapshot, event updates, terminal attach, text input, stage-only input, uploads, and pane controls work.
-9. Toggle the mobile terminal tap setting and confirm terminal taps can focus either the text input or terminal.
-10. Force-close and reopen the app; confirm the active backend persists.
-11. Test Android back behavior from the mobile sidebar/detail views.
-12. Test an unreachable backend and confirm the app stays usable enough to edit settings.
+9. Open the Terminal area, change input transport and batching delay, and confirm terminal input
+   still works.
+10. Open the Mobile area, toggle the mobile terminal tap setting, and confirm terminal taps can
+    focus either the text input or terminal.
+11. Force-close and reopen the app; confirm the active backend and settings persist.
+12. Test Android back behavior from the mobile sidebar/detail views.
+13. Test an unreachable backend and confirm the app stays usable enough to edit settings.
 
 ## Release Notes
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -131,7 +131,7 @@ bin/herdr-web --host 0.0.0.0 --port 4000 \
   --allow-host herdr-host.local
 ```
 
-Then install the Android APK and add the bridge URL in Bridges settings.
+Then install the Android APK and add the bridge URL in the Bridge area of Settings.
 
 ## Manual Release Upload
 

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -35,6 +35,6 @@ bin/herdr-web --host 0.0.0.0 --port 4000 \
   --allow-host herdr-host.local
 ```
 
-Then add the bridge URL in the Android app's Bridges settings.
+Then add the bridge URL in the Android app's Bridge area of Settings.
 
 Only bind to non-loopback interfaces on networks you trust.

--- a/web/README.md
+++ b/web/README.md
@@ -37,6 +37,7 @@ The app expects these bridge routes:
 - `/api/command`
 - `/api/selection`
 - `/api/uploads`
+- `/ws/activity`
 - `/ws/events`
 - `/ws/ui-events`
 - `/ws/terminal`

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,13 @@ import type { MenuItem } from "./overlays";
 import { createSnapshotRefreshController } from "./refreshCoordinator";
 import { TerminalView } from "./TerminalView";
 import {
+  DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
+  DEFAULT_TERMINAL_INPUT_TRANSPORT,
+  parseTerminalInputBatchDelayMs,
+  parseTerminalInputTransport,
+} from "./terminalInputTransport";
+import type { TerminalInputTransport } from "./terminalInputTransport";
+import {
   aggregateStatus,
   canClearTabName,
   canClearWorkspaceName,
@@ -93,6 +100,8 @@ type DisplayPrefs = {
   sidebarOpen: boolean;
   activeSpaceId: string | null;
   selectedPaneId: string | null;
+  terminalInputTransport: TerminalInputTransport;
+  terminalInputBatchDelayMs: number;
   mobileTerminalTapTarget: MobileTerminalTapTarget;
   mobileTouchSelection: boolean;
   mobileKeyboardHideRefit: boolean;
@@ -116,6 +125,8 @@ function readDisplayPrefs(): DisplayPrefs {
     sidebarOpen: true,
     activeSpaceId: null,
     selectedPaneId: null,
+    terminalInputTransport: DEFAULT_TERMINAL_INPUT_TRANSPORT,
+    terminalInputBatchDelayMs: DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
     mobileTerminalTapTarget: DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
     mobileTouchSelection: DEFAULT_MOBILE_TOUCH_SELECTION,
     mobileKeyboardHideRefit: DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
@@ -152,6 +163,8 @@ function readDisplayPrefs(): DisplayPrefs {
         typeof parsed.activeSpaceId === "string" ? parsed.activeSpaceId : fallback.activeSpaceId,
       selectedPaneId:
         typeof parsed.selectedPaneId === "string" ? parsed.selectedPaneId : fallback.selectedPaneId,
+      terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
+      terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
       mobileTerminalTapTarget: parseMobileTerminalTapTarget(parsed.mobileTerminalTapTarget),
       mobileTouchSelection: parseMobileTouchSelection(parsed.mobileTouchSelection),
       mobileKeyboardHideRefit: parseMobileKeyboardHideRefit(parsed.mobileKeyboardHideRefit),
@@ -236,6 +249,12 @@ export function App() {
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [backendSettingsOpen, setBackendSettingsOpen] = useState(false);
+  const [terminalInputTransport, setTerminalInputTransport] = useState(
+    initialPrefs.terminalInputTransport,
+  );
+  const [terminalInputBatchDelayMs, setTerminalInputBatchDelayMs] = useState(
+    initialPrefs.terminalInputBatchDelayMs,
+  );
   const [mobileTerminalTapTarget, setMobileTerminalTapTarget] = useState(
     initialPrefs.mobileTerminalTapTarget,
   );
@@ -357,6 +376,8 @@ export function App() {
       sidebarOpen,
       activeSpaceId,
       selectedPaneId,
+      terminalInputTransport,
+      terminalInputBatchDelayMs,
       mobileTerminalTapTarget,
       mobileTouchSelection,
       mobileKeyboardHideRefit,
@@ -370,6 +391,8 @@ export function App() {
     sidebarOpen,
     activeSpaceId,
     selectedPaneId,
+    terminalInputTransport,
+    terminalInputBatchDelayMs,
     mobileTerminalTapTarget,
     mobileTouchSelection,
     mobileKeyboardHideRefit,
@@ -1275,6 +1298,8 @@ export function App() {
             touchInput={isTouchInput}
             mobileTapTarget={mobileTerminalTapTarget}
             mobileTouchSelection={mobileTouchSelection}
+            terminalInputTransport={terminalInputTransport}
+            terminalInputBatchDelayMs={terminalInputBatchDelayMs}
             connectionKey={bridge.connectionKey}
             resumeToken={bridge.resumeToken}
             httpUrl={bridge.httpUrl}
@@ -1292,6 +1317,8 @@ export function App() {
             mobileControls={isTouchInput}
             mobileTapTarget={mobileTerminalTapTarget}
             mobileTouchSelection={mobileTouchSelection}
+            terminalInputTransport={terminalInputTransport}
+            terminalInputBatchDelayMs={terminalInputBatchDelayMs}
             refitToken={refitToken}
             focusToken={terminalFocusToken}
           />
@@ -1346,6 +1373,10 @@ export function App() {
       {backendSettingsOpen ? (
         <BackendSettingsDialog
           showMobileTerminalSettings={isTouchInput}
+          terminalInputTransport={terminalInputTransport}
+          onTerminalInputTransport={setTerminalInputTransport}
+          terminalInputBatchDelayMs={terminalInputBatchDelayMs}
+          onTerminalInputBatchDelayMs={setTerminalInputBatchDelayMs}
           mobileTerminalTapTarget={mobileTerminalTapTarget}
           onMobileTerminalTapTarget={setMobileTerminalTapTarget}
           mobileTouchSelection={mobileTouchSelection}
@@ -1510,6 +1541,8 @@ function SplitGrid({
   touchInput,
   mobileTapTarget,
   mobileTouchSelection,
+  terminalInputTransport,
+  terminalInputBatchDelayMs,
   connectionKey,
   resumeToken,
   httpUrl,
@@ -1523,6 +1556,8 @@ function SplitGrid({
   touchInput: boolean;
   mobileTapTarget: MobileTerminalTapTarget;
   mobileTouchSelection: boolean;
+  terminalInputTransport: TerminalInputTransport;
+  terminalInputBatchDelayMs: number;
   connectionKey: string;
   resumeToken: number;
   httpUrl: (path: string, query?: URLSearchParams) => string;
@@ -1551,6 +1586,8 @@ function SplitGrid({
               mobileControls={selected && touchInput}
               mobileTapTarget={mobileTapTarget}
               mobileTouchSelection={mobileTouchSelection}
+              terminalInputTransport={terminalInputTransport}
+              terminalInputBatchDelayMs={terminalInputBatchDelayMs}
               refitToken={selected ? refitToken : 0}
               focusToken={selected ? focusToken : 0}
             />

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { Check, Plus, X } from "lucide-react";
+import { Check, Plus, Server, Smartphone, SquareTerminal, X } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   duplicateBackend,
@@ -7,9 +7,15 @@ import {
 } from "./bridge";
 import type { BridgeBackendProfile } from "./bridge";
 import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
+import { TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS } from "./terminalInputTransport";
+import type { TerminalInputTransport } from "./terminalInputTransport";
 
 type Props = {
   showMobileTerminalSettings: boolean;
+  terminalInputTransport: TerminalInputTransport;
+  onTerminalInputTransport: (transport: TerminalInputTransport) => void;
+  terminalInputBatchDelayMs: number;
+  onTerminalInputBatchDelayMs: (delayMs: number) => void;
   mobileTerminalTapTarget: MobileTerminalTapTarget;
   onMobileTerminalTapTarget: (target: MobileTerminalTapTarget) => void;
   mobileTouchSelection: boolean;
@@ -27,6 +33,7 @@ type FormState = {
 };
 
 type SelectionMode = "same-origin" | "new" | "backend";
+type SettingsArea = "bridge" | "terminal" | "mobile";
 
 const emptyForm: FormState = {
   id: null,
@@ -36,6 +43,10 @@ const emptyForm: FormState = {
 
 export function BackendSettingsDialog({
   showMobileTerminalSettings,
+  terminalInputTransport,
+  onTerminalInputTransport,
+  terminalInputBatchDelayMs,
+  onTerminalInputBatchDelayMs,
   mobileTerminalTapTarget,
   onMobileTerminalTapTarget,
   mobileTouchSelection,
@@ -56,6 +67,7 @@ export function BackendSettingsDialog({
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [duplicate, setDuplicate] = useState<BridgeBackendProfile | null>(null);
+  const [activeArea, setActiveArea] = useState<SettingsArea>("bridge");
 
   const activeBackend = bridge.activeBackend;
   const selectedBackend = useMemo(
@@ -64,12 +76,21 @@ export function BackendSettingsDialog({
   );
 
   useEffect(() => {
+    if (activeArea !== "bridge") {
+      return;
+    }
     if (selectionMode === "same-origin") {
       closeButtonRef.current?.focus();
       return;
     }
     nameInputRef.current?.focus();
-  }, [selectionMode]);
+  }, [activeArea, selectionMode]);
+
+  useEffect(() => {
+    if (activeArea === "mobile" && !showMobileTerminalSettings) {
+      setActiveArea("terminal");
+    }
+  }, [activeArea, showMobileTerminalSettings]);
 
   useEffect(() => {
     if (selectionMode !== "backend" || form.id || bridge.store.backends.length === 0) {
@@ -184,6 +205,13 @@ export function BackendSettingsDialog({
   const editingBackend = selectionMode !== "same-origin";
   const sameOriginUrl = sameOriginDisplayUrl();
   const showSameOrigin = bridge.sameOriginAvailable;
+  const areas: { id: SettingsArea; label: string; icon: typeof Server }[] = [
+    { id: "bridge", label: "Bridge", icon: Server },
+    { id: "terminal", label: "Terminal", icon: SquareTerminal },
+    ...(showMobileTerminalSettings
+      ? [{ id: "mobile" as const, label: "Mobile", icon: Smartphone }]
+      : []),
+  ];
 
   return (
     <div className="overlay-root">
@@ -202,7 +230,7 @@ export function BackendSettingsDialog({
         }}
         onSubmit={(event) => {
           event.preventDefault();
-          if (!editingBackend) {
+          if (activeArea !== "bridge" || !editingBackend) {
             return;
           }
           void saveBackend(true);
@@ -220,96 +248,208 @@ export function BackendSettingsDialog({
         </button>
         <div id={titleId} className="modal-title">Settings</div>
         <div className="backend-layout">
-          <div className="backend-list" role="list" aria-label="Saved bridges">
-            {showSameOrigin ? (
+          <div className="settings-area-list" role="tablist" aria-label="Settings areas">
+            {areas.map(({ id, label, icon: Icon }) => (
               <button
-                className="backend-row"
+                key={id}
+                className="settings-area-tab"
                 type="button"
-                data-active={selectionMode === "same-origin" ? "true" : undefined}
-                onClick={selectSameOrigin}
+                role="tab"
+                data-active={activeArea === id ? "true" : undefined}
+                aria-selected={activeArea === id}
+                onClick={() => setActiveArea(id)}
               >
-                {!bridge.store.activeBackendId ? <Check size={14} /> : <span />}
-                <span>
-                  <strong>Same origin</strong>
-                  <small>{sameOriginUrl}</small>
-                </span>
-              </button>
-            ) : null}
-            {bridge.store.backends.map((backend) => (
-              <button
-                key={backend.id}
-                className="backend-row"
-                type="button"
-                data-active={backend.id === form.id ? "true" : undefined}
-                onClick={() => editBackend(backend)}
-              >
-                {backend.id === bridge.store.activeBackendId ? <Check size={14} /> : <span />}
-                <span>
-                  <strong>{backend.name}</strong>
-                  <small>{backend.baseUrl}</small>
-                </span>
+                <Icon size={15} />
+                <span>{label}</span>
               </button>
             ))}
-            <button
-              className="backend-row"
-              type="button"
-              data-active={selectionMode === "new" ? "true" : undefined}
-              onClick={startNew}
-            >
-              <Plus size={14} />
-              <span>
-                <strong>Add bridge</strong>
-                <small>Save another bridge URL</small>
-              </span>
-            </button>
           </div>
-          <div className="backend-form">
-            {selectionMode === "same-origin" ? (
-              <div className="backend-static">
-                <strong>Same origin</strong>
-                <span>Uses the server that delivered this web app.</span>
-              </div>
-            ) : (
+
+          <div className="settings-panel" role="tabpanel">
+            {activeArea === "bridge" ? (
               <>
-                <label className="field-label">
-                  <span>Display name</span>
-                  <input
-                    ref={nameInputRef}
-                    className="field"
-                    value={form.name}
-                    placeholder="Home workstation"
-                    autoComplete="off"
-                    onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
-                  />
-                </label>
-                <label className="field-label">
-                  <span>Bridge URL</span>
-                  <input
-                    className="field"
-                    value={form.baseUrl}
-                    placeholder="http://192.168.1.20:4000"
-                    autoComplete="off"
-                    spellCheck={false}
-                    onBlur={validateDuplicate}
-                    onChange={(event) =>
-                      setForm((current) => ({ ...current, baseUrl: event.target.value }))
-                    }
-                  />
-                </label>
-                {selectedBackend?.lastConnectedAt ? (
-                  <div className="backend-note">Last used {formatDate(selectedBackend.lastConnectedAt)}</div>
-                ) : null}
+                <div className="bridge-settings-grid">
+                  <div className="backend-list" role="list" aria-label="Saved bridges">
+                    {showSameOrigin ? (
+                      <button
+                        className="backend-row"
+                        type="button"
+                        data-active={selectionMode === "same-origin" ? "true" : undefined}
+                        onClick={selectSameOrigin}
+                      >
+                        {!bridge.store.activeBackendId ? <Check size={14} /> : <span />}
+                        <span>
+                          <strong>Same origin</strong>
+                          <small>{sameOriginUrl}</small>
+                        </span>
+                      </button>
+                    ) : null}
+                    {bridge.store.backends.map((backend) => (
+                      <button
+                        key={backend.id}
+                        className="backend-row"
+                        type="button"
+                        data-active={backend.id === form.id ? "true" : undefined}
+                        onClick={() => editBackend(backend)}
+                      >
+                        {backend.id === bridge.store.activeBackendId ? <Check size={14} /> : <span />}
+                        <span>
+                          <strong>{backend.name}</strong>
+                          <small>{backend.baseUrl}</small>
+                        </span>
+                      </button>
+                    ))}
+                    <button
+                      className="backend-row"
+                      type="button"
+                      data-active={selectionMode === "new" ? "true" : undefined}
+                      onClick={startNew}
+                    >
+                      <Plus size={14} />
+                      <span>
+                        <strong>Add bridge</strong>
+                        <small>Save another bridge URL</small>
+                      </span>
+                    </button>
+                  </div>
+                  <div className="backend-form">
+                    {selectionMode === "same-origin" ? (
+                      <div className="backend-static">
+                        <strong>Same origin</strong>
+                        <span>Uses the server that delivered this web app.</span>
+                      </div>
+                    ) : (
+                      <>
+                        <label className="field-label">
+                          <span>Display name</span>
+                          <input
+                            ref={nameInputRef}
+                            className="field"
+                            value={form.name}
+                            placeholder="Home workstation"
+                            autoComplete="off"
+                            onChange={(event) =>
+                              setForm((current) => ({ ...current, name: event.target.value }))
+                            }
+                          />
+                        </label>
+                        <label className="field-label">
+                          <span>Bridge URL</span>
+                          <input
+                            className="field"
+                            value={form.baseUrl}
+                            placeholder="http://192.168.1.20:4000"
+                            autoComplete="off"
+                            spellCheck={false}
+                            onBlur={validateDuplicate}
+                            onChange={(event) =>
+                              setForm((current) => ({ ...current, baseUrl: event.target.value }))
+                            }
+                          />
+                        </label>
+                        {selectedBackend?.lastConnectedAt ? (
+                          <div className="backend-note">
+                            Last used {formatDate(selectedBackend.lastConnectedAt)}
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                    {selectionMode === "same-origin" && bridge.store.activeBackendId ? (
+                      <div className="backend-note">
+                        Use switches back from the active saved bridge.
+                      </div>
+                    ) : null}
+                    {duplicate ? (
+                      <div className="backend-warning">
+                        This URL is already saved as {duplicate.name}.
+                      </div>
+                    ) : null}
+                    {message ? <div className="modal-message">{message}</div> : null}
+                  </div>
+                </div>
+                <div className="modal-actions">
+                  {canDelete ? (
+                    <button type="button" className="btn btn-danger" disabled={busy} onClick={deleteBackend}>
+                      Delete
+                    </button>
+                  ) : null}
+                  {selectionMode === "same-origin" && bridge.store.activeBackendId ? (
+                    <button type="button" className="btn btn-primary" onClick={useSameOrigin}>
+                      Use
+                    </button>
+                  ) : null}
+                  {editingBackend ? (
+                    <>
+                      <button
+                        type="button"
+                        className="btn"
+                        disabled={busy || !form.baseUrl.trim()}
+                        onClick={testBackend}
+                      >
+                        Test
+                      </button>
+                      <button
+                        type="button"
+                        className="btn"
+                        disabled={busy || !form.baseUrl.trim()}
+                        onClick={() => void saveBackend(false)}
+                      >
+                        Save
+                      </button>
+                      <button type="submit" className="btn btn-primary" disabled={busy || !form.baseUrl.trim()}>
+                        Save & use
+                      </button>
+                    </>
+                  ) : null}
+                </div>
               </>
-            )}
-            {selectionMode === "same-origin" && bridge.store.activeBackendId ? (
-              <div className="backend-note">Use switches back from the active saved bridge.</div>
             ) : null}
-            {duplicate ? (
-              <div className="backend-warning">This URL is already saved as {duplicate.name}.</div>
+
+            {activeArea === "terminal" ? (
+              <div className="settings-section settings-section-flat">
+                <div className="settings-label">Terminal transport</div>
+                <div className="settings-row">
+                  <span>Input payloads</span>
+                  <div className="segmented-control" role="group" aria-label="Terminal input payloads">
+                    <button
+                      type="button"
+                      data-on={terminalInputTransport === "json"}
+                      aria-pressed={terminalInputTransport === "json"}
+                      onClick={() => onTerminalInputTransport("json")}
+                    >
+                      JSON
+                    </button>
+                    <button
+                      type="button"
+                      data-on={terminalInputTransport === "binary"}
+                      aria-pressed={terminalInputTransport === "binary"}
+                      onClick={() => onTerminalInputTransport("binary")}
+                    >
+                      Binary
+                    </button>
+                  </div>
+                </div>
+                <div className="settings-row">
+                  <span>Input batching</span>
+                  <div className="segmented-control" role="group" aria-label="Terminal input batching">
+                    {TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS.map((delayMs) => (
+                      <button
+                        key={delayMs}
+                        type="button"
+                        data-on={terminalInputBatchDelayMs === delayMs}
+                        aria-pressed={terminalInputBatchDelayMs === delayMs}
+                        onClick={() => onTerminalInputBatchDelayMs(delayMs)}
+                      >
+                        {delayMs === 0 ? "Off" : `${delayMs}ms`}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
             ) : null}
-            {message ? <div className="modal-message">{message}</div> : null}
-            {showMobileTerminalSettings ? (
-              <div className="settings-section">
+
+            {activeArea === "mobile" && showMobileTerminalSettings ? (
+              <div className="settings-section settings-section-flat">
                 <div className="settings-label">Mobile terminal</div>
                 <div className="settings-row">
                   <span>Terminal tap</span>
@@ -383,36 +523,6 @@ export function BackendSettingsDialog({
               </div>
             ) : null}
           </div>
-        </div>
-        <div className="modal-actions">
-          {canDelete ? (
-            <button type="button" className="btn btn-danger" disabled={busy} onClick={deleteBackend}>
-              Delete
-            </button>
-          ) : null}
-          {selectionMode === "same-origin" && bridge.store.activeBackendId ? (
-            <button type="button" className="btn btn-primary" onClick={useSameOrigin}>
-              Use
-            </button>
-          ) : null}
-          {editingBackend ? (
-            <>
-              <button type="button" className="btn" disabled={busy || !form.baseUrl.trim()} onClick={testBackend}>
-                Test
-              </button>
-              <button
-                type="button"
-                className="btn"
-                disabled={busy || !form.baseUrl.trim()}
-                onClick={() => void saveBackend(false)}
-              >
-                Save
-              </button>
-              <button type="submit" className="btn btn-primary" disabled={busy || !form.baseUrl.trim()}>
-                Save & use
-              </button>
-            </>
-          ) : null}
         </div>
       </form>
     </div>

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -16,7 +16,12 @@ import { shellQuote } from "./shell";
 import { findFirstUrlInSelection, openableHttpUrl } from "./terminalSelection";
 import { GhosttyRenderer } from "./terminalRenderer";
 import type { TerminalRenderer, TerminalSize } from "./terminalRenderer";
-import { TERMINAL_INPUT_BATCH_MAX_BYTES } from "./terminalInputTransport";
+import {
+  appendTerminalInputBatch,
+  drainTerminalInputBatch,
+  emptyTerminalInputBatch,
+  shouldSendTerminalInputImmediately,
+} from "./terminalInputTransport";
 import type { TerminalInputTransport } from "./terminalInputTransport";
 import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
 import type { PaneInfo } from "./types";
@@ -96,11 +101,7 @@ export function TerminalView({
   const sendResizeRef = useRef<(size: TerminalSize) => void>(() => {});
   const inputQueueRef = useRef<string[]>([]);
   const inputFlushTimerRef = useRef<number | null>(null);
-  const batchedInputRef = useRef<{ parts: string[]; bytes: number; source: string | null }>({
-    parts: [],
-    bytes: 0,
-    source: null,
-  });
+  const batchedInputRef = useRef(emptyTerminalInputBatch());
   const batchedInputFlushTimerRef = useRef<number | null>(null);
   const terminalInputEncoderRef = useRef(new TextEncoder());
   const uploadStatusTimerRef = useRef<number | null>(null);
@@ -126,6 +127,8 @@ export function TerminalView({
   mobileTapTargetRef.current = mobileTapTarget;
   const mobileTouchSelectionRef = useRef(mobileTouchSelection);
   mobileTouchSelectionRef.current = mobileTouchSelection;
+  const terminalInputTransportRef = useRef(terminalInputTransport);
+  terminalInputTransportRef.current = terminalInputTransport;
   const terminalInputBatchDelayMsRef = useRef(terminalInputBatchDelayMs);
   terminalInputBatchDelayMsRef.current = terminalInputBatchDelayMs;
   connectionKeyRef.current = connectionKey;
@@ -231,9 +234,8 @@ export function TerminalView({
   );
 
   const sendTerminalInputFrame = useCallback(
-    (socket: WebSocket, data: string, source: string) => {
-      void source;
-      if (terminalInputTransport === "binary") {
+    (socket: WebSocket, data: string) => {
+      if (terminalInputTransportRef.current === "binary") {
         const encoded = terminalInputEncoderRef.current.encode(data);
         socket.send(encoded);
         return;
@@ -241,7 +243,7 @@ export function TerminalView({
       const payload = JSON.stringify({ type: "input", data });
       socket.send(payload);
     },
-    [terminalInputTransport],
+    [],
   );
 
   const clearBatchedInputTimer = useCallback(() => {
@@ -255,20 +257,18 @@ export function TerminalView({
     clearBatchedInputTimer();
     const pending = batchedInputRef.current;
     if (pending.parts.length === 0) {
-      pending.bytes = 0;
-      pending.source = null;
+      batchedInputRef.current = emptyTerminalInputBatch();
       return;
     }
     const socket = socketRef.current;
-    const parts = pending.parts;
-    const source = pending.source ?? "renderer";
-    pending.parts = [];
-    pending.bytes = 0;
-    pending.source = null;
     if (socket?.readyState !== WebSocket.OPEN) {
       return;
     }
-    sendTerminalInputFrame(socket, parts.join(""), `${source}-batch`);
+    const drained = drainTerminalInputBatch(pending);
+    batchedInputRef.current = drained.batch;
+    if (drained.data !== null) {
+      sendTerminalInputFrame(socket, drained.data);
+    }
   }, [clearBatchedInputTimer, sendTerminalInputFrame]);
 
   const scheduleBatchedTerminalInputFlush = useCallback(() => {
@@ -278,28 +278,21 @@ export function TerminalView({
   }, [clearBatchedInputTimer, flushBatchedTerminalInput]);
 
   const sendTerminalInputData = useCallback(
-    (data: string, source: string) => {
+    (data: string) => {
       const socket = socketRef.current;
       if (socket?.readyState !== WebSocket.OPEN) {
         return;
       }
       const delayMs = terminalInputBatchDelayMsRef.current;
-      if (delayMs <= 0) {
-        flushBatchedTerminalInput();
-        sendTerminalInputFrame(socket, data, source);
-        return;
-      }
       const bytes = terminalInputEncoderRef.current.encode(data).byteLength;
-      const pending = batchedInputRef.current;
-      if (bytes >= TERMINAL_INPUT_BATCH_MAX_BYTES) {
+      if (shouldSendTerminalInputImmediately(bytes, delayMs)) {
         flushBatchedTerminalInput();
-        sendTerminalInputFrame(socket, data, source);
+        sendTerminalInputFrame(socket, data);
         return;
       }
-      pending.parts.push(data);
-      pending.bytes += bytes;
-      pending.source = pending.source === null ? source : pending.source;
-      if (pending.bytes >= TERMINAL_INPUT_BATCH_MAX_BYTES) {
+      const result = appendTerminalInputBatch(batchedInputRef.current, data, bytes);
+      batchedInputRef.current = result.batch;
+      if (result.shouldFlush) {
         flushBatchedTerminalInput();
         return;
       }
@@ -386,7 +379,7 @@ export function TerminalView({
         );
 
         disposeInput = renderer.onInput((data) => {
-          sendTerminalInputData(data, "renderer");
+          sendTerminalInputData(data);
         });
         disposeScroll = renderer.onScroll((lines) => {
           if (socket?.readyState !== WebSocket.OPEN || lines === 0) {
@@ -492,6 +485,7 @@ export function TerminalView({
               if (autoFocusRef.current) {
                 window.setTimeout(() => renderer.focus(), 0);
               }
+              flushBatchedTerminalInput();
             }
           });
           nextSocket.addEventListener("message", (event) => {
@@ -637,7 +631,7 @@ export function TerminalView({
   }, [mobileControls, pane?.terminal_id, resizeTerminal]);
 
   const sendTerminalInput = (data: string) => {
-    sendTerminalInputData(data, "mobile-key");
+    sendTerminalInputData(data);
   };
   const uploadDisabled = !pane || uploading;
 
@@ -790,7 +784,7 @@ export function TerminalView({
       retryCount = 0;
       const next = inputQueueRef.current.shift();
       if (next !== undefined) {
-        sendTerminalInputFrame(socket, next, "queued");
+        sendTerminalInputFrame(socket, next);
       }
       if (inputQueueRef.current.length > 0) {
         inputFlushTimerRef.current = window.setTimeout(flush, 35);

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -67,24 +67,9 @@ type MobileSelectionAction = {
   text: string;
   url: string;
 };
-type TerminalOutputDiagnostic = {
-  startedAt: number;
-  reportAfter: number;
-  inputBytes: number;
-  inputFrame: number;
-  outputFrames: number;
-  outputBytes: number;
-  maxFrameBytes: number;
-  totalWriteMs: number;
-  maxWriteMs: number;
-  firstOutputMs: number | null;
-};
 
 const MAX_UPLOAD_FILES = 8;
 const TERMINAL_CONNECT_TIMEOUT_MS = 3500;
-const TERMINAL_IO_DIAGNOSTIC_MIN_INPUT_BYTES = 64 * 1024;
-const TERMINAL_IO_DIAGNOSTIC_WINDOW_MS = 30_000;
-const TERMINAL_IO_DIAGNOSTIC_REPORT_MS = 1_000;
 
 export function TerminalView({
   pane,
@@ -118,8 +103,6 @@ export function TerminalView({
   });
   const batchedInputFlushTimerRef = useRef<number | null>(null);
   const terminalInputEncoderRef = useRef(new TextEncoder());
-  const terminalInputLogRef = useRef({ frames: 0, chars: 0, bytes: 0, maxBytes: 0 });
-  const terminalOutputDiagnosticRef = useRef<TerminalOutputDiagnostic | null>(null);
   const uploadStatusTimerRef = useRef<number | null>(null);
   const uploadInFlightRef = useRef(false);
   const uploadConflictRef = useRef<UploadConflictState | null>(null);
@@ -247,151 +230,18 @@ export function TerminalView({
     [measureTerminal],
   );
 
-  const logTerminalInputFrame = useCallback((
-    source: string,
-    transport: string,
-    data: string,
-    bytes: number,
-    timings: {
-      encodeMs?: number;
-      stringifyMs?: number;
-      sendMs: number;
-      totalMs: number;
-      bufferedBefore: number;
-      bufferedAfter: number;
-    },
-  ) => {
-    const stats = terminalInputLogRef.current;
-    stats.frames += 1;
-    stats.chars += data.length;
-    stats.bytes += bytes;
-    stats.maxBytes = Math.max(stats.maxBytes, bytes);
-    console.info("[terminal input frame]", {
-      source,
-      transport,
-      frame: stats.frames,
-      chars: data.length,
-      bytes,
-      totalChars: stats.chars,
-      totalBytes: stats.bytes,
-      maxBytes: stats.maxBytes,
-      encodeMs: timings.encodeMs,
-      stringifyMs: timings.stringifyMs,
-      sendMs: timings.sendMs,
-      totalMs: timings.totalMs,
-      bufferedBefore: timings.bufferedBefore,
-      bufferedAfter: timings.bufferedAfter,
-      bufferedDelta: timings.bufferedAfter - timings.bufferedBefore,
-    });
-    if (bytes >= TERMINAL_IO_DIAGNOSTIC_MIN_INPUT_BYTES) {
-      terminalOutputDiagnosticRef.current = {
-        startedAt: performance.now(),
-        reportAfter: performance.now() + TERMINAL_IO_DIAGNOSTIC_REPORT_MS,
-        inputBytes: bytes,
-        inputFrame: stats.frames,
-        outputFrames: 0,
-        outputBytes: 0,
-        maxFrameBytes: 0,
-        totalWriteMs: 0,
-        maxWriteMs: 0,
-        firstOutputMs: null,
-      };
-      console.info("[terminal output diagnostic started]", {
-        source,
-        transport,
-        inputFrame: stats.frames,
-        inputBytes: bytes,
-        windowMs: TERMINAL_IO_DIAGNOSTIC_WINDOW_MS,
-      });
-    }
-  }, []);
-
-  const logTerminalOutputFrame = useCallback((bytes: number, writeMs: number) => {
-    const diagnostic = terminalOutputDiagnosticRef.current;
-    if (!diagnostic) {
-      return;
-    }
-    const now = performance.now();
-    if (now - diagnostic.startedAt > TERMINAL_IO_DIAGNOSTIC_WINDOW_MS) {
-      console.info("[terminal output diagnostic finished]", {
-        inputFrame: diagnostic.inputFrame,
-        inputBytes: diagnostic.inputBytes,
-        outputFrames: diagnostic.outputFrames,
-        outputBytes: diagnostic.outputBytes,
-        maxFrameBytes: diagnostic.maxFrameBytes,
-        totalWriteMs: diagnostic.totalWriteMs,
-        maxWriteMs: diagnostic.maxWriteMs,
-        firstOutputMs: diagnostic.firstOutputMs,
-        elapsedMs: now - diagnostic.startedAt,
-      });
-      terminalOutputDiagnosticRef.current = null;
-      return;
-    }
-    diagnostic.outputFrames += 1;
-    diagnostic.outputBytes += bytes;
-    diagnostic.maxFrameBytes = Math.max(diagnostic.maxFrameBytes, bytes);
-    diagnostic.totalWriteMs += writeMs;
-    diagnostic.maxWriteMs = Math.max(diagnostic.maxWriteMs, writeMs);
-    if (diagnostic.firstOutputMs === null) {
-      diagnostic.firstOutputMs = now - diagnostic.startedAt;
-      console.info("[terminal first output after input]", {
-        inputFrame: diagnostic.inputFrame,
-        inputBytes: diagnostic.inputBytes,
-        firstOutputMs: diagnostic.firstOutputMs,
-        frameBytes: bytes,
-        writeMs,
-      });
-    }
-    if (now >= diagnostic.reportAfter) {
-      diagnostic.reportAfter = now + TERMINAL_IO_DIAGNOSTIC_REPORT_MS;
-      console.info("[terminal output diagnostic]", {
-        inputFrame: diagnostic.inputFrame,
-        inputBytes: diagnostic.inputBytes,
-        outputFrames: diagnostic.outputFrames,
-        outputBytes: diagnostic.outputBytes,
-        maxFrameBytes: diagnostic.maxFrameBytes,
-        totalWriteMs: diagnostic.totalWriteMs,
-        maxWriteMs: diagnostic.maxWriteMs,
-        firstOutputMs: diagnostic.firstOutputMs,
-        elapsedMs: now - diagnostic.startedAt,
-      });
-    }
-  }, []);
-
   const sendTerminalInputFrame = useCallback(
     (socket: WebSocket, data: string, source: string) => {
-      const start = performance.now();
-      const bufferedBefore = socket.bufferedAmount;
+      void source;
       if (terminalInputTransport === "binary") {
         const encoded = terminalInputEncoderRef.current.encode(data);
-        const encodedAt = performance.now();
         socket.send(encoded);
-        const sentAt = performance.now();
-        logTerminalInputFrame(source, terminalInputTransport, data, encoded.byteLength, {
-          encodeMs: encodedAt - start,
-          sendMs: sentAt - encodedAt,
-          totalMs: sentAt - start,
-          bufferedBefore,
-          bufferedAfter: socket.bufferedAmount,
-        });
         return;
       }
-      const bytes = terminalInputEncoderRef.current.encode(data).byteLength;
-      const encodedAt = performance.now();
       const payload = JSON.stringify({ type: "input", data });
-      const stringifiedAt = performance.now();
       socket.send(payload);
-      const sentAt = performance.now();
-      logTerminalInputFrame(source, terminalInputTransport, data, bytes, {
-        encodeMs: encodedAt - start,
-        stringifyMs: stringifiedAt - encodedAt,
-        sendMs: sentAt - stringifiedAt,
-        totalMs: sentAt - start,
-        bufferedBefore,
-        bufferedAfter: socket.bufferedAmount,
-      });
     },
-    [logTerminalInputFrame, terminalInputTransport],
+    [terminalInputTransport],
   );
 
   const clearBatchedInputTimer = useCallback(() => {
@@ -607,12 +457,6 @@ export function TerminalView({
           scheduleReconnect();
         };
 
-        const writeTerminalOutput = (data: Uint8Array) => {
-          const startedAt = performance.now();
-          renderer.write(data);
-          logTerminalOutputFrame(data.byteLength, performance.now() - startedAt);
-        };
-
         const connectSocket = () => {
           if (disposed) {
             return;
@@ -656,13 +500,13 @@ export function TerminalView({
               return;
             }
             if (event.data instanceof ArrayBuffer) {
-              writeTerminalOutput(new Uint8Array(event.data));
+              renderer.write(new Uint8Array(event.data));
               return;
             }
             if (event.data instanceof Blob) {
               void event.data.arrayBuffer().then((buffer) => {
                 if (!disposed && socket === nextSocket) {
-                  writeTerminalOutput(new Uint8Array(buffer));
+                  renderer.write(new Uint8Array(buffer));
                 }
               });
             }
@@ -728,7 +572,6 @@ export function TerminalView({
     };
   }, [
     connectionKey,
-    logTerminalOutputFrame,
     measureTerminal,
     pane?.terminal_id,
     resumeToken,

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -539,6 +539,7 @@ export function TerminalView({
     return () => {
       disposed = true;
       flushBatchedTerminalInput();
+      batchedInputRef.current = emptyTerminalInputBatch();
       inputQueueRef.current = [];
       if (inputFlushTimerRef.current !== null) {
         window.clearTimeout(inputFlushTimerRef.current);

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -16,6 +16,8 @@ import { shellQuote } from "./shell";
 import { findFirstUrlInSelection, openableHttpUrl } from "./terminalSelection";
 import { GhosttyRenderer } from "./terminalRenderer";
 import type { TerminalRenderer, TerminalSize } from "./terminalRenderer";
+import { TERMINAL_INPUT_BATCH_MAX_BYTES } from "./terminalInputTransport";
+import type { TerminalInputTransport } from "./terminalInputTransport";
 import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
 import type { PaneInfo } from "./types";
 
@@ -35,6 +37,10 @@ type Props = {
   mobileTapTarget?: MobileTerminalTapTarget;
   /** Enables long-press drag selection on touch terminals. */
   mobileTouchSelection?: boolean;
+  /** Browser-to-bridge transport for terminal input payloads. */
+  terminalInputTransport?: TerminalInputTransport;
+  /** Delay for coalescing short terminal input payloads. Zero disables batching. */
+  terminalInputBatchDelayMs?: number;
   /** Incrementing token from the parent that requests an immediate fit+resize. */
   refitToken?: number;
   /** Incrementing token from the parent that requests focus on the preferred terminal input. */
@@ -61,9 +67,24 @@ type MobileSelectionAction = {
   text: string;
   url: string;
 };
+type TerminalOutputDiagnostic = {
+  startedAt: number;
+  reportAfter: number;
+  inputBytes: number;
+  inputFrame: number;
+  outputFrames: number;
+  outputBytes: number;
+  maxFrameBytes: number;
+  totalWriteMs: number;
+  maxWriteMs: number;
+  firstOutputMs: number | null;
+};
 
 const MAX_UPLOAD_FILES = 8;
 const TERMINAL_CONNECT_TIMEOUT_MS = 3500;
+const TERMINAL_IO_DIAGNOSTIC_MIN_INPUT_BYTES = 64 * 1024;
+const TERMINAL_IO_DIAGNOSTIC_WINDOW_MS = 30_000;
+const TERMINAL_IO_DIAGNOSTIC_REPORT_MS = 1_000;
 
 export function TerminalView({
   pane,
@@ -76,6 +97,8 @@ export function TerminalView({
   mobileControls = false,
   mobileTapTarget = "command-input",
   mobileTouchSelection = false,
+  terminalInputTransport = "json",
+  terminalInputBatchDelayMs = 0,
   refitToken = 0,
   focusToken = 0,
 }: Props) {
@@ -88,6 +111,15 @@ export function TerminalView({
   const sendResizeRef = useRef<(size: TerminalSize) => void>(() => {});
   const inputQueueRef = useRef<string[]>([]);
   const inputFlushTimerRef = useRef<number | null>(null);
+  const batchedInputRef = useRef<{ parts: string[]; bytes: number; source: string | null }>({
+    parts: [],
+    bytes: 0,
+    source: null,
+  });
+  const batchedInputFlushTimerRef = useRef<number | null>(null);
+  const terminalInputEncoderRef = useRef(new TextEncoder());
+  const terminalInputLogRef = useRef({ frames: 0, chars: 0, bytes: 0, maxBytes: 0 });
+  const terminalOutputDiagnosticRef = useRef<TerminalOutputDiagnostic | null>(null);
   const uploadStatusTimerRef = useRef<number | null>(null);
   const uploadInFlightRef = useRef(false);
   const uploadConflictRef = useRef<UploadConflictState | null>(null);
@@ -111,6 +143,8 @@ export function TerminalView({
   mobileTapTargetRef.current = mobileTapTarget;
   const mobileTouchSelectionRef = useRef(mobileTouchSelection);
   mobileTouchSelectionRef.current = mobileTouchSelection;
+  const terminalInputBatchDelayMsRef = useRef(terminalInputBatchDelayMs);
+  terminalInputBatchDelayMsRef.current = terminalInputBatchDelayMs;
   connectionKeyRef.current = connectionKey;
   terminalIdRef.current = pane?.terminal_id ?? null;
 
@@ -213,6 +247,225 @@ export function TerminalView({
     [measureTerminal],
   );
 
+  const logTerminalInputFrame = useCallback((
+    source: string,
+    transport: string,
+    data: string,
+    bytes: number,
+    timings: {
+      encodeMs?: number;
+      stringifyMs?: number;
+      sendMs: number;
+      totalMs: number;
+      bufferedBefore: number;
+      bufferedAfter: number;
+    },
+  ) => {
+    const stats = terminalInputLogRef.current;
+    stats.frames += 1;
+    stats.chars += data.length;
+    stats.bytes += bytes;
+    stats.maxBytes = Math.max(stats.maxBytes, bytes);
+    console.info("[terminal input frame]", {
+      source,
+      transport,
+      frame: stats.frames,
+      chars: data.length,
+      bytes,
+      totalChars: stats.chars,
+      totalBytes: stats.bytes,
+      maxBytes: stats.maxBytes,
+      encodeMs: timings.encodeMs,
+      stringifyMs: timings.stringifyMs,
+      sendMs: timings.sendMs,
+      totalMs: timings.totalMs,
+      bufferedBefore: timings.bufferedBefore,
+      bufferedAfter: timings.bufferedAfter,
+      bufferedDelta: timings.bufferedAfter - timings.bufferedBefore,
+    });
+    if (bytes >= TERMINAL_IO_DIAGNOSTIC_MIN_INPUT_BYTES) {
+      terminalOutputDiagnosticRef.current = {
+        startedAt: performance.now(),
+        reportAfter: performance.now() + TERMINAL_IO_DIAGNOSTIC_REPORT_MS,
+        inputBytes: bytes,
+        inputFrame: stats.frames,
+        outputFrames: 0,
+        outputBytes: 0,
+        maxFrameBytes: 0,
+        totalWriteMs: 0,
+        maxWriteMs: 0,
+        firstOutputMs: null,
+      };
+      console.info("[terminal output diagnostic started]", {
+        source,
+        transport,
+        inputFrame: stats.frames,
+        inputBytes: bytes,
+        windowMs: TERMINAL_IO_DIAGNOSTIC_WINDOW_MS,
+      });
+    }
+  }, []);
+
+  const logTerminalOutputFrame = useCallback((bytes: number, writeMs: number) => {
+    const diagnostic = terminalOutputDiagnosticRef.current;
+    if (!diagnostic) {
+      return;
+    }
+    const now = performance.now();
+    if (now - diagnostic.startedAt > TERMINAL_IO_DIAGNOSTIC_WINDOW_MS) {
+      console.info("[terminal output diagnostic finished]", {
+        inputFrame: diagnostic.inputFrame,
+        inputBytes: diagnostic.inputBytes,
+        outputFrames: diagnostic.outputFrames,
+        outputBytes: diagnostic.outputBytes,
+        maxFrameBytes: diagnostic.maxFrameBytes,
+        totalWriteMs: diagnostic.totalWriteMs,
+        maxWriteMs: diagnostic.maxWriteMs,
+        firstOutputMs: diagnostic.firstOutputMs,
+        elapsedMs: now - diagnostic.startedAt,
+      });
+      terminalOutputDiagnosticRef.current = null;
+      return;
+    }
+    diagnostic.outputFrames += 1;
+    diagnostic.outputBytes += bytes;
+    diagnostic.maxFrameBytes = Math.max(diagnostic.maxFrameBytes, bytes);
+    diagnostic.totalWriteMs += writeMs;
+    diagnostic.maxWriteMs = Math.max(diagnostic.maxWriteMs, writeMs);
+    if (diagnostic.firstOutputMs === null) {
+      diagnostic.firstOutputMs = now - diagnostic.startedAt;
+      console.info("[terminal first output after input]", {
+        inputFrame: diagnostic.inputFrame,
+        inputBytes: diagnostic.inputBytes,
+        firstOutputMs: diagnostic.firstOutputMs,
+        frameBytes: bytes,
+        writeMs,
+      });
+    }
+    if (now >= diagnostic.reportAfter) {
+      diagnostic.reportAfter = now + TERMINAL_IO_DIAGNOSTIC_REPORT_MS;
+      console.info("[terminal output diagnostic]", {
+        inputFrame: diagnostic.inputFrame,
+        inputBytes: diagnostic.inputBytes,
+        outputFrames: diagnostic.outputFrames,
+        outputBytes: diagnostic.outputBytes,
+        maxFrameBytes: diagnostic.maxFrameBytes,
+        totalWriteMs: diagnostic.totalWriteMs,
+        maxWriteMs: diagnostic.maxWriteMs,
+        firstOutputMs: diagnostic.firstOutputMs,
+        elapsedMs: now - diagnostic.startedAt,
+      });
+    }
+  }, []);
+
+  const sendTerminalInputFrame = useCallback(
+    (socket: WebSocket, data: string, source: string) => {
+      const start = performance.now();
+      const bufferedBefore = socket.bufferedAmount;
+      if (terminalInputTransport === "binary") {
+        const encoded = terminalInputEncoderRef.current.encode(data);
+        const encodedAt = performance.now();
+        socket.send(encoded);
+        const sentAt = performance.now();
+        logTerminalInputFrame(source, terminalInputTransport, data, encoded.byteLength, {
+          encodeMs: encodedAt - start,
+          sendMs: sentAt - encodedAt,
+          totalMs: sentAt - start,
+          bufferedBefore,
+          bufferedAfter: socket.bufferedAmount,
+        });
+        return;
+      }
+      const bytes = terminalInputEncoderRef.current.encode(data).byteLength;
+      const encodedAt = performance.now();
+      const payload = JSON.stringify({ type: "input", data });
+      const stringifiedAt = performance.now();
+      socket.send(payload);
+      const sentAt = performance.now();
+      logTerminalInputFrame(source, terminalInputTransport, data, bytes, {
+        encodeMs: encodedAt - start,
+        stringifyMs: stringifiedAt - encodedAt,
+        sendMs: sentAt - stringifiedAt,
+        totalMs: sentAt - start,
+        bufferedBefore,
+        bufferedAfter: socket.bufferedAmount,
+      });
+    },
+    [logTerminalInputFrame, terminalInputTransport],
+  );
+
+  const clearBatchedInputTimer = useCallback(() => {
+    if (batchedInputFlushTimerRef.current !== null) {
+      window.clearTimeout(batchedInputFlushTimerRef.current);
+      batchedInputFlushTimerRef.current = null;
+    }
+  }, []);
+
+  const flushBatchedTerminalInput = useCallback(() => {
+    clearBatchedInputTimer();
+    const pending = batchedInputRef.current;
+    if (pending.parts.length === 0) {
+      pending.bytes = 0;
+      pending.source = null;
+      return;
+    }
+    const socket = socketRef.current;
+    const parts = pending.parts;
+    const source = pending.source ?? "renderer";
+    pending.parts = [];
+    pending.bytes = 0;
+    pending.source = null;
+    if (socket?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    sendTerminalInputFrame(socket, parts.join(""), `${source}-batch`);
+  }, [clearBatchedInputTimer, sendTerminalInputFrame]);
+
+  const scheduleBatchedTerminalInputFlush = useCallback(() => {
+    clearBatchedInputTimer();
+    const delayMs = terminalInputBatchDelayMsRef.current;
+    batchedInputFlushTimerRef.current = window.setTimeout(flushBatchedTerminalInput, delayMs);
+  }, [clearBatchedInputTimer, flushBatchedTerminalInput]);
+
+  const sendTerminalInputData = useCallback(
+    (data: string, source: string) => {
+      const socket = socketRef.current;
+      if (socket?.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      const delayMs = terminalInputBatchDelayMsRef.current;
+      if (delayMs <= 0) {
+        flushBatchedTerminalInput();
+        sendTerminalInputFrame(socket, data, source);
+        return;
+      }
+      const bytes = terminalInputEncoderRef.current.encode(data).byteLength;
+      const pending = batchedInputRef.current;
+      if (bytes >= TERMINAL_INPUT_BATCH_MAX_BYTES) {
+        flushBatchedTerminalInput();
+        sendTerminalInputFrame(socket, data, source);
+        return;
+      }
+      pending.parts.push(data);
+      pending.bytes += bytes;
+      pending.source = pending.source === null ? source : pending.source;
+      if (pending.bytes >= TERMINAL_INPUT_BATCH_MAX_BYTES) {
+        flushBatchedTerminalInput();
+        return;
+      }
+      if (batchedInputFlushTimerRef.current === null) {
+        scheduleBatchedTerminalInputFlush();
+      }
+    },
+    [flushBatchedTerminalInput, scheduleBatchedTerminalInputFlush, sendTerminalInputFrame],
+  );
+
+  useEffect(() => {
+    if (terminalInputBatchDelayMs <= 0) {
+      flushBatchedTerminalInput();
+    }
+  }, [flushBatchedTerminalInput, terminalInputBatchDelayMs]);
+
   // Re-apply scroll tuning live when crossing the desktop/mobile breakpoint,
   // without tearing down the socket.
   useEffect(() => {
@@ -283,9 +536,7 @@ export function TerminalView({
         );
 
         disposeInput = renderer.onInput((data) => {
-          if (socket?.readyState === WebSocket.OPEN) {
-            socket.send(JSON.stringify({ type: "input", data }));
-          }
+          sendTerminalInputData(data, "renderer");
         });
         disposeScroll = renderer.onScroll((lines) => {
           if (socket?.readyState !== WebSocket.OPEN || lines === 0) {
@@ -356,6 +607,12 @@ export function TerminalView({
           scheduleReconnect();
         };
 
+        const writeTerminalOutput = (data: Uint8Array) => {
+          const startedAt = performance.now();
+          renderer.write(data);
+          logTerminalOutputFrame(data.byteLength, performance.now() - startedAt);
+        };
+
         const connectSocket = () => {
           if (disposed) {
             return;
@@ -399,13 +656,13 @@ export function TerminalView({
               return;
             }
             if (event.data instanceof ArrayBuffer) {
-              renderer.write(new Uint8Array(event.data));
+              writeTerminalOutput(new Uint8Array(event.data));
               return;
             }
             if (event.data instanceof Blob) {
               void event.data.arrayBuffer().then((buffer) => {
                 if (!disposed && socket === nextSocket) {
-                  renderer.write(new Uint8Array(buffer));
+                  writeTerminalOutput(new Uint8Array(buffer));
                 }
               });
             }
@@ -443,6 +700,7 @@ export function TerminalView({
 
     return () => {
       disposed = true;
+      flushBatchedTerminalInput();
       inputQueueRef.current = [];
       if (inputFlushTimerRef.current !== null) {
         window.clearTimeout(inputFlushTimerRef.current);
@@ -468,7 +726,17 @@ export function TerminalView({
       rendererRef.current = null;
       host.replaceChildren();
     };
-  }, [connectionKey, measureTerminal, pane?.terminal_id, resumeToken, wsUrl]);
+  }, [
+    connectionKey,
+    logTerminalOutputFrame,
+    measureTerminal,
+    pane?.terminal_id,
+    resumeToken,
+    flushBatchedTerminalInput,
+    sendTerminalInputData,
+    sendTerminalInputFrame,
+    wsUrl,
+  ]);
 
   useEffect(() => {
     rendererRef.current?.setTapFocusHandler(
@@ -526,10 +794,7 @@ export function TerminalView({
   }, [mobileControls, pane?.terminal_id, resizeTerminal]);
 
   const sendTerminalInput = (data: string) => {
-    const socket = socketRef.current;
-    if (socket?.readyState === WebSocket.OPEN) {
-      socket.send(JSON.stringify({ type: "input", data }));
-    }
+    sendTerminalInputData(data, "mobile-key");
   };
   const uploadDisabled = !pane || uploading;
 
@@ -682,7 +947,7 @@ export function TerminalView({
       retryCount = 0;
       const next = inputQueueRef.current.shift();
       if (next !== undefined) {
-        socket.send(JSON.stringify({ type: "input", data: next }));
+        sendTerminalInputFrame(socket, next, "queued");
       }
       if (inputQueueRef.current.length > 0) {
         inputFlushTimerRef.current = window.setTimeout(flush, 35);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1455,14 +1455,58 @@ button {
 }
 
 .backend-modal {
-  width: min(720px, 100%);
+  width: min(760px, 100%);
 }
 
 .backend-layout {
   display: grid;
-  grid-template-columns: minmax(170px, 0.8fr) minmax(0, 1.2fr);
+  grid-template-columns: 150px minmax(0, 1fr);
   gap: 14px;
   min-height: 260px;
+}
+
+.settings-area-list {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-area-tab {
+  display: inline-flex;
+  width: 100%;
+  height: 36px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  color: var(--subtext0);
+  background: transparent;
+  font-size: 12.5px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.settings-area-tab:hover {
+  color: var(--text);
+  background: var(--row-hover);
+}
+
+.settings-area-tab[data-active="true"] {
+  border-color: var(--line);
+  color: var(--text);
+  background: var(--row-active);
+}
+
+.settings-panel {
+  min-width: 0;
+}
+
+.bridge-settings-grid {
+  display: grid;
+  grid-template-columns: minmax(170px, 0.8fr) minmax(0, 1.2fr);
+  gap: 14px;
 }
 
 .backend-list {
@@ -1565,6 +1609,12 @@ button {
   margin-top: 4px;
   padding-top: 12px;
   border-top: 1px solid var(--line);
+}
+
+.settings-section-flat {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
 }
 
 .settings-label {
@@ -1832,6 +1882,22 @@ button {
   .backend-layout {
     grid-template-columns: 1fr;
     min-height: 0;
+  }
+
+  .settings-area-list {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .settings-area-tab {
+    width: auto;
+    min-width: 104px;
+    justify-content: center;
+  }
+
+  .bridge-settings-grid {
+    grid-template-columns: 1fr;
   }
 
   .backend-list {

--- a/web/src/terminalInputTransport.test.ts
+++ b/web/src/terminalInputTransport.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
+  DEFAULT_TERMINAL_INPUT_TRANSPORT,
+  parseTerminalInputBatchDelayMs,
+  parseTerminalInputTransport,
+  TERMINAL_INPUT_BATCH_MAX_BYTES,
+} from "./terminalInputTransport";
+
+describe("terminal input transport preferences", () => {
+  it("parses supported transports", () => {
+    expect(parseTerminalInputTransport("json")).toBe("json");
+    expect(parseTerminalInputTransport("binary")).toBe("binary");
+  });
+
+  it("falls back for unknown transports", () => {
+    expect(parseTerminalInputTransport("text")).toBe(DEFAULT_TERMINAL_INPUT_TRANSPORT);
+    expect(parseTerminalInputTransport(null)).toBe(DEFAULT_TERMINAL_INPUT_TRANSPORT);
+  });
+
+  it("parses supported batch delays", () => {
+    expect(parseTerminalInputBatchDelayMs(0)).toBe(0);
+    expect(parseTerminalInputBatchDelayMs(32)).toBe(32);
+    expect(parseTerminalInputBatchDelayMs(64)).toBe(64);
+    expect(parseTerminalInputBatchDelayMs(128)).toBe(128);
+    expect(parseTerminalInputBatchDelayMs(256)).toBe(256);
+  });
+
+  it("falls back for unknown batch delays", () => {
+    expect(parseTerminalInputBatchDelayMs(16)).toBe(DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS);
+    expect(parseTerminalInputBatchDelayMs(512)).toBe(DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS);
+    expect(parseTerminalInputBatchDelayMs("128")).toBe(DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS);
+  });
+
+  it("uses a fixed small input batch size", () => {
+    expect(TERMINAL_INPUT_BATCH_MAX_BYTES).toBe(32);
+  });
+});

--- a/web/src/terminalInputTransport.test.ts
+++ b/web/src/terminalInputTransport.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  appendTerminalInputBatch,
   DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
   DEFAULT_TERMINAL_INPUT_TRANSPORT,
+  drainTerminalInputBatch,
+  emptyTerminalInputBatch,
   parseTerminalInputBatchDelayMs,
   parseTerminalInputTransport,
+  shouldSendTerminalInputImmediately,
   TERMINAL_INPUT_BATCH_MAX_BYTES,
 } from "./terminalInputTransport";
 
@@ -34,5 +38,39 @@ describe("terminal input transport preferences", () => {
 
   it("uses a fixed small input batch size", () => {
     expect(TERMINAL_INPUT_BATCH_MAX_BYTES).toBe(32);
+  });
+
+  it("coalesces input below the fixed batch size", () => {
+    const first = appendTerminalInputBatch(emptyTerminalInputBatch(), "abc", 3);
+    expect(first).toEqual({
+      batch: { parts: ["abc"], bytes: 3 },
+      shouldFlush: false,
+    });
+    const second = appendTerminalInputBatch(first.batch, "def", 3);
+    expect(second).toEqual({
+      batch: { parts: ["abc", "def"], bytes: 6 },
+      shouldFlush: false,
+    });
+  });
+
+  it("flushes accumulated input at the fixed batch size", () => {
+    const result = appendTerminalInputBatch({ parts: ["a".repeat(20)], bytes: 20 }, "b".repeat(12), 12);
+    expect(result.shouldFlush).toBe(true);
+    expect(result.batch.bytes).toBe(32);
+  });
+
+  it("sends large single input chunks immediately when batching is enabled", () => {
+    expect(shouldSendTerminalInputImmediately(31, 64)).toBe(false);
+    expect(shouldSendTerminalInputImmediately(32, 64)).toBe(true);
+    expect(shouldSendTerminalInputImmediately(1, 0)).toBe(true);
+  });
+
+  it("drains batched input in order", () => {
+    const drained = drainTerminalInputBatch({ parts: ["ab", "cd"], bytes: 4 });
+    expect(drained).toEqual({
+      data: "abcd",
+      batch: { parts: [], bytes: 0 },
+    });
+    expect(drainTerminalInputBatch(emptyTerminalInputBatch()).data).toBeNull();
   });
 });

--- a/web/src/terminalInputTransport.ts
+++ b/web/src/terminalInputTransport.ts
@@ -1,0 +1,21 @@
+export type TerminalInputTransport = "json" | "binary";
+
+export const DEFAULT_TERMINAL_INPUT_TRANSPORT: TerminalInputTransport = "json";
+export const DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS = 0;
+export const TERMINAL_INPUT_BATCH_MAX_BYTES = 32;
+export const TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS = [0, 32, 64, 128, 256] as const;
+
+export function parseTerminalInputTransport(value: unknown): TerminalInputTransport {
+  return value === "binary" || value === "json" ? value : DEFAULT_TERMINAL_INPUT_TRANSPORT;
+}
+
+export function parseTerminalInputBatchDelayMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS;
+  }
+  return TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS.includes(
+    value as (typeof TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS)[number],
+  )
+    ? value
+    : DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS;
+}

--- a/web/src/terminalInputTransport.ts
+++ b/web/src/terminalInputTransport.ts
@@ -1,4 +1,8 @@
 export type TerminalInputTransport = "json" | "binary";
+export type TerminalInputBatch = {
+  parts: string[];
+  bytes: number;
+};
 
 export const DEFAULT_TERMINAL_INPUT_TRANSPORT: TerminalInputTransport = "json";
 export const DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS = 0;
@@ -18,4 +22,37 @@ export function parseTerminalInputBatchDelayMs(value: unknown): number {
   )
     ? value
     : DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS;
+}
+
+export function emptyTerminalInputBatch(): TerminalInputBatch {
+  return { parts: [], bytes: 0 };
+}
+
+export function shouldSendTerminalInputImmediately(bytes: number, delayMs: number): boolean {
+  return delayMs <= 0 || bytes >= TERMINAL_INPUT_BATCH_MAX_BYTES;
+}
+
+export function appendTerminalInputBatch(
+  batch: TerminalInputBatch,
+  data: string,
+  bytes: number,
+): { batch: TerminalInputBatch; shouldFlush: boolean } {
+  const next = {
+    parts: [...batch.parts, data],
+    bytes: batch.bytes + bytes,
+  };
+  return {
+    batch: next,
+    shouldFlush: next.bytes >= TERMINAL_INPUT_BATCH_MAX_BYTES,
+  };
+}
+
+export function drainTerminalInputBatch(batch: TerminalInputBatch): {
+  data: string | null;
+  batch: TerminalInputBatch;
+} {
+  return {
+    data: batch.parts.length === 0 ? null : batch.parts.join(""),
+    batch: emptyTerminalInputBatch(),
+  };
 }

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -248,11 +248,29 @@ export class GhosttyRenderer implements TerminalRenderer {
     return this.#terminal;
   }
 
+  #isCurrentTerminal(terminal: Terminal) {
+    return this.#terminal === terminal;
+  }
+
+  #hasMouseTracking(terminal: Terminal) {
+    if (!this.#isCurrentTerminal(terminal)) {
+      return true;
+    }
+    try {
+      return terminal.hasMouseTracking();
+    } catch (error) {
+      if (isGhosttyDisposedError(error)) {
+        return true;
+      }
+      throw error;
+    }
+  }
+
   #installScrollHandlers() {
     const terminal = this.#requireTerminal();
 
     terminal.attachCustomWheelEventHandler((event) => {
-      if (terminal.hasMouseTracking()) {
+      if (!this.#isCurrentTerminal(terminal) || this.#hasMouseTracking(terminal)) {
         return false;
       }
       event.preventDefault();
@@ -334,7 +352,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       selectionTimer = null;
       if (
         !this.#mobileTouchSelectionEnabled ||
-        terminal.hasMouseTracking() ||
+        this.#hasMouseTracking(terminal) ||
         touchStartX === null ||
         touchStartY === null
       ) {
@@ -379,7 +397,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       ) {
         return null;
       }
-      if (terminal.hasMouseTracking()) {
+      if (this.#hasMouseTracking(terminal)) {
         return null;
       }
       const touch = event.changedTouches[0];
@@ -408,7 +426,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     const onTouchStart = (event: TouchEvent) => {
       clearSelectionTimer();
       if (event.touches.length === 1) {
-        const mouseTracking = terminal.hasMouseTracking();
+        const mouseTracking = this.#hasMouseTracking(terminal);
         if (this.#mobileTouchSelectionEnabled && !mouseTracking) {
           preventTouchEvent(event);
           suppressMouseEvents(TOUCH_SELECTION_LONG_PRESS_MS + TOUCH_COMPAT_MOUSE_SUPPRESS_MS);
@@ -446,7 +464,7 @@ export class GhosttyRenderer implements TerminalRenderer {
         preventTouchEvent(event);
         return;
       }
-      if (terminal.hasMouseTracking() || event.touches.length !== 1 || lastTouchY === null) {
+      if (this.#hasMouseTracking(terminal) || event.touches.length !== 1 || lastTouchY === null) {
         return;
       }
       const currentY = event.touches[0].clientY;
@@ -479,7 +497,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     };
     const onTouchEnd = (event: TouchEvent) => {
       clearSelectionTimer();
-      if (terminal.hasMouseTracking()) {
+      if (this.#hasMouseTracking(terminal)) {
         lastTouchY = null;
         touchStartX = null;
         touchStartY = null;
@@ -551,7 +569,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       return false;
     };
     const onMouseDown = (event: MouseEvent) => {
-      if (terminal.hasMouseTracking()) {
+      if (this.#hasMouseTracking(terminal)) {
         return;
       }
       if (suppressCompatMouseEvent(event)) {
@@ -722,6 +740,10 @@ function hideGhosttyTextarea(textarea: HTMLTextAreaElement) {
   textarea.style.background = "transparent";
   textarea.style.caretColor = "transparent";
   textarea.style.overflow = "hidden";
+}
+
+function isGhosttyDisposedError(error: unknown) {
+  return error instanceof Error && error.message === "Terminal has been disposed";
 }
 
 function cleanupEditableArtifacts(container: HTMLElement | null) {


### PR DESCRIPTION
## Summary
- add configurable JSON/binary terminal input transport, with binary payload concepts credited to the roy-levi-amazon fork
- add opt-in terminal input batching with a fixed 32-byte flush threshold
- rework Settings into Bridge, Terminal, and Mobile areas with mobile tabs
- chunk large terminal input before forwarding to Herdr and remove temporary diagnostics

## Review
- Claude xhigh iterative review completed with final clean follow-up

## Tests
- npm run test:web
- npm run lint:web
- npm run build:web
- cargo fmt --manifest-path bridge/Cargo.toml --check
- cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge
- cargo build --release --manifest-path bridge/Cargo.toml --bin herdr-web-bridge
- npm run android:build:debug