### PR TITLE
Add display padding and mobile input sizing settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added a bridge-owned agent activity stream so pane status, title, display agent, and custom
   status updates reach connected browsers without waiting for a full snapshot refresh; concepts
   derived from the @roy-levi-amazon fork. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
+- Added Display settings for top/bottom app padding and mobile terminal controls size.
 - Added configurable terminal input transport, with binary payload concepts derived from the
   @roy-levi-amazon fork. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
 - Added opt-in terminal input batching controls with a fixed 32-byte flush threshold for slow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   status updates reach connected browsers without waiting for a full snapshot refresh; concepts
   derived from the @roy-levi-amazon fork. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
 - Added Display settings for top/bottom app padding and mobile terminal controls size.
+  [PR #13](https://github.com/kcosr/herdr-web/pull/13)
 - Added configurable terminal input transport, with binary payload concepts derived from the
   @roy-levi-amazon fork. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
 - Added opt-in terminal input batching controls with a fixed 32-byte flush threshold for slow

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,14 @@ import {
   currentConnectionSnapshot,
   isConnectionResultCurrent,
 } from "./connectionState";
+import {
+  DEFAULT_CONTENT_INSET_BOTTOM_PX,
+  DEFAULT_CONTENT_INSET_TOP_PX,
+  DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
+  parseContentInsetBottomPx,
+  parseContentInsetTopPx,
+  parseMobileControlsScalePercent,
+} from "./displayPrefs";
 import { LaunchDialog } from "./LaunchDialog";
 import { resolveLaunchSpec } from "./launch";
 import type { LaunchTarget } from "./launch";
@@ -102,6 +110,9 @@ type DisplayPrefs = {
   selectedPaneId: string | null;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
+  contentInsetTopPx: number;
+  contentInsetBottomPx: number;
+  mobileControlsScalePercent: number;
   mobileTerminalTapTarget: MobileTerminalTapTarget;
   mobileTouchSelection: boolean;
   mobileKeyboardHideRefit: boolean;
@@ -127,6 +138,9 @@ function readDisplayPrefs(): DisplayPrefs {
     selectedPaneId: null,
     terminalInputTransport: DEFAULT_TERMINAL_INPUT_TRANSPORT,
     terminalInputBatchDelayMs: DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
+    contentInsetTopPx: DEFAULT_CONTENT_INSET_TOP_PX,
+    contentInsetBottomPx: DEFAULT_CONTENT_INSET_BOTTOM_PX,
+    mobileControlsScalePercent: DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
     mobileTerminalTapTarget: DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
     mobileTouchSelection: DEFAULT_MOBILE_TOUCH_SELECTION,
     mobileKeyboardHideRefit: DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
@@ -165,6 +179,11 @@ function readDisplayPrefs(): DisplayPrefs {
         typeof parsed.selectedPaneId === "string" ? parsed.selectedPaneId : fallback.selectedPaneId,
       terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
       terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
+      contentInsetTopPx: parseContentInsetTopPx(parsed.contentInsetTopPx),
+      contentInsetBottomPx: parseContentInsetBottomPx(parsed.contentInsetBottomPx),
+      mobileControlsScalePercent: parseMobileControlsScalePercent(
+        parsed.mobileControlsScalePercent,
+      ),
       mobileTerminalTapTarget: parseMobileTerminalTapTarget(parsed.mobileTerminalTapTarget),
       mobileTouchSelection: parseMobileTouchSelection(parsed.mobileTouchSelection),
       mobileKeyboardHideRefit: parseMobileKeyboardHideRefit(parsed.mobileKeyboardHideRefit),
@@ -254,6 +273,13 @@ export function App() {
   );
   const [terminalInputBatchDelayMs, setTerminalInputBatchDelayMs] = useState(
     initialPrefs.terminalInputBatchDelayMs,
+  );
+  const [contentInsetTopPx, setContentInsetTopPx] = useState(initialPrefs.contentInsetTopPx);
+  const [contentInsetBottomPx, setContentInsetBottomPx] = useState(
+    initialPrefs.contentInsetBottomPx,
+  );
+  const [mobileControlsScalePercent, setMobileControlsScalePercent] = useState(
+    initialPrefs.mobileControlsScalePercent,
   );
   const [mobileTerminalTapTarget, setMobileTerminalTapTarget] = useState(
     initialPrefs.mobileTerminalTapTarget,
@@ -378,6 +404,9 @@ export function App() {
       selectedPaneId,
       terminalInputTransport,
       terminalInputBatchDelayMs,
+      contentInsetTopPx,
+      contentInsetBottomPx,
+      mobileControlsScalePercent,
       mobileTerminalTapTarget,
       mobileTouchSelection,
       mobileKeyboardHideRefit,
@@ -393,6 +422,9 @@ export function App() {
     selectedPaneId,
     terminalInputTransport,
     terminalInputBatchDelayMs,
+    contentInsetTopPx,
+    contentInsetBottomPx,
+    mobileControlsScalePercent,
     mobileTerminalTapTarget,
     mobileTouchSelection,
     mobileKeyboardHideRefit,
@@ -1106,8 +1138,19 @@ export function App() {
   };
 
   const renderTerminal = !isCompactLayout || showDetail;
-  const appStyle = { "--sidebar-w": `${sidebarWidth}px` } as CSSProperties &
-    Record<"--sidebar-w", string>;
+  const appStyle = {
+    "--sidebar-w": `${sidebarWidth}px`,
+    "--content-inset-top": `${contentInsetTopPx}px`,
+    "--content-inset-bottom": `${contentInsetBottomPx}px`,
+    "--mobile-controls-scale": String(mobileControlsScalePercent / 100),
+  } as CSSProperties &
+    Record<
+      | "--sidebar-w"
+      | "--content-inset-top"
+      | "--content-inset-bottom"
+      | "--mobile-controls-scale",
+      string
+    >;
 
   return (
     <div
@@ -1377,6 +1420,12 @@ export function App() {
           onTerminalInputTransport={setTerminalInputTransport}
           terminalInputBatchDelayMs={terminalInputBatchDelayMs}
           onTerminalInputBatchDelayMs={setTerminalInputBatchDelayMs}
+          contentInsetTopPx={contentInsetTopPx}
+          onContentInsetTopPx={setContentInsetTopPx}
+          contentInsetBottomPx={contentInsetBottomPx}
+          onContentInsetBottomPx={setContentInsetBottomPx}
+          mobileControlsScalePercent={mobileControlsScalePercent}
+          onMobileControlsScalePercent={setMobileControlsScalePercent}
           mobileTerminalTapTarget={mobileTerminalTapTarget}
           onMobileTerminalTapTarget={setMobileTerminalTapTarget}
           mobileTouchSelection={mobileTouchSelection}

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -1,4 +1,13 @@
-import { Check, Plus, Server, Smartphone, SquareTerminal, X } from "lucide-react";
+import {
+  Check,
+  Plus,
+  RotateCcw,
+  Server,
+  SlidersHorizontal,
+  Smartphone,
+  SquareTerminal,
+  X,
+} from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   duplicateBackend,
@@ -6,6 +15,20 @@ import {
   useBridge,
 } from "./bridge";
 import type { BridgeBackendProfile } from "./bridge";
+import {
+  DEFAULT_CONTENT_INSET_BOTTOM_PX,
+  DEFAULT_CONTENT_INSET_TOP_PX,
+  DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
+  MAX_CONTENT_INSET_BOTTOM_PX,
+  MAX_CONTENT_INSET_TOP_PX,
+  MAX_MOBILE_CONTROLS_SCALE_PERCENT,
+  MIN_CONTENT_INSET_BOTTOM_PX,
+  MIN_CONTENT_INSET_TOP_PX,
+  MIN_MOBILE_CONTROLS_SCALE_PERCENT,
+  parseContentInsetBottomPx,
+  parseContentInsetTopPx,
+  parseMobileControlsScalePercent,
+} from "./displayPrefs";
 import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
 import { TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS } from "./terminalInputTransport";
 import type { TerminalInputTransport } from "./terminalInputTransport";
@@ -16,6 +39,12 @@ type Props = {
   onTerminalInputTransport: (transport: TerminalInputTransport) => void;
   terminalInputBatchDelayMs: number;
   onTerminalInputBatchDelayMs: (delayMs: number) => void;
+  contentInsetTopPx: number;
+  onContentInsetTopPx: (value: number) => void;
+  contentInsetBottomPx: number;
+  onContentInsetBottomPx: (value: number) => void;
+  mobileControlsScalePercent: number;
+  onMobileControlsScalePercent: (value: number) => void;
   mobileTerminalTapTarget: MobileTerminalTapTarget;
   onMobileTerminalTapTarget: (target: MobileTerminalTapTarget) => void;
   mobileTouchSelection: boolean;
@@ -33,7 +62,7 @@ type FormState = {
 };
 
 type SelectionMode = "same-origin" | "new" | "backend";
-type SettingsArea = "bridge" | "terminal" | "mobile";
+type SettingsArea = "bridge" | "display" | "terminal" | "mobile";
 
 const emptyForm: FormState = {
   id: null,
@@ -47,6 +76,12 @@ export function BackendSettingsDialog({
   onTerminalInputTransport,
   terminalInputBatchDelayMs,
   onTerminalInputBatchDelayMs,
+  contentInsetTopPx,
+  onContentInsetTopPx,
+  contentInsetBottomPx,
+  onContentInsetBottomPx,
+  mobileControlsScalePercent,
+  onMobileControlsScalePercent,
   mobileTerminalTapTarget,
   onMobileTerminalTapTarget,
   mobileTouchSelection,
@@ -207,6 +242,7 @@ export function BackendSettingsDialog({
   const showSameOrigin = bridge.sameOriginAvailable;
   const areas: { id: SettingsArea; label: string; icon: typeof Server }[] = [
     { id: "bridge", label: "Bridge", icon: Server },
+    { id: "display", label: "Display", icon: SlidersHorizontal },
     { id: "terminal", label: "Terminal", icon: SquareTerminal },
     ...(showMobileTerminalSettings
       ? [{ id: "mobile" as const, label: "Mobile", icon: Smartphone }]
@@ -405,6 +441,53 @@ export function BackendSettingsDialog({
               </>
             ) : null}
 
+            {activeArea === "display" ? (
+              <div className="settings-section settings-section-flat">
+                <div className="settings-label">Display spacing</div>
+                <div className="settings-row">
+                  <span>Top padding</span>
+                  <NumberSettingControl
+                    ariaLabel="Top padding"
+                    value={contentInsetTopPx}
+                    min={MIN_CONTENT_INSET_TOP_PX}
+                    max={MAX_CONTENT_INSET_TOP_PX}
+                    unit="px"
+                    defaultValue={DEFAULT_CONTENT_INSET_TOP_PX}
+                    onChange={(value) => onContentInsetTopPx(parseContentInsetTopPx(value))}
+                  />
+                </div>
+                <div className="settings-row">
+                  <span>Bottom padding</span>
+                  <NumberSettingControl
+                    ariaLabel="Bottom padding"
+                    value={contentInsetBottomPx}
+                    min={MIN_CONTENT_INSET_BOTTOM_PX}
+                    max={MAX_CONTENT_INSET_BOTTOM_PX}
+                    unit="px"
+                    defaultValue={DEFAULT_CONTENT_INSET_BOTTOM_PX}
+                    onChange={(value) => onContentInsetBottomPx(parseContentInsetBottomPx(value))}
+                  />
+                </div>
+                {showMobileTerminalSettings ? (
+                  <div className="settings-row settings-slider-row">
+                    <span>Mobile input controls size</span>
+                    <SliderSettingControl
+                      ariaLabel="Mobile input controls size"
+                      value={mobileControlsScalePercent}
+                      min={MIN_MOBILE_CONTROLS_SCALE_PERCENT}
+                      max={MAX_MOBILE_CONTROLS_SCALE_PERCENT}
+                      step={5}
+                      unit="%"
+                      defaultValue={DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT}
+                      onChange={(value) =>
+                        onMobileControlsScalePercent(parseMobileControlsScalePercent(value))
+                      }
+                    />
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
             {activeArea === "terminal" ? (
               <div className="settings-section settings-section-flat">
                 <div className="settings-label">Terminal transport</div>
@@ -526,6 +609,171 @@ export function BackendSettingsDialog({
         </div>
       </form>
     </div>
+  );
+}
+
+function NumberSettingControl({
+  ariaLabel,
+  value,
+  min,
+  max,
+  unit,
+  defaultValue,
+  onChange,
+}: {
+  ariaLabel: string;
+  value: number;
+  min: number;
+  max: number;
+  unit: string;
+  defaultValue: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <div className="settings-value-control">
+      <DraftNumberInput
+        ariaLabel={ariaLabel}
+        value={value}
+        min={min}
+        max={max}
+        step={1}
+        onCommit={onChange}
+      />
+      <span className="settings-unit">{unit}</span>
+      <ResetSettingButton
+        disabled={value === defaultValue}
+        label={`Reset ${ariaLabel.toLowerCase()}`}
+        onClick={() => onChange(defaultValue)}
+      />
+    </div>
+  );
+}
+
+function SliderSettingControl({
+  ariaLabel,
+  value,
+  min,
+  max,
+  step,
+  unit,
+  defaultValue,
+  onChange,
+}: {
+  ariaLabel: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  unit: string;
+  defaultValue: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <div className="settings-slider-control">
+      <input
+        className="settings-range"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        aria-label={ariaLabel}
+        onChange={(event) => onChange(event.currentTarget.valueAsNumber)}
+      />
+      <div className="settings-value-control">
+        <DraftNumberInput
+          ariaLabel={`${ariaLabel} percent`}
+          value={value}
+          min={min}
+          max={max}
+          step={step}
+          onCommit={onChange}
+        />
+        <span className="settings-unit">{unit}</span>
+        <ResetSettingButton
+          disabled={value === defaultValue}
+          label={`Reset ${ariaLabel.toLowerCase()}`}
+          onClick={() => onChange(defaultValue)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function DraftNumberInput({
+  ariaLabel,
+  value,
+  min,
+  max,
+  step,
+  onCommit,
+}: {
+  ariaLabel: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onCommit: (value: number) => void;
+}) {
+  const [draft, setDraft] = useState(String(value));
+
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  const commit = () => {
+    const next = Number(draft);
+    if (Number.isFinite(next)) {
+      onCommit(next);
+      return;
+    }
+    setDraft(String(value));
+  };
+
+  return (
+    <input
+      className="settings-number-field"
+      type="number"
+      min={min}
+      max={max}
+      step={step}
+      value={draft}
+      aria-label={ariaLabel}
+      onFocus={(event) => event.currentTarget.select()}
+      onChange={(event) => setDraft(event.currentTarget.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.currentTarget.blur();
+        } else if (event.key === "Escape") {
+          setDraft(String(value));
+          event.currentTarget.blur();
+        }
+      }}
+    />
+  );
+}
+
+function ResetSettingButton({
+  disabled,
+  label,
+  onClick,
+}: {
+  disabled: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className="settings-reset icon-btn"
+      type="button"
+      aria-label={label}
+      title="Reset"
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <RotateCcw size={13} />
+    </button>
   );
 }
 

--- a/web/src/displayPrefs.test.ts
+++ b/web/src/displayPrefs.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CONTENT_INSET_BOTTOM_PX,
+  DEFAULT_CONTENT_INSET_TOP_PX,
+  DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
+  MAX_CONTENT_INSET_BOTTOM_PX,
+  MAX_CONTENT_INSET_TOP_PX,
+  MAX_MOBILE_CONTROLS_SCALE_PERCENT,
+  MIN_MOBILE_CONTROLS_SCALE_PERCENT,
+  parseContentInsetBottomPx,
+  parseContentInsetTopPx,
+  parseMobileControlsScalePercent,
+} from "./displayPrefs";
+
+describe("display preferences", () => {
+  it("parses and clamps content inset values", () => {
+    expect(parseContentInsetTopPx(16)).toBe(16);
+    expect(parseContentInsetTopPx(16.7)).toBe(17);
+    expect(parseContentInsetTopPx(-4)).toBe(DEFAULT_CONTENT_INSET_TOP_PX);
+    expect(parseContentInsetTopPx(999)).toBe(MAX_CONTENT_INSET_TOP_PX);
+
+    expect(parseContentInsetBottomPx(24)).toBe(24);
+    expect(parseContentInsetBottomPx(24.4)).toBe(24);
+    expect(parseContentInsetBottomPx(-1)).toBe(DEFAULT_CONTENT_INSET_BOTTOM_PX);
+    expect(parseContentInsetBottomPx(999)).toBe(MAX_CONTENT_INSET_BOTTOM_PX);
+  });
+
+  it("falls back for invalid content inset values", () => {
+    expect(parseContentInsetTopPx("16")).toBe(DEFAULT_CONTENT_INSET_TOP_PX);
+    expect(parseContentInsetBottomPx(Number.NaN)).toBe(DEFAULT_CONTENT_INSET_BOTTOM_PX);
+  });
+
+  it("parses and clamps the mobile controls scale", () => {
+    expect(parseMobileControlsScalePercent(125)).toBe(125);
+    expect(parseMobileControlsScalePercent(124.6)).toBe(125);
+    expect(parseMobileControlsScalePercent(50)).toBe(MIN_MOBILE_CONTROLS_SCALE_PERCENT);
+    expect(parseMobileControlsScalePercent(200)).toBe(MAX_MOBILE_CONTROLS_SCALE_PERCENT);
+  });
+
+  it("falls back for invalid mobile controls scale values", () => {
+    expect(parseMobileControlsScalePercent(null)).toBe(DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT);
+    expect(parseMobileControlsScalePercent("100")).toBe(DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT);
+  });
+});

--- a/web/src/displayPrefs.ts
+++ b/web/src/displayPrefs.ts
@@ -1,0 +1,44 @@
+export const DEFAULT_CONTENT_INSET_TOP_PX = 0;
+export const DEFAULT_CONTENT_INSET_BOTTOM_PX = 0;
+export const DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT = 100;
+
+export const MIN_CONTENT_INSET_TOP_PX = 0;
+export const MAX_CONTENT_INSET_TOP_PX = 96;
+export const MIN_CONTENT_INSET_BOTTOM_PX = 0;
+export const MAX_CONTENT_INSET_BOTTOM_PX = 160;
+export const MIN_MOBILE_CONTROLS_SCALE_PERCENT = 80;
+export const MAX_MOBILE_CONTROLS_SCALE_PERCENT = 150;
+
+export function parseContentInsetTopPx(value: unknown) {
+  return parseClampedInteger(
+    value,
+    MIN_CONTENT_INSET_TOP_PX,
+    MAX_CONTENT_INSET_TOP_PX,
+    DEFAULT_CONTENT_INSET_TOP_PX,
+  );
+}
+
+export function parseContentInsetBottomPx(value: unknown) {
+  return parseClampedInteger(
+    value,
+    MIN_CONTENT_INSET_BOTTOM_PX,
+    MAX_CONTENT_INSET_BOTTOM_PX,
+    DEFAULT_CONTENT_INSET_BOTTOM_PX,
+  );
+}
+
+export function parseMobileControlsScalePercent(value: unknown) {
+  return parseClampedInteger(
+    value,
+    MIN_MOBILE_CONTROLS_SCALE_PERCENT,
+    MAX_MOBILE_CONTROLS_SCALE_PERCENT,
+    DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
+  );
+}
+
+function parseClampedInteger(value: unknown, min: number, max: number, fallback: number) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, Math.round(value)));
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -52,6 +52,9 @@
   --r-md: 9px;
   --r-lg: 13px;
   --sidebar-w: 320px;
+  --content-inset-top: 0px;
+  --content-inset-bottom: 0px;
+  --mobile-controls-scale: 1;
 
   --ui:
     "Geist Variable", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
@@ -103,6 +106,7 @@ button {
   grid-template-columns: var(--sidebar-w) minmax(0, 1fr);
   width: 100%;
   height: 100%;
+  padding-block: var(--content-inset-top) var(--content-inset-bottom);
   overflow: hidden;
   background: var(--app-bg);
   transition: grid-template-columns 200ms cubic-bezier(0.4, 0, 0.2, 1);
@@ -1072,10 +1076,20 @@ button {
 }
 
 .terminal-mobile-controls {
+  --mobile-control-gap: calc(5px * var(--mobile-controls-scale));
+  --mobile-key-height: calc(30px * var(--mobile-controls-scale));
+  --mobile-key-min-width: calc(34px * var(--mobile-controls-scale));
+  --mobile-key-icon-width: calc(34px * var(--mobile-controls-scale));
+  --mobile-key-padding-x: calc(7px * var(--mobile-controls-scale));
+  --mobile-key-panel-padding-x: calc(3px * var(--mobile-controls-scale));
+  --mobile-input-row-height: calc(34px * var(--mobile-controls-scale));
+  --mobile-input-padding-x: calc(10px * var(--mobile-controls-scale));
+  --mobile-send-width: calc(38px * var(--mobile-controls-scale));
   display: none;
   flex: 0 0 auto;
-  gap: 5px;
-  padding: 6px max(8px, env(safe-area-inset-right)) 7px max(8px, env(safe-area-inset-left));
+  gap: var(--mobile-control-gap);
+  padding: calc(6px * var(--mobile-controls-scale)) max(8px, env(safe-area-inset-right))
+    calc(7px * var(--mobile-controls-scale)) max(8px, env(safe-area-inset-left));
   border-top: 1px solid var(--line);
   background: color-mix(in srgb, var(--mantle) 94%, black);
 }
@@ -1087,7 +1101,7 @@ button {
 .term-input-row {
   display: flex;
   min-width: 0;
-  gap: 5px;
+  gap: var(--mobile-control-gap);
 }
 
 .term-key-strip {
@@ -1109,7 +1123,7 @@ button {
   flex: 0 0 auto;
   justify-content: flex-end;
   margin-left: auto;
-  padding-left: 7px;
+  padding-left: var(--mobile-key-padding-x);
   border-left: 1px solid var(--line);
 }
 
@@ -1122,14 +1136,14 @@ button {
 .term-send {
   display: inline-grid;
   min-width: 0;
-  height: 30px;
+  height: var(--mobile-key-height);
   flex: 0 0 auto;
   place-items: center;
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   background: var(--surface0);
   color: var(--text);
-  font-size: 11px;
+  font-size: clamp(10px, calc(11px * var(--mobile-controls-scale)), 16px);
   line-height: 1;
   white-space: nowrap;
   user-select: none;
@@ -1137,18 +1151,28 @@ button {
 }
 
 .term-key {
-  min-width: 34px;
-  padding: 0 7px;
+  min-width: var(--mobile-key-min-width);
+  padding: 0 var(--mobile-key-padding-x);
 }
 
 .term-key-icon {
-  width: 34px;
+  width: var(--mobile-key-icon-width);
   padding: 0;
+}
+
+.term-key-icon svg {
+  width: calc(15px * var(--mobile-controls-scale));
+  height: calc(15px * var(--mobile-controls-scale));
+}
+
+.term-send svg {
+  width: calc(16px * var(--mobile-controls-scale));
+  height: calc(16px * var(--mobile-controls-scale));
 }
 
 .term-key-panel .term-key {
   width: 100%;
-  padding: 0 3px;
+  padding: 0 var(--mobile-key-panel-padding-x);
 }
 
 .term-key[data-active="true"] {
@@ -1166,7 +1190,7 @@ button {
 }
 
 .term-input-row {
-  height: 34px;
+  height: var(--mobile-input-row-height);
 }
 
 .term-native-input {
@@ -1175,10 +1199,10 @@ button {
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   outline: none;
-  padding: 0 10px;
+  padding: 0 var(--mobile-input-padding-x);
   background: var(--crust);
   color: var(--text);
-  font-size: 13px;
+  font-size: clamp(11px, calc(13px * var(--mobile-controls-scale)), 20px);
 }
 
 .term-native-input:focus {
@@ -1187,8 +1211,8 @@ button {
 }
 
 .term-send {
-  width: 38px;
-  flex: 0 0 38px;
+  width: var(--mobile-send-width);
+  flex: 0 0 var(--mobile-send-width);
   background: color-mix(in srgb, var(--blue) 22%, var(--surface0));
   color: var(--blue);
 }
@@ -1663,6 +1687,61 @@ button {
   background: var(--surface1);
 }
 
+.settings-value-control {
+  display: grid;
+  grid-template-columns: 74px auto 30px;
+  align-items: center;
+  gap: 6px;
+  justify-self: end;
+}
+
+.settings-slider-control {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: min(340px, 100%);
+}
+
+.settings-range {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.settings-number-field {
+  width: 74px;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--surface1);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  background: var(--crust);
+  font: inherit;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  outline: none;
+}
+
+.settings-number-field:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.settings-unit {
+  color: var(--overlay1);
+  font-size: 12px;
+}
+
+.settings-reset {
+  width: 30px;
+  height: 30px;
+}
+
+.settings-reset:disabled {
+  cursor: default;
+  opacity: 0.42;
+}
+
 .field-label {
   display: grid;
   gap: 6px;
@@ -1847,10 +1926,10 @@ button {
   .sidebar,
   .stage {
     position: fixed;
-    top: 0;
+    top: var(--content-inset-top);
     left: 0;
     width: 100vw;
-    height: 100dvh;
+    height: calc(100dvh - var(--content-inset-top) - var(--content-inset-bottom));
     flex: none;
     transition: transform 260ms cubic-bezier(0.4, 0, 0.2, 1);
   }
@@ -1907,6 +1986,12 @@ button {
   .settings-row {
     grid-template-columns: 1fr;
   }
+
+  .settings-value-control,
+  .settings-slider-control {
+    justify-self: stretch;
+    width: 100%;
+  }
 }
 
 .app[data-compact="true"] {
@@ -1925,10 +2010,10 @@ button {
 .app[data-compact="true"] .sidebar,
 .app[data-compact="true"] .stage {
   position: fixed;
-  top: 0;
+  top: var(--content-inset-top);
   left: 0;
   width: 100vw;
-  height: 100dvh;
+  height: calc(100dvh - var(--content-inset-top) - var(--content-inset-bottom));
   flex: none;
   transition: transform 260ms cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -1978,31 +2063,31 @@ button {
 }
 
 .app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-overlay {
-  bottom: 120px;
+  bottom: calc(120px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-upload-status {
-  bottom: 122px;
+  bottom: calc(122px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-selection-sheet {
-  bottom: 122px;
+  bottom: calc(122px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"]
   .terminal-stage:has(.terminal-mobile-controls[data-expanded="true"])
   .terminal-overlay {
-  bottom: 158px;
+  bottom: calc(158px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"]
   .terminal-stage:has(.terminal-mobile-controls[data-expanded="true"])
   .terminal-upload-status {
-  bottom: 160px;
+  bottom: calc(160px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"]
   .terminal-stage:has(.terminal-mobile-controls[data-expanded="true"])
   .terminal-selection-sheet {
-  bottom: 160px;
+  bottom: calc(160px * var(--mobile-controls-scale));
 }


### PR DESCRIPTION
## Summary
- add Display settings for top and bottom app padding
- add a mobile input controls size setting with reset behavior
- persist and clamp new display preferences with parser tests

## Verification
- npm run test:web
- npm run lint:web
- npm run build:web
- ANDROID_HOME="/home/kevin/.local/android-sdk" ANDROID_SDK_ROOT="/home/kevin/.local/android-sdk" PATH="/home/kevin/.local/android-sdk/platform-tools:/home/kevin/.local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/kevin/.bun/bin:/home/kevin/.bun/bin:/home/kevin/.cargo/bin:/home/kevin/.local/bin:/home/kevin/.bun/bin:/home/kevin/.bun/bin:/home/kevin/.bun/bin:/home/kevin/.codex/tmp/arg0/codex-arg0dsbiMX:/home/kevin/.local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin" npm run android:build:debug