### PR TITLE
Add configurable terminal output batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Changed
 
+- Coalesced fast terminal output bursts in the bridge before forwarding them to browser clients,
+  reducing WebSocket frame churn during rapid TUI redraws.
 - Reworked Settings into Bridge, Terminal, and Mobile areas, with horizontal area tabs on narrow
   screens. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
 - Improved browser startup by lazy-loading the terminal renderer with retry after load failures,
@@ -27,6 +29,9 @@
   [PR #10](https://github.com/kcosr/herdr-web/pull/10)
 
 ### Fixed
+
+- Cleared stale terminal content immediately when switching panes in the single-terminal mobile
+  detail view, and delayed transient connecting status during fast terminal attaches.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,6 @@
 
 ### Fixed
 
-- Cleared stale terminal content immediately when switching panes in the single-terminal mobile
-  detail view, and delayed transient connecting status during fast terminal attaches.
-
 ### Removed
 
 ## [0.1.1] - 2026-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@
 ### Changed
 
 - Coalesced fast terminal output bursts in the bridge before forwarding them to browser clients,
-  reducing WebSocket frame churn during rapid TUI redraws.
+  with a per-client Terminal output batching setting for tuning frame churn during rapid TUI
+  redraws; concepts derived from the @roy-levi-amazon fork.
+  [PR #14](https://github.com/kcosr/herdr-web/pull/14)
 - Reworked Settings into Bridge, Terminal, and Mobile areas, with horizontal area tabs on narrow
   screens. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
 - Improved browser startup by lazy-loading the terminal renderer with retry after load failures,

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -24,6 +24,7 @@ use axum::{extract::Request as AxumRequest, Json, Router};
 use futures_util::{SinkExt, StreamExt};
 use herdr_compat::TryClone as _;
 use serde::{Deserialize, Serialize};
+use tokio::time::Instant;
 use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
 use tower_http::services::ServeDir;
@@ -50,6 +51,10 @@ const DEFAULT_STATIC_DIR: &str = "web/dist";
 const MIN_TERMINAL_ATTACH_PROTOCOL: u32 = 13;
 const MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
 const MAX_TERMINAL_INPUT_CHUNK_BYTES: usize = 768 * 1024;
+const TERMINAL_OUTPUT_COALESCE_WINDOW: Duration = Duration::from_millis(8);
+const TERMINAL_OUTPUT_COALESCE_MAX_BYTES: usize = 32 * 1024;
+const TERMINAL_OUTPUT_COALESCE_MAX_CHUNKS: usize = 256;
+const TERMINAL_OUTPUT_STATS_INTERVAL: Duration = Duration::from_secs(10);
 const DAEMON_STATUS_TIMEOUT: Duration = Duration::from_secs(5);
 const ACTIVITY_WATCHER_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const ACTIVITY_WATCHER_MAX_BACKOFF: Duration = Duration::from_secs(30);
@@ -176,8 +181,347 @@ fn default_scroll_lines() -> u16 {
 
 #[derive(Debug, Clone)]
 enum TerminalOutput {
-    Bytes(Vec<u8>),
+    Bytes(Bytes),
     Close(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalOutputFlushReason {
+    Timer,
+    ByteThreshold,
+    ChunkThreshold,
+    Close,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TerminalOutputCoalescingDecision {
+    SendNow(Bytes),
+    Pending,
+    FlushPending(TerminalOutputFlushReason),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct TerminalOutputCoalescingStats {
+    source_frames: u64,
+    source_bytes: u64,
+    sent_frames: u64,
+    sent_bytes: u64,
+    immediate_frames: u64,
+    coalesced_source_frames: u64,
+    coalesced_sent_frames: u64,
+    timer_flushes: u64,
+    byte_flushes: u64,
+    chunk_flushes: u64,
+    single_chunk_flushes: u64,
+    merged_flushes: u64,
+    lagged_events: u64,
+    lagged_frames: u64,
+    max_pending_bytes: usize,
+    max_pending_chunks: usize,
+    total_flush_latency_us: u128,
+    max_flush_latency_us: u128,
+}
+
+impl TerminalOutputCoalescingStats {
+    fn record_source(&mut self, bytes: usize) {
+        self.source_frames += 1;
+        self.source_bytes += bytes as u64;
+    }
+
+    fn record_immediate_send(&mut self, bytes: usize) {
+        self.sent_frames += 1;
+        self.sent_bytes += bytes as u64;
+        self.immediate_frames += 1;
+    }
+
+    fn record_pending(&mut self, bytes: usize, chunks: usize) {
+        self.max_pending_bytes = self.max_pending_bytes.max(bytes);
+        self.max_pending_chunks = self.max_pending_chunks.max(chunks);
+    }
+
+    fn record_flush_reason(&mut self, reason: TerminalOutputFlushReason) {
+        match reason {
+            TerminalOutputFlushReason::Timer => self.timer_flushes += 1,
+            TerminalOutputFlushReason::ByteThreshold => self.byte_flushes += 1,
+            TerminalOutputFlushReason::ChunkThreshold => self.chunk_flushes += 1,
+            TerminalOutputFlushReason::Close => {}
+        }
+    }
+
+    fn record_coalesced_send(&mut self, source_chunks: usize, bytes: usize, latency: Duration) {
+        self.sent_frames += 1;
+        self.sent_bytes += bytes as u64;
+        self.coalesced_source_frames += source_chunks as u64;
+        self.coalesced_sent_frames += 1;
+        if source_chunks <= 1 {
+            self.single_chunk_flushes += 1;
+        } else {
+            self.merged_flushes += 1;
+        }
+
+        let latency_us = latency.as_micros();
+        self.total_flush_latency_us += latency_us;
+        self.max_flush_latency_us = self.max_flush_latency_us.max(latency_us);
+    }
+
+    fn record_lagged(&mut self, frames: u64) {
+        self.lagged_events += 1;
+        self.lagged_frames += frames;
+    }
+
+    fn has_activity(&self) -> bool {
+        self.source_frames > 0 || self.lagged_events > 0
+    }
+
+    fn has_source_frames(&self) -> bool {
+        self.source_frames > 0
+    }
+
+    fn frames_saved(&self) -> u64 {
+        self.source_frames.saturating_sub(self.sent_frames)
+    }
+
+    fn coalescing_ratio(&self) -> f64 {
+        if self.sent_frames == 0 {
+            return 0.0;
+        }
+        self.source_frames as f64 / self.sent_frames as f64
+    }
+
+    fn avg_source_frame_bytes(&self) -> f64 {
+        if self.source_frames == 0 {
+            return 0.0;
+        }
+        self.source_bytes as f64 / self.source_frames as f64
+    }
+
+    fn avg_sent_frame_bytes(&self) -> f64 {
+        if self.sent_frames == 0 {
+            return 0.0;
+        }
+        self.sent_bytes as f64 / self.sent_frames as f64
+    }
+
+    fn avg_flush_latency_us(&self) -> f64 {
+        if self.coalesced_sent_frames == 0 {
+            return 0.0;
+        }
+        self.total_flush_latency_us as f64 / self.coalesced_sent_frames as f64
+    }
+}
+
+#[derive(Debug)]
+struct TerminalOutputCoalescer {
+    pending: Vec<Bytes>,
+    pending_bytes: usize,
+    pending_started_at: Option<Instant>,
+    deadline: Option<Instant>,
+    interval_stats: TerminalOutputCoalescingStats,
+    lifetime_stats: TerminalOutputCoalescingStats,
+    last_stats_log_at: Instant,
+}
+
+impl TerminalOutputCoalescer {
+    fn new(now: Instant) -> Self {
+        Self {
+            pending: Vec::new(),
+            pending_bytes: 0,
+            pending_started_at: None,
+            deadline: None,
+            interval_stats: TerminalOutputCoalescingStats::default(),
+            lifetime_stats: TerminalOutputCoalescingStats::default(),
+            last_stats_log_at: now,
+        }
+    }
+
+    fn deadline(&self) -> Option<Instant> {
+        self.deadline
+    }
+
+    fn push_bytes(&mut self, bytes: Bytes, now: Instant) -> TerminalOutputCoalescingDecision {
+        let byte_count = bytes.len();
+        self.record_source(byte_count);
+
+        if self.deadline.is_none() {
+            self.deadline = Some(now + TERMINAL_OUTPUT_COALESCE_WINDOW);
+            self.record_immediate_send(byte_count);
+            return TerminalOutputCoalescingDecision::SendNow(bytes);
+        }
+
+        if self.pending.is_empty() {
+            self.pending_started_at = Some(now);
+        }
+        self.pending_bytes += byte_count;
+        self.pending.push(bytes);
+        self.record_pending();
+
+        if self.pending_bytes >= TERMINAL_OUTPUT_COALESCE_MAX_BYTES {
+            TerminalOutputCoalescingDecision::FlushPending(TerminalOutputFlushReason::ByteThreshold)
+        } else if self.pending.len() >= TERMINAL_OUTPUT_COALESCE_MAX_CHUNKS {
+            TerminalOutputCoalescingDecision::FlushPending(
+                TerminalOutputFlushReason::ChunkThreshold,
+            )
+        } else {
+            TerminalOutputCoalescingDecision::Pending
+        }
+    }
+
+    fn handle_deadline(&mut self) -> Option<TerminalOutputFlushReason> {
+        self.deadline?;
+        if self.pending.is_empty() {
+            self.deadline = None;
+            return None;
+        }
+        Some(TerminalOutputFlushReason::Timer)
+    }
+
+    fn flush_pending(&mut self, reason: TerminalOutputFlushReason, now: Instant) -> Option<Bytes> {
+        if self.pending.is_empty() {
+            self.pending_bytes = 0;
+            self.pending_started_at = None;
+            if matches!(reason, TerminalOutputFlushReason::Close) {
+                self.deadline = None;
+            }
+            return None;
+        }
+
+        self.record_flush_reason(reason);
+        let source_chunks = self.pending.len();
+        let latency = self
+            .pending_started_at
+            .map(|started_at| now.saturating_duration_since(started_at))
+            .unwrap_or_default();
+        let Some(bytes) = drain_terminal_output_pending(&mut self.pending, &mut self.pending_bytes)
+        else {
+            self.pending_started_at = None;
+            return None;
+        };
+
+        self.pending_started_at = None;
+        if matches!(reason, TerminalOutputFlushReason::Close) {
+            self.deadline = None;
+        } else {
+            self.deadline = Some(now + TERMINAL_OUTPUT_COALESCE_WINDOW);
+        }
+        self.record_coalesced_send(source_chunks, bytes.len(), latency);
+        Some(bytes)
+    }
+
+    fn record_lagged(&mut self, frames: u64) {
+        self.interval_stats.record_lagged(frames);
+        self.lifetime_stats.record_lagged(frames);
+    }
+
+    fn maybe_log_interval(&mut self, terminal_id: &str, now: Instant) {
+        if now.duration_since(self.last_stats_log_at) < TERMINAL_OUTPUT_STATS_INTERVAL {
+            return;
+        }
+
+        if self.interval_stats.has_source_frames() {
+            log_terminal_output_coalescing_stats(terminal_id, "interval", &self.interval_stats);
+            self.interval_stats = TerminalOutputCoalescingStats::default();
+        }
+        self.last_stats_log_at = now;
+    }
+
+    fn log_final(&self, terminal_id: &str) {
+        if self.interval_stats.has_activity() {
+            log_terminal_output_coalescing_stats(
+                terminal_id,
+                "final_interval",
+                &self.interval_stats,
+            );
+        }
+        if self.lifetime_stats.has_activity() {
+            log_terminal_output_coalescing_stats(terminal_id, "lifetime", &self.lifetime_stats);
+        }
+    }
+
+    fn record_source(&mut self, bytes: usize) {
+        self.interval_stats.record_source(bytes);
+        self.lifetime_stats.record_source(bytes);
+    }
+
+    fn record_immediate_send(&mut self, bytes: usize) {
+        self.interval_stats.record_immediate_send(bytes);
+        self.lifetime_stats.record_immediate_send(bytes);
+    }
+
+    fn record_pending(&mut self) {
+        self.interval_stats
+            .record_pending(self.pending_bytes, self.pending.len());
+        self.lifetime_stats
+            .record_pending(self.pending_bytes, self.pending.len());
+    }
+
+    fn record_flush_reason(&mut self, reason: TerminalOutputFlushReason) {
+        self.interval_stats.record_flush_reason(reason);
+        self.lifetime_stats.record_flush_reason(reason);
+    }
+
+    fn record_coalesced_send(&mut self, chunks: usize, bytes: usize, latency: Duration) {
+        self.interval_stats
+            .record_coalesced_send(chunks, bytes, latency);
+        self.lifetime_stats
+            .record_coalesced_send(chunks, bytes, latency);
+    }
+}
+
+fn drain_terminal_output_pending(
+    pending: &mut Vec<Bytes>,
+    pending_bytes: &mut usize,
+) -> Option<Bytes> {
+    if pending.is_empty() {
+        *pending_bytes = 0;
+        return None;
+    }
+
+    let byte_count = *pending_bytes;
+    *pending_bytes = 0;
+    if pending.len() == 1 {
+        return pending.pop();
+    }
+
+    let mut output = Vec::with_capacity(byte_count);
+    for chunk in pending.drain(..) {
+        output.extend_from_slice(&chunk);
+    }
+    Some(Bytes::from(output))
+}
+
+fn log_terminal_output_coalescing_stats(
+    terminal_id: &str,
+    scope: &str,
+    stats: &TerminalOutputCoalescingStats,
+) {
+    debug!(
+        terminal_id = %terminal_id,
+        scope = %scope,
+        source_frames = stats.source_frames,
+        source_bytes = stats.source_bytes,
+        sent_frames = stats.sent_frames,
+        sent_bytes = stats.sent_bytes,
+        immediate_frames = stats.immediate_frames,
+        coalesced_source_frames = stats.coalesced_source_frames,
+        coalesced_sent_frames = stats.coalesced_sent_frames,
+        timer_flushes = stats.timer_flushes,
+        byte_flushes = stats.byte_flushes,
+        chunk_flushes = stats.chunk_flushes,
+        single_chunk_flushes = stats.single_chunk_flushes,
+        merged_flushes = stats.merged_flushes,
+        lagged_events = stats.lagged_events,
+        lagged_frames = stats.lagged_frames,
+        max_pending_bytes = stats.max_pending_bytes,
+        max_pending_chunks = stats.max_pending_chunks,
+        total_flush_latency_us = stats.total_flush_latency_us,
+        max_flush_latency_us = stats.max_flush_latency_us,
+        coalescing_ratio = stats.coalescing_ratio(),
+        frames_saved = stats.frames_saved(),
+        avg_source_frame_bytes = stats.avg_source_frame_bytes(),
+        avg_sent_frame_bytes = stats.avg_sent_frame_bytes(),
+        avg_flush_latency_us = stats.avg_flush_latency_us(),
+        "terminal output coalescing stats"
+    );
 }
 
 #[derive(Clone)]
@@ -1681,6 +2025,7 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
 
     let write_tx = session.write_tx.clone();
     let mut terminal_rx = session.output_tx.subscribe();
+    let mut output_coalescer = TerminalOutputCoalescer::new(Instant::now());
     let _ = write_tx.send(ClientMessage::Resize {
         cols,
         rows,
@@ -1689,46 +2034,147 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
     });
 
     loop {
-        tokio::select! {
-            output = terminal_rx.recv() => {
-                match output {
-                    Ok(output) => match output {
-                    TerminalOutput::Bytes(bytes) => {
-                        if ws_sender.send(Message::Binary(bytes.into())).await.is_err() {
-                            break;
-                        }
-                    }
-                    TerminalOutput::Close(reason) => {
-                        let _ = ws_sender.send(Message::Text(close_message(&reason).into())).await;
+        if let Some(deadline) = output_coalescer.deadline() {
+            tokio::select! {
+                biased;
+                _ = tokio::time::sleep_until(deadline) => {
+                    if !handle_terminal_output_deadline(
+                        &terminal_id,
+                        &mut ws_sender,
+                        &mut output_coalescer,
+                    )
+                    .await
+                    {
                         break;
                     }
-                    },
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }
-            }
-            Some(message) = ws_receiver.next() => {
-                match message {
-                    Ok(Message::Text(text)) => {
-                        if handle_terminal_text_frame(&write_tx, text.as_str()).is_err() {
-                            break;
-                        }
+                Some(message) = ws_receiver.next() => {
+                    if !handle_terminal_client_message(&write_tx, message) {
+                        break;
                     }
-                    Ok(Message::Binary(bytes)) => {
-                        if send_terminal_input_chunks(&write_tx, &bytes).is_err() {
-                            break;
-                        }
-                    }
-                    Ok(Message::Close(_)) => break,
-                    Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {}
-                    Err(_) => break,
                 }
+                output = terminal_rx.recv() => {
+                    if !handle_terminal_output_message(
+                        &terminal_id,
+                        output,
+                        &mut ws_sender,
+                        &mut output_coalescer,
+                    )
+                    .await
+                    {
+                        break;
+                    }
+                }
+                else => break,
             }
-            else => break,
+        } else {
+            tokio::select! {
+                output = terminal_rx.recv() => {
+                    if !handle_terminal_output_message(
+                        &terminal_id,
+                        output,
+                        &mut ws_sender,
+                        &mut output_coalescer,
+                    )
+                    .await
+                    {
+                        break;
+                    }
+                }
+                Some(message) = ws_receiver.next() => {
+                    if !handle_terminal_client_message(&write_tx, message) {
+                        break;
+                    }
+                }
+                else => break,
+            }
         }
     }
 
+    output_coalescer.log_final(&terminal_id);
     release_terminal_session(&state, &terminal_id, &session);
+}
+
+async fn handle_terminal_output_deadline(
+    terminal_id: &str,
+    ws_sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    output_coalescer: &mut TerminalOutputCoalescer,
+) -> bool {
+    let Some(reason) = output_coalescer.handle_deadline() else {
+        return true;
+    };
+    let Some(bytes) = output_coalescer.flush_pending(reason, Instant::now()) else {
+        return true;
+    };
+    if ws_sender.send(Message::Binary(bytes)).await.is_err() {
+        return false;
+    }
+    output_coalescer.maybe_log_interval(terminal_id, Instant::now());
+    true
+}
+
+async fn handle_terminal_output_message(
+    terminal_id: &str,
+    output: Result<TerminalOutput, tokio::sync::broadcast::error::RecvError>,
+    ws_sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    output_coalescer: &mut TerminalOutputCoalescer,
+) -> bool {
+    match output {
+        Ok(TerminalOutput::Bytes(bytes)) => {
+            let decision = output_coalescer.push_bytes(bytes, Instant::now());
+            match decision {
+                TerminalOutputCoalescingDecision::SendNow(bytes) => {
+                    if ws_sender.send(Message::Binary(bytes)).await.is_err() {
+                        return false;
+                    }
+                    output_coalescer.maybe_log_interval(terminal_id, Instant::now());
+                }
+                TerminalOutputCoalescingDecision::Pending => {}
+                TerminalOutputCoalescingDecision::FlushPending(reason) => {
+                    let Some(bytes) = output_coalescer.flush_pending(reason, Instant::now()) else {
+                        return true;
+                    };
+                    if ws_sender.send(Message::Binary(bytes)).await.is_err() {
+                        return false;
+                    }
+                    output_coalescer.maybe_log_interval(terminal_id, Instant::now());
+                }
+            }
+            true
+        }
+        Ok(TerminalOutput::Close(reason)) => {
+            if let Some(bytes) =
+                output_coalescer.flush_pending(TerminalOutputFlushReason::Close, Instant::now())
+            {
+                if ws_sender.send(Message::Binary(bytes)).await.is_err() {
+                    return false;
+                }
+                output_coalescer.maybe_log_interval(terminal_id, Instant::now());
+            }
+            let _ = ws_sender
+                .send(Message::Text(close_message(&reason).into()))
+                .await;
+            false
+        }
+        Err(tokio::sync::broadcast::error::RecvError::Lagged(frames)) => {
+            output_coalescer.record_lagged(frames);
+            true
+        }
+        Err(tokio::sync::broadcast::error::RecvError::Closed) => false,
+    }
+}
+
+fn handle_terminal_client_message(
+    write_tx: &mpsc::Sender<ClientMessage>,
+    message: Result<Message, axum::Error>,
+) -> bool {
+    match message {
+        Ok(Message::Text(text)) => handle_terminal_text_frame(write_tx, text.as_str()).is_ok(),
+        Ok(Message::Binary(bytes)) => send_terminal_input_chunks(write_tx, &bytes).is_ok(),
+        Ok(Message::Close(_)) => false,
+        Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => true,
+        Err(_) => false,
+    }
 }
 
 async fn acquire_terminal_session(
@@ -2281,7 +2727,7 @@ fn open_terminal_attach(
             };
         match message {
             ServerMessage::Terminal(frame) => {
-                let _ = output_tx.send(TerminalOutput::Bytes(frame.bytes));
+                let _ = output_tx.send(TerminalOutput::Bytes(Bytes::from(frame.bytes)));
             }
             ServerMessage::ServerShutdown { reason } => {
                 let _ = output_tx.send(TerminalOutput::Close(
@@ -2354,6 +2800,235 @@ fn unsupported_daemon_protocol_message(protocol: u32) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn coalescer_sends_first_output_immediately() {
+        let now = Instant::now();
+        let mut coalescer = TerminalOutputCoalescer::new(now);
+
+        assert_eq!(
+            coalescer.push_bytes(Bytes::from_static(b"first"), now),
+            TerminalOutputCoalescingDecision::SendNow(Bytes::from_static(b"first"))
+        );
+        assert_eq!(
+            coalescer.deadline(),
+            Some(now + TERMINAL_OUTPUT_COALESCE_WINDOW)
+        );
+        assert_eq!(coalescer.lifetime_stats.source_frames, 1);
+        assert_eq!(coalescer.lifetime_stats.sent_frames, 1);
+        assert_eq!(coalescer.lifetime_stats.immediate_frames, 1);
+    }
+
+    #[test]
+    fn coalescer_pends_output_inside_active_window() {
+        let now = Instant::now();
+        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let _ = coalescer.push_bytes(Bytes::from_static(b"first"), now);
+
+        assert_eq!(
+            coalescer.push_bytes(Bytes::from_static(b"second"), now),
+            TerminalOutputCoalescingDecision::Pending
+        );
+        assert_eq!(coalescer.pending_bytes, 6);
+        assert_eq!(coalescer.pending.len(), 1);
+        assert_eq!(coalescer.lifetime_stats.max_pending_bytes, 6);
+        assert_eq!(coalescer.lifetime_stats.max_pending_chunks, 1);
+    }
+
+    #[test]
+    fn coalescer_flushes_when_byte_threshold_is_reached() {
+        let now = Instant::now();
+        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let _ = coalescer.push_bytes(Bytes::from_static(b"first"), now);
+
+        let decision = coalescer.push_bytes(
+            Bytes::from(vec![b'x'; TERMINAL_OUTPUT_COALESCE_MAX_BYTES]),
+            now,
+        );
+
+        assert_eq!(
+            decision,
+            TerminalOutputCoalescingDecision::FlushPending(
+                TerminalOutputFlushReason::ByteThreshold
+            )
+        );
+        let flushed = coalescer
+            .flush_pending(TerminalOutputFlushReason::ByteThreshold, now)
+            .unwrap();
+        assert_eq!(flushed.len(), TERMINAL_OUTPUT_COALESCE_MAX_BYTES);
+        assert_eq!(coalescer.pending_bytes, 0);
+        assert_eq!(coalescer.pending.len(), 0);
+        assert_eq!(coalescer.lifetime_stats.byte_flushes, 1);
+        assert_eq!(coalescer.lifetime_stats.coalesced_sent_frames, 1);
+    }
+
+    #[test]
+    fn coalescer_deadline_returns_to_idle_when_nothing_pending() {
+        let now = Instant::now();
+        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let _ = coalescer.push_bytes(Bytes::from_static(b"first"), now);
+
+        assert_eq!(coalescer.handle_deadline(), None);
+        assert_eq!(coalescer.deadline(), None);
+    }
+
+    #[test]
+    fn coalescer_deadline_flushes_pending_and_rearms_window() {
+        let now = Instant::now();
+        let flush_at = now + TERMINAL_OUTPUT_COALESCE_WINDOW;
+        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let _ = coalescer.push_bytes(Bytes::from_static(b"first"), now);
+        let _ = coalescer.push_bytes(Bytes::from_static(b"second"), now);
+
+        assert_eq!(
+            coalescer.handle_deadline(),
+            Some(TerminalOutputFlushReason::Timer)
+        );
+        assert_eq!(
+            coalescer.flush_pending(TerminalOutputFlushReason::Timer, flush_at),
+            Some(Bytes::from_static(b"second"))
+        );
+        assert_eq!(
+            coalescer.deadline(),
+            Some(flush_at + TERMINAL_OUTPUT_COALESCE_WINDOW)
+        );
+        assert_eq!(coalescer.lifetime_stats.timer_flushes, 1);
+    }
+
+    #[test]
+    fn coalescer_keeps_spaced_output_immediate() {
+        let now = Instant::now();
+        let mut coalescer = TerminalOutputCoalescer::new(now);
+
+        assert_eq!(
+            coalescer.push_bytes(Bytes::from_static(b"one"), now),
+            TerminalOutputCoalescingDecision::SendNow(Bytes::from_static(b"one"))
+        );
+        assert_eq!(coalescer.handle_deadline(), None);
+        assert_eq!(
+            coalescer.push_bytes(
+                Bytes::from_static(b"two"),
+                now + TERMINAL_OUTPUT_COALESCE_WINDOW + Duration::from_millis(1),
+            ),
+            TerminalOutputCoalescingDecision::SendNow(Bytes::from_static(b"two"))
+        );
+        assert_eq!(coalescer.handle_deadline(), None);
+        assert_eq!(
+            coalescer.push_bytes(
+                Bytes::from_static(b"three"),
+                now + TERMINAL_OUTPUT_COALESCE_WINDOW * 2 + Duration::from_millis(2),
+            ),
+            TerminalOutputCoalescingDecision::SendNow(Bytes::from_static(b"three"))
+        );
+
+        assert_eq!(coalescer.lifetime_stats.source_frames, 3);
+        assert_eq!(coalescer.lifetime_stats.sent_frames, 3);
+        assert_eq!(coalescer.lifetime_stats.immediate_frames, 3);
+        assert_eq!(coalescer.lifetime_stats.coalesced_source_frames, 0);
+        assert_eq!(coalescer.lifetime_stats.coalesced_sent_frames, 0);
+        assert_eq!(coalescer.lifetime_stats.merged_flushes, 0);
+    }
+
+    #[test]
+    fn coalescer_keeps_continuous_stream_in_active_window() {
+        let now = Instant::now();
+        let first_flush = now + TERMINAL_OUTPUT_COALESCE_WINDOW;
+        let second_flush = first_flush + TERMINAL_OUTPUT_COALESCE_WINDOW;
+        let mut coalescer = TerminalOutputCoalescer::new(now);
+
+        let _ = coalescer.push_bytes(Bytes::from_static(b"one"), now);
+        let _ = coalescer.push_bytes(Bytes::from_static(b"two"), now + Duration::from_millis(1));
+        let _ = coalescer.push_bytes(Bytes::from_static(b"three"), now + Duration::from_millis(2));
+        assert_eq!(
+            coalescer.handle_deadline(),
+            Some(TerminalOutputFlushReason::Timer)
+        );
+        assert_eq!(
+            coalescer.flush_pending(TerminalOutputFlushReason::Timer, first_flush),
+            Some(Bytes::from_static(b"twothree"))
+        );
+
+        let _ = coalescer.push_bytes(
+            Bytes::from_static(b"four"),
+            first_flush + Duration::from_millis(1),
+        );
+        let _ = coalescer.push_bytes(
+            Bytes::from_static(b"five"),
+            first_flush + Duration::from_millis(2),
+        );
+        assert_eq!(
+            coalescer.handle_deadline(),
+            Some(TerminalOutputFlushReason::Timer)
+        );
+        assert_eq!(
+            coalescer.flush_pending(TerminalOutputFlushReason::Timer, second_flush),
+            Some(Bytes::from_static(b"fourfive"))
+        );
+
+        assert_eq!(coalescer.lifetime_stats.source_frames, 5);
+        assert_eq!(coalescer.lifetime_stats.sent_frames, 3);
+        assert_eq!(coalescer.lifetime_stats.immediate_frames, 1);
+        assert_eq!(coalescer.lifetime_stats.coalesced_source_frames, 4);
+        assert_eq!(coalescer.lifetime_stats.coalesced_sent_frames, 2);
+        assert_eq!(coalescer.lifetime_stats.merged_flushes, 2);
+    }
+
+    #[test]
+    fn draining_terminal_output_pending_preserves_order() {
+        let mut pending = vec![
+            Bytes::from_static(b"abc"),
+            Bytes::from_static(b"def"),
+            Bytes::from_static(b"ghi"),
+        ];
+        let mut pending_bytes = 9;
+
+        assert_eq!(
+            drain_terminal_output_pending(&mut pending, &mut pending_bytes),
+            Some(Bytes::from_static(b"abcdefghi"))
+        );
+        assert!(pending.is_empty());
+        assert_eq!(pending_bytes, 0);
+    }
+
+    #[test]
+    fn coalescing_stats_derived_values_are_zero_safe() {
+        let stats = TerminalOutputCoalescingStats::default();
+
+        assert_eq!(stats.frames_saved(), 0);
+        assert_eq!(stats.coalescing_ratio(), 0.0);
+        assert_eq!(stats.avg_source_frame_bytes(), 0.0);
+        assert_eq!(stats.avg_sent_frame_bytes(), 0.0);
+        assert_eq!(stats.avg_flush_latency_us(), 0.0);
+    }
+
+    #[test]
+    fn coalescing_stats_track_saved_frames_and_latency() {
+        let mut stats = TerminalOutputCoalescingStats::default();
+
+        stats.record_source(4);
+        stats.record_source(6);
+        stats.record_source(10);
+        stats.record_immediate_send(4);
+        stats.record_flush_reason(TerminalOutputFlushReason::Timer);
+        stats.record_coalesced_send(2, 16, Duration::from_micros(800));
+
+        assert_eq!(stats.sent_frames, 2);
+        assert_eq!(stats.frames_saved(), 1);
+        assert_eq!(stats.coalesced_source_frames, 2);
+        assert_eq!(stats.merged_flushes, 1);
+        assert_eq!(
+            stats.sent_frames,
+            stats.immediate_frames + stats.coalesced_sent_frames
+        );
+        assert_eq!(
+            stats.source_frames,
+            stats.immediate_frames + stats.coalesced_source_frames
+        );
+        assert_eq!(stats.coalescing_ratio(), 1.5);
+        assert_eq!(stats.avg_flush_latency_us(), 800.0);
+        assert_eq!(stats.avg_source_frame_bytes(), 20.0 / 3.0);
+        assert_eq!(stats.avg_sent_frame_bytes(), 10.0);
+    }
 
     #[test]
     fn parses_input_frame() {

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -51,10 +51,10 @@ const DEFAULT_STATIC_DIR: &str = "web/dist";
 const MIN_TERMINAL_ATTACH_PROTOCOL: u32 = 13;
 const MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
 const MAX_TERMINAL_INPUT_CHUNK_BYTES: usize = 768 * 1024;
-const TERMINAL_OUTPUT_COALESCE_WINDOW: Duration = Duration::from_millis(8);
+const DEFAULT_TERMINAL_OUTPUT_COALESCE_MS: u64 = 16;
+const MAX_TERMINAL_OUTPUT_COALESCE_MS: u64 = 256;
 const TERMINAL_OUTPUT_COALESCE_MAX_BYTES: usize = 32 * 1024;
 const TERMINAL_OUTPUT_COALESCE_MAX_CHUNKS: usize = 256;
-const TERMINAL_OUTPUT_STATS_INTERVAL: Duration = Duration::from_secs(10);
 const DAEMON_STATUS_TIMEOUT: Duration = Duration::from_secs(5);
 const ACTIVITY_WATCHER_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const ACTIVITY_WATCHER_MAX_BACKOFF: Duration = Duration::from_secs(30);
@@ -143,6 +143,7 @@ struct TerminalQuery {
     terminal_id: String,
     cols: Option<u16>,
     rows: Option<u16>,
+    coalesce_ms: Option<u64>,
     #[serde(default)]
     takeover: bool,
 }
@@ -200,6 +201,7 @@ enum TerminalOutputCoalescingDecision {
     FlushPending(TerminalOutputFlushReason),
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct TerminalOutputCoalescingStats {
     source_frames: u64,
@@ -222,6 +224,7 @@ struct TerminalOutputCoalescingStats {
     max_flush_latency_us: u128,
 }
 
+#[cfg(test)]
 impl TerminalOutputCoalescingStats {
     fn record_source(&mut self, bytes: usize) {
         self.source_frames += 1;
@@ -269,18 +272,12 @@ impl TerminalOutputCoalescingStats {
         self.lagged_frames += frames;
     }
 
-    fn has_activity(&self) -> bool {
-        self.source_frames > 0 || self.lagged_events > 0
-    }
-
-    fn has_source_frames(&self) -> bool {
-        self.source_frames > 0
-    }
-
+    #[cfg(test)]
     fn frames_saved(&self) -> u64 {
         self.source_frames.saturating_sub(self.sent_frames)
     }
 
+    #[cfg(test)]
     fn coalescing_ratio(&self) -> f64 {
         if self.sent_frames == 0 {
             return 0.0;
@@ -288,6 +285,7 @@ impl TerminalOutputCoalescingStats {
         self.source_frames as f64 / self.sent_frames as f64
     }
 
+    #[cfg(test)]
     fn avg_source_frame_bytes(&self) -> f64 {
         if self.source_frames == 0 {
             return 0.0;
@@ -295,6 +293,7 @@ impl TerminalOutputCoalescingStats {
         self.source_bytes as f64 / self.source_frames as f64
     }
 
+    #[cfg(test)]
     fn avg_sent_frame_bytes(&self) -> f64 {
         if self.sent_frames == 0 {
             return 0.0;
@@ -302,6 +301,7 @@ impl TerminalOutputCoalescingStats {
         self.sent_bytes as f64 / self.sent_frames as f64
     }
 
+    #[cfg(test)]
     fn avg_flush_latency_us(&self) -> f64 {
         if self.coalesced_sent_frames == 0 {
             return 0.0;
@@ -310,27 +310,26 @@ impl TerminalOutputCoalescingStats {
     }
 }
 
-#[derive(Debug)]
 struct TerminalOutputCoalescer {
+    window: Duration,
     pending: Vec<Bytes>,
     pending_bytes: usize,
     pending_started_at: Option<Instant>,
     deadline: Option<Instant>,
-    interval_stats: TerminalOutputCoalescingStats,
+    #[cfg(test)]
     lifetime_stats: TerminalOutputCoalescingStats,
-    last_stats_log_at: Instant,
 }
 
 impl TerminalOutputCoalescer {
-    fn new(now: Instant) -> Self {
+    fn new(window: Duration) -> Self {
         Self {
+            window,
             pending: Vec::new(),
             pending_bytes: 0,
             pending_started_at: None,
             deadline: None,
-            interval_stats: TerminalOutputCoalescingStats::default(),
+            #[cfg(test)]
             lifetime_stats: TerminalOutputCoalescingStats::default(),
-            last_stats_log_at: now,
         }
     }
 
@@ -342,8 +341,13 @@ impl TerminalOutputCoalescer {
         let byte_count = bytes.len();
         self.record_source(byte_count);
 
+        if self.window.is_zero() {
+            self.record_immediate_send(byte_count);
+            return TerminalOutputCoalescingDecision::SendNow(bytes);
+        }
+
         if self.deadline.is_none() {
-            self.deadline = Some(now + TERMINAL_OUTPUT_COALESCE_WINDOW);
+            self.deadline = Some(now + self.window);
             self.record_immediate_send(byte_count);
             return TerminalOutputCoalescingDecision::SendNow(bytes);
         }
@@ -401,70 +405,62 @@ impl TerminalOutputCoalescer {
         if matches!(reason, TerminalOutputFlushReason::Close) {
             self.deadline = None;
         } else {
-            self.deadline = Some(now + TERMINAL_OUTPUT_COALESCE_WINDOW);
+            // Keep a trailing window warm so sustained redraws continue batching between flushes.
+            self.deadline = Some(now + self.window);
         }
         self.record_coalesced_send(source_chunks, bytes.len(), latency);
         Some(bytes)
     }
 
+    #[cfg(test)]
     fn record_lagged(&mut self, frames: u64) {
-        self.interval_stats.record_lagged(frames);
         self.lifetime_stats.record_lagged(frames);
     }
 
-    fn maybe_log_interval(&mut self, terminal_id: &str, now: Instant) {
-        if now.duration_since(self.last_stats_log_at) < TERMINAL_OUTPUT_STATS_INTERVAL {
-            return;
-        }
+    #[cfg(not(test))]
+    fn record_lagged(&mut self, _frames: u64) {}
 
-        if self.interval_stats.has_source_frames() {
-            log_terminal_output_coalescing_stats(terminal_id, "interval", &self.interval_stats);
-            self.interval_stats = TerminalOutputCoalescingStats::default();
-        }
-        self.last_stats_log_at = now;
-    }
-
-    fn log_final(&self, terminal_id: &str) {
-        if self.interval_stats.has_activity() {
-            log_terminal_output_coalescing_stats(
-                terminal_id,
-                "final_interval",
-                &self.interval_stats,
-            );
-        }
-        if self.lifetime_stats.has_activity() {
-            log_terminal_output_coalescing_stats(terminal_id, "lifetime", &self.lifetime_stats);
-        }
-    }
-
+    #[cfg(test)]
     fn record_source(&mut self, bytes: usize) {
-        self.interval_stats.record_source(bytes);
         self.lifetime_stats.record_source(bytes);
     }
 
+    #[cfg(not(test))]
+    fn record_source(&mut self, _bytes: usize) {}
+
+    #[cfg(test)]
     fn record_immediate_send(&mut self, bytes: usize) {
-        self.interval_stats.record_immediate_send(bytes);
         self.lifetime_stats.record_immediate_send(bytes);
     }
 
+    #[cfg(not(test))]
+    fn record_immediate_send(&mut self, _bytes: usize) {}
+
+    #[cfg(test)]
     fn record_pending(&mut self) {
-        self.interval_stats
-            .record_pending(self.pending_bytes, self.pending.len());
         self.lifetime_stats
             .record_pending(self.pending_bytes, self.pending.len());
     }
 
+    #[cfg(not(test))]
+    fn record_pending(&mut self) {}
+
+    #[cfg(test)]
     fn record_flush_reason(&mut self, reason: TerminalOutputFlushReason) {
-        self.interval_stats.record_flush_reason(reason);
         self.lifetime_stats.record_flush_reason(reason);
     }
 
+    #[cfg(not(test))]
+    fn record_flush_reason(&mut self, _reason: TerminalOutputFlushReason) {}
+
+    #[cfg(test)]
     fn record_coalesced_send(&mut self, chunks: usize, bytes: usize, latency: Duration) {
-        self.interval_stats
-            .record_coalesced_send(chunks, bytes, latency);
         self.lifetime_stats
             .record_coalesced_send(chunks, bytes, latency);
     }
+
+    #[cfg(not(test))]
+    fn record_coalesced_send(&mut self, _chunks: usize, _bytes: usize, _latency: Duration) {}
 }
 
 fn drain_terminal_output_pending(
@@ -489,39 +485,12 @@ fn drain_terminal_output_pending(
     Some(Bytes::from(output))
 }
 
-fn log_terminal_output_coalescing_stats(
-    terminal_id: &str,
-    scope: &str,
-    stats: &TerminalOutputCoalescingStats,
-) {
-    debug!(
-        terminal_id = %terminal_id,
-        scope = %scope,
-        source_frames = stats.source_frames,
-        source_bytes = stats.source_bytes,
-        sent_frames = stats.sent_frames,
-        sent_bytes = stats.sent_bytes,
-        immediate_frames = stats.immediate_frames,
-        coalesced_source_frames = stats.coalesced_source_frames,
-        coalesced_sent_frames = stats.coalesced_sent_frames,
-        timer_flushes = stats.timer_flushes,
-        byte_flushes = stats.byte_flushes,
-        chunk_flushes = stats.chunk_flushes,
-        single_chunk_flushes = stats.single_chunk_flushes,
-        merged_flushes = stats.merged_flushes,
-        lagged_events = stats.lagged_events,
-        lagged_frames = stats.lagged_frames,
-        max_pending_bytes = stats.max_pending_bytes,
-        max_pending_chunks = stats.max_pending_chunks,
-        total_flush_latency_us = stats.total_flush_latency_us,
-        max_flush_latency_us = stats.max_flush_latency_us,
-        coalescing_ratio = stats.coalescing_ratio(),
-        frames_saved = stats.frames_saved(),
-        avg_source_frame_bytes = stats.avg_source_frame_bytes(),
-        avg_sent_frame_bytes = stats.avg_sent_frame_bytes(),
-        avg_flush_latency_us = stats.avg_flush_latency_us(),
-        "terminal output coalescing stats"
-    );
+fn terminal_output_coalesce_window(coalesce_ms: Option<u64>) -> Duration {
+    Duration::from_millis(
+        coalesce_ms
+            .unwrap_or(DEFAULT_TERMINAL_OUTPUT_COALESCE_MS)
+            .min(MAX_TERMINAL_OUTPUT_COALESCE_MS),
+    )
 }
 
 #[derive(Clone)]
@@ -2003,6 +1972,7 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
     let terminal_id = query.terminal_id.clone();
     let cols = query.cols.unwrap_or(DEFAULT_COLS);
     let rows = query.rows.unwrap_or(DEFAULT_ROWS);
+    let coalesce_window = terminal_output_coalesce_window(query.coalesce_ms);
     let (mut ws_sender, mut ws_receiver) = socket.split();
     let session = match acquire_terminal_session(
         state.clone(),
@@ -2025,7 +1995,7 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
 
     let write_tx = session.write_tx.clone();
     let mut terminal_rx = session.output_tx.subscribe();
-    let mut output_coalescer = TerminalOutputCoalescer::new(Instant::now());
+    let mut output_coalescer = TerminalOutputCoalescer::new(coalesce_window);
     let _ = write_tx.send(ClientMessage::Resize {
         cols,
         rows,
@@ -2039,7 +2009,6 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
                 biased;
                 _ = tokio::time::sleep_until(deadline) => {
                     if !handle_terminal_output_deadline(
-                        &terminal_id,
                         &mut ws_sender,
                         &mut output_coalescer,
                     )
@@ -2055,7 +2024,6 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
                 }
                 output = terminal_rx.recv() => {
                     if !handle_terminal_output_message(
-                        &terminal_id,
                         output,
                         &mut ws_sender,
                         &mut output_coalescer,
@@ -2071,7 +2039,6 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
             tokio::select! {
                 output = terminal_rx.recv() => {
                     if !handle_terminal_output_message(
-                        &terminal_id,
                         output,
                         &mut ws_sender,
                         &mut output_coalescer,
@@ -2091,12 +2058,10 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
         }
     }
 
-    output_coalescer.log_final(&terminal_id);
     release_terminal_session(&state, &terminal_id, &session);
 }
 
 async fn handle_terminal_output_deadline(
-    terminal_id: &str,
     ws_sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
     output_coalescer: &mut TerminalOutputCoalescer,
 ) -> bool {
@@ -2109,12 +2074,10 @@ async fn handle_terminal_output_deadline(
     if ws_sender.send(Message::Binary(bytes)).await.is_err() {
         return false;
     }
-    output_coalescer.maybe_log_interval(terminal_id, Instant::now());
     true
 }
 
 async fn handle_terminal_output_message(
-    terminal_id: &str,
     output: Result<TerminalOutput, tokio::sync::broadcast::error::RecvError>,
     ws_sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
     output_coalescer: &mut TerminalOutputCoalescer,
@@ -2127,7 +2090,6 @@ async fn handle_terminal_output_message(
                     if ws_sender.send(Message::Binary(bytes)).await.is_err() {
                         return false;
                     }
-                    output_coalescer.maybe_log_interval(terminal_id, Instant::now());
                 }
                 TerminalOutputCoalescingDecision::Pending => {}
                 TerminalOutputCoalescingDecision::FlushPending(reason) => {
@@ -2137,7 +2099,6 @@ async fn handle_terminal_output_message(
                     if ws_sender.send(Message::Binary(bytes)).await.is_err() {
                         return false;
                     }
-                    output_coalescer.maybe_log_interval(terminal_id, Instant::now());
                 }
             }
             true
@@ -2149,7 +2110,6 @@ async fn handle_terminal_output_message(
                 if ws_sender.send(Message::Binary(bytes)).await.is_err() {
                     return false;
                 }
-                output_coalescer.maybe_log_interval(terminal_id, Instant::now());
             }
             let _ = ws_sender
                 .send(Message::Text(close_message(&reason).into()))
@@ -2804,7 +2764,7 @@ mod tests {
     #[test]
     fn coalescer_sends_first_output_immediately() {
         let now = Instant::now();
-        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let mut coalescer = TerminalOutputCoalescer::new(terminal_output_coalesce_window(None));
 
         assert_eq!(
             coalescer.push_bytes(Bytes::from_static(b"first"), now),
@@ -2812,7 +2772,7 @@ mod tests {
         );
         assert_eq!(
             coalescer.deadline(),
-            Some(now + TERMINAL_OUTPUT_COALESCE_WINDOW)
+            Some(now + terminal_output_coalesce_window(None))
         );
         assert_eq!(coalescer.lifetime_stats.source_frames, 1);
         assert_eq!(coalescer.lifetime_stats.sent_frames, 1);
@@ -2820,9 +2780,45 @@ mod tests {
     }
 
     #[test]
+    fn coalescer_can_disable_output_coalescing() {
+        let now = Instant::now();
+        let mut coalescer = TerminalOutputCoalescer::new(Duration::ZERO);
+
+        assert_eq!(
+            coalescer.push_bytes(Bytes::from_static(b"first"), now),
+            TerminalOutputCoalescingDecision::SendNow(Bytes::from_static(b"first"))
+        );
+        assert_eq!(
+            coalescer.push_bytes(Bytes::from_static(b"second"), now),
+            TerminalOutputCoalescingDecision::SendNow(Bytes::from_static(b"second"))
+        );
+        assert_eq!(coalescer.deadline(), None);
+        assert_eq!(coalescer.lifetime_stats.source_frames, 2);
+        assert_eq!(coalescer.lifetime_stats.sent_frames, 2);
+        assert_eq!(coalescer.lifetime_stats.coalesced_sent_frames, 0);
+    }
+
+    #[test]
+    fn terminal_output_coalesce_window_defaults_and_clamps() {
+        assert_eq!(
+            terminal_output_coalesce_window(None),
+            Duration::from_millis(DEFAULT_TERMINAL_OUTPUT_COALESCE_MS)
+        );
+        assert_eq!(terminal_output_coalesce_window(Some(0)), Duration::ZERO);
+        assert_eq!(
+            terminal_output_coalesce_window(Some(128)),
+            Duration::from_millis(128)
+        );
+        assert_eq!(
+            terminal_output_coalesce_window(Some(999)),
+            Duration::from_millis(MAX_TERMINAL_OUTPUT_COALESCE_MS)
+        );
+    }
+
+    #[test]
     fn coalescer_pends_output_inside_active_window() {
         let now = Instant::now();
-        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let mut coalescer = TerminalOutputCoalescer::new(terminal_output_coalesce_window(None));
         let _ = coalescer.push_bytes(Bytes::from_static(b"first"), now);
 
         assert_eq!(
@@ -2838,7 +2834,7 @@ mod tests {
     #[test]
     fn coalescer_flushes_when_byte_threshold_is_reached() {
         let now = Instant::now();
-        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let mut coalescer = TerminalOutputCoalescer::new(terminal_output_coalesce_window(None));
         let _ = coalescer.push_bytes(Bytes::from_static(b"first"), now);
 
         let decision = coalescer.push_bytes(
@@ -2865,7 +2861,7 @@ mod tests {
     #[test]
     fn coalescer_deadline_returns_to_idle_when_nothing_pending() {
         let now = Instant::now();
-        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let mut coalescer = TerminalOutputCoalescer::new(terminal_output_coalesce_window(None));
         let _ = coalescer.push_bytes(Bytes::from_static(b"first"), now);
 
         assert_eq!(coalescer.handle_deadline(), None);
@@ -2875,8 +2871,8 @@ mod tests {
     #[test]
     fn coalescer_deadline_flushes_pending_and_rearms_window() {
         let now = Instant::now();
-        let flush_at = now + TERMINAL_OUTPUT_COALESCE_WINDOW;
-        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let flush_at = now + terminal_output_coalesce_window(None);
+        let mut coalescer = TerminalOutputCoalescer::new(terminal_output_coalesce_window(None));
         let _ = coalescer.push_bytes(Bytes::from_static(b"first"), now);
         let _ = coalescer.push_bytes(Bytes::from_static(b"second"), now);
 
@@ -2890,7 +2886,7 @@ mod tests {
         );
         assert_eq!(
             coalescer.deadline(),
-            Some(flush_at + TERMINAL_OUTPUT_COALESCE_WINDOW)
+            Some(flush_at + terminal_output_coalesce_window(None))
         );
         assert_eq!(coalescer.lifetime_stats.timer_flushes, 1);
     }
@@ -2898,7 +2894,7 @@ mod tests {
     #[test]
     fn coalescer_keeps_spaced_output_immediate() {
         let now = Instant::now();
-        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let mut coalescer = TerminalOutputCoalescer::new(terminal_output_coalesce_window(None));
 
         assert_eq!(
             coalescer.push_bytes(Bytes::from_static(b"one"), now),
@@ -2908,7 +2904,7 @@ mod tests {
         assert_eq!(
             coalescer.push_bytes(
                 Bytes::from_static(b"two"),
-                now + TERMINAL_OUTPUT_COALESCE_WINDOW + Duration::from_millis(1),
+                now + terminal_output_coalesce_window(None) + Duration::from_millis(1),
             ),
             TerminalOutputCoalescingDecision::SendNow(Bytes::from_static(b"two"))
         );
@@ -2916,7 +2912,7 @@ mod tests {
         assert_eq!(
             coalescer.push_bytes(
                 Bytes::from_static(b"three"),
-                now + TERMINAL_OUTPUT_COALESCE_WINDOW * 2 + Duration::from_millis(2),
+                now + terminal_output_coalesce_window(None) * 2 + Duration::from_millis(2),
             ),
             TerminalOutputCoalescingDecision::SendNow(Bytes::from_static(b"three"))
         );
@@ -2932,9 +2928,9 @@ mod tests {
     #[test]
     fn coalescer_keeps_continuous_stream_in_active_window() {
         let now = Instant::now();
-        let first_flush = now + TERMINAL_OUTPUT_COALESCE_WINDOW;
-        let second_flush = first_flush + TERMINAL_OUTPUT_COALESCE_WINDOW;
-        let mut coalescer = TerminalOutputCoalescer::new(now);
+        let first_flush = now + terminal_output_coalesce_window(None);
+        let second_flush = first_flush + terminal_output_coalesce_window(None);
+        let mut coalescer = TerminalOutputCoalescer::new(terminal_output_coalesce_window(None));
 
         let _ = coalescer.push_bytes(Bytes::from_static(b"one"), now);
         let _ = coalescer.push_bytes(Bytes::from_static(b"two"), now + Duration::from_millis(1));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,6 +119,7 @@ type DisplayPrefs = {
 };
 const COMPACT_LAYOUT_QUERY = "(max-width: 820px)";
 const TOUCH_INPUT_QUERY = "(hover: none) and (pointer: coarse)";
+const MOBILE_TERMINAL_SWITCH_CLEAR_MS = 300;
 const DISPLAY_PREFS_KEY = "herdr.mobileWeb.displayPrefs.v1";
 const MOBILE_SIDEBAR_HISTORY_KEY = "herdrWebMobileSidebar";
 const MOBILE_DETAIL_HISTORY_KEY = "herdrWebMobileDetail";
@@ -295,6 +296,7 @@ export function App() {
   const [error, setError] = useState<string | null>(null);
   const [refitToken, setRefitToken] = useState(0);
   const [terminalFocusToken, setTerminalFocusToken] = useState(0);
+  const [mobileTerminalSwitchingId, setMobileTerminalSwitchingId] = useState<string | null>(null);
   const isCompactLayout = useIsCompactLayout();
   const isTouchInput = useIsTouchInput();
   const showMobileKeyboardHideRefit = isNativeAndroid();
@@ -761,6 +763,9 @@ export function App() {
   };
 
   const openPane = (pane: PaneInfo) => {
+    if (isCompactLayout && selectedPane?.terminal_id !== pane.terminal_id) {
+      setMobileTerminalSwitchingId(pane.terminal_id);
+    }
     setSelectedPaneId(pane.pane_id);
     setActiveSpaceId(pane.workspace_id);
     void syncSelectedPane(bridge.httpUrl, pane.pane_id).catch(() => {});
@@ -771,6 +776,29 @@ export function App() {
   };
 
   const requestTerminalFocus = () => setTerminalFocusToken((token) => token + 1);
+
+  useEffect(() => {
+    if (!isCompactLayout || !showDetail) {
+      setMobileTerminalSwitchingId(null);
+    }
+  }, [isCompactLayout, showDetail]);
+
+  useEffect(() => {
+    if (
+      !isCompactLayout ||
+      !showDetail ||
+      mobileTerminalSwitchingId === null ||
+      selectedPane?.terminal_id !== mobileTerminalSwitchingId
+    ) {
+      return;
+    }
+
+    const switchingId = mobileTerminalSwitchingId;
+    const timer = window.setTimeout(() => {
+      setMobileTerminalSwitchingId((current) => (current === switchingId ? null : current));
+    }, MOBILE_TERMINAL_SWITCH_CLEAR_MS);
+    return () => window.clearTimeout(timer);
+  }, [isCompactLayout, mobileTerminalSwitchingId, selectedPane?.terminal_id, showDetail]);
 
   const selectSpace = (workspaceId: string) => {
     setActiveSpaceId(workspaceId);
@@ -1161,6 +1189,7 @@ export function App() {
       data-compact={isCompactLayout ? "true" : "false"}
       data-touch={isTouchInput ? "true" : "false"}
       data-detail={isCompactLayout && showDetail ? "true" : "false"}
+      data-terminal-switching={mobileTerminalSwitchingId !== null ? "true" : "false"}
     >
       <aside className="sidebar" aria-label="Switcher">
         <Switcher
@@ -1350,6 +1379,7 @@ export function App() {
           />
         ) : renderTerminal ? (
           <TerminalView
+            key={selectedPane?.terminal_id ?? "empty-terminal"}
             pane={selectedPane}
             connectionKey={bridge.connectionKey}
             resumeToken={bridge.resumeToken}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,7 +119,6 @@ type DisplayPrefs = {
 };
 const COMPACT_LAYOUT_QUERY = "(max-width: 820px)";
 const TOUCH_INPUT_QUERY = "(hover: none) and (pointer: coarse)";
-const MOBILE_TERMINAL_SWITCH_CLEAR_MS = 300;
 const DISPLAY_PREFS_KEY = "herdr.mobileWeb.displayPrefs.v1";
 const MOBILE_SIDEBAR_HISTORY_KEY = "herdrWebMobileSidebar";
 const MOBILE_DETAIL_HISTORY_KEY = "herdrWebMobileDetail";
@@ -296,7 +295,6 @@ export function App() {
   const [error, setError] = useState<string | null>(null);
   const [refitToken, setRefitToken] = useState(0);
   const [terminalFocusToken, setTerminalFocusToken] = useState(0);
-  const [mobileTerminalSwitchingId, setMobileTerminalSwitchingId] = useState<string | null>(null);
   const isCompactLayout = useIsCompactLayout();
   const isTouchInput = useIsTouchInput();
   const showMobileKeyboardHideRefit = isNativeAndroid();
@@ -763,9 +761,6 @@ export function App() {
   };
 
   const openPane = (pane: PaneInfo) => {
-    if (isCompactLayout && selectedPane?.terminal_id !== pane.terminal_id) {
-      setMobileTerminalSwitchingId(pane.terminal_id);
-    }
     setSelectedPaneId(pane.pane_id);
     setActiveSpaceId(pane.workspace_id);
     void syncSelectedPane(bridge.httpUrl, pane.pane_id).catch(() => {});
@@ -776,29 +771,6 @@ export function App() {
   };
 
   const requestTerminalFocus = () => setTerminalFocusToken((token) => token + 1);
-
-  useEffect(() => {
-    if (!isCompactLayout || !showDetail) {
-      setMobileTerminalSwitchingId(null);
-    }
-  }, [isCompactLayout, showDetail]);
-
-  useEffect(() => {
-    if (
-      !isCompactLayout ||
-      !showDetail ||
-      mobileTerminalSwitchingId === null ||
-      selectedPane?.terminal_id !== mobileTerminalSwitchingId
-    ) {
-      return;
-    }
-
-    const switchingId = mobileTerminalSwitchingId;
-    const timer = window.setTimeout(() => {
-      setMobileTerminalSwitchingId((current) => (current === switchingId ? null : current));
-    }, MOBILE_TERMINAL_SWITCH_CLEAR_MS);
-    return () => window.clearTimeout(timer);
-  }, [isCompactLayout, mobileTerminalSwitchingId, selectedPane?.terminal_id, showDetail]);
 
   const selectSpace = (workspaceId: string) => {
     setActiveSpaceId(workspaceId);
@@ -1189,7 +1161,6 @@ export function App() {
       data-compact={isCompactLayout ? "true" : "false"}
       data-touch={isTouchInput ? "true" : "false"}
       data-detail={isCompactLayout && showDetail ? "true" : "false"}
-      data-terminal-switching={mobileTerminalSwitchingId !== null ? "true" : "false"}
     >
       <aside className="sidebar" aria-label="Switcher">
         <Switcher
@@ -1379,7 +1350,6 @@ export function App() {
           />
         ) : renderTerminal ? (
           <TerminalView
-            key={selectedPane?.terminal_id ?? "empty-terminal"}
             pane={selectedPane}
             connectionKey={bridge.connectionKey}
             resumeToken={bridge.resumeToken}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -53,6 +53,10 @@ import {
 } from "./terminalInputTransport";
 import type { TerminalInputTransport } from "./terminalInputTransport";
 import {
+  DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
+  parseTerminalOutputCoalesceMs,
+} from "./terminalOutputCoalescing";
+import {
   aggregateStatus,
   canClearTabName,
   canClearWorkspaceName,
@@ -110,6 +114,7 @@ type DisplayPrefs = {
   selectedPaneId: string | null;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
+  terminalOutputCoalesceMs: number;
   contentInsetTopPx: number;
   contentInsetBottomPx: number;
   mobileControlsScalePercent: number;
@@ -138,6 +143,7 @@ function readDisplayPrefs(): DisplayPrefs {
     selectedPaneId: null,
     terminalInputTransport: DEFAULT_TERMINAL_INPUT_TRANSPORT,
     terminalInputBatchDelayMs: DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
+    terminalOutputCoalesceMs: DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
     contentInsetTopPx: DEFAULT_CONTENT_INSET_TOP_PX,
     contentInsetBottomPx: DEFAULT_CONTENT_INSET_BOTTOM_PX,
     mobileControlsScalePercent: DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
@@ -179,6 +185,9 @@ function readDisplayPrefs(): DisplayPrefs {
         typeof parsed.selectedPaneId === "string" ? parsed.selectedPaneId : fallback.selectedPaneId,
       terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
       terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
+      terminalOutputCoalesceMs: parseTerminalOutputCoalesceMs(
+        parsed.terminalOutputCoalesceMs,
+      ),
       contentInsetTopPx: parseContentInsetTopPx(parsed.contentInsetTopPx),
       contentInsetBottomPx: parseContentInsetBottomPx(parsed.contentInsetBottomPx),
       mobileControlsScalePercent: parseMobileControlsScalePercent(
@@ -273,6 +282,9 @@ export function App() {
   );
   const [terminalInputBatchDelayMs, setTerminalInputBatchDelayMs] = useState(
     initialPrefs.terminalInputBatchDelayMs,
+  );
+  const [terminalOutputCoalesceMs, setTerminalOutputCoalesceMs] = useState(
+    initialPrefs.terminalOutputCoalesceMs,
   );
   const [contentInsetTopPx, setContentInsetTopPx] = useState(initialPrefs.contentInsetTopPx);
   const [contentInsetBottomPx, setContentInsetBottomPx] = useState(
@@ -404,6 +416,7 @@ export function App() {
       selectedPaneId,
       terminalInputTransport,
       terminalInputBatchDelayMs,
+      terminalOutputCoalesceMs,
       contentInsetTopPx,
       contentInsetBottomPx,
       mobileControlsScalePercent,
@@ -422,6 +435,7 @@ export function App() {
     selectedPaneId,
     terminalInputTransport,
     terminalInputBatchDelayMs,
+    terminalOutputCoalesceMs,
     contentInsetTopPx,
     contentInsetBottomPx,
     mobileControlsScalePercent,
@@ -1343,6 +1357,7 @@ export function App() {
             mobileTouchSelection={mobileTouchSelection}
             terminalInputTransport={terminalInputTransport}
             terminalInputBatchDelayMs={terminalInputBatchDelayMs}
+            terminalOutputCoalesceMs={terminalOutputCoalesceMs}
             connectionKey={bridge.connectionKey}
             resumeToken={bridge.resumeToken}
             httpUrl={bridge.httpUrl}
@@ -1362,6 +1377,7 @@ export function App() {
             mobileTouchSelection={mobileTouchSelection}
             terminalInputTransport={terminalInputTransport}
             terminalInputBatchDelayMs={terminalInputBatchDelayMs}
+            terminalOutputCoalesceMs={terminalOutputCoalesceMs}
             refitToken={refitToken}
             focusToken={terminalFocusToken}
           />
@@ -1420,6 +1436,8 @@ export function App() {
           onTerminalInputTransport={setTerminalInputTransport}
           terminalInputBatchDelayMs={terminalInputBatchDelayMs}
           onTerminalInputBatchDelayMs={setTerminalInputBatchDelayMs}
+          terminalOutputCoalesceMs={terminalOutputCoalesceMs}
+          onTerminalOutputCoalesceMs={setTerminalOutputCoalesceMs}
           contentInsetTopPx={contentInsetTopPx}
           onContentInsetTopPx={setContentInsetTopPx}
           contentInsetBottomPx={contentInsetBottomPx}
@@ -1592,6 +1610,7 @@ function SplitGrid({
   mobileTouchSelection,
   terminalInputTransport,
   terminalInputBatchDelayMs,
+  terminalOutputCoalesceMs,
   connectionKey,
   resumeToken,
   httpUrl,
@@ -1607,6 +1626,7 @@ function SplitGrid({
   mobileTouchSelection: boolean;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
+  terminalOutputCoalesceMs: number;
   connectionKey: string;
   resumeToken: number;
   httpUrl: (path: string, query?: URLSearchParams) => string;
@@ -1637,6 +1657,7 @@ function SplitGrid({
               mobileTouchSelection={mobileTouchSelection}
               terminalInputTransport={terminalInputTransport}
               terminalInputBatchDelayMs={terminalInputBatchDelayMs}
+              terminalOutputCoalesceMs={terminalOutputCoalesceMs}
               refitToken={selected ? refitToken : 0}
               focusToken={selected ? focusToken : 0}
             />

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -32,6 +32,7 @@ import {
 import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
 import { TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS } from "./terminalInputTransport";
 import type { TerminalInputTransport } from "./terminalInputTransport";
+import { TERMINAL_OUTPUT_COALESCE_OPTIONS_MS } from "./terminalOutputCoalescing";
 
 type Props = {
   showMobileTerminalSettings: boolean;
@@ -39,6 +40,8 @@ type Props = {
   onTerminalInputTransport: (transport: TerminalInputTransport) => void;
   terminalInputBatchDelayMs: number;
   onTerminalInputBatchDelayMs: (delayMs: number) => void;
+  terminalOutputCoalesceMs: number;
+  onTerminalOutputCoalesceMs: (delayMs: number) => void;
   contentInsetTopPx: number;
   onContentInsetTopPx: (value: number) => void;
   contentInsetBottomPx: number;
@@ -76,6 +79,8 @@ export function BackendSettingsDialog({
   onTerminalInputTransport,
   terminalInputBatchDelayMs,
   onTerminalInputBatchDelayMs,
+  terminalOutputCoalesceMs,
+  onTerminalOutputCoalesceMs,
   contentInsetTopPx,
   onContentInsetTopPx,
   contentInsetBottomPx,
@@ -513,7 +518,7 @@ export function BackendSettingsDialog({
                   </div>
                 </div>
                 <div className="settings-row">
-                  <span>Input batching</span>
+                  <span>Input batching (ms)</span>
                   <div className="segmented-control" role="group" aria-label="Terminal input batching">
                     {TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS.map((delayMs) => (
                       <button
@@ -523,7 +528,23 @@ export function BackendSettingsDialog({
                         aria-pressed={terminalInputBatchDelayMs === delayMs}
                         onClick={() => onTerminalInputBatchDelayMs(delayMs)}
                       >
-                        {delayMs === 0 ? "Off" : `${delayMs}ms`}
+                        {delayMs === 0 ? "Off" : delayMs}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="settings-row">
+                  <span>Output batching (ms)</span>
+                  <div className="segmented-control" role="group" aria-label="Terminal output batching">
+                    {TERMINAL_OUTPUT_COALESCE_OPTIONS_MS.map((delayMs) => (
+                      <button
+                        key={delayMs}
+                        type="button"
+                        data-on={terminalOutputCoalesceMs === delayMs}
+                        aria-pressed={terminalOutputCoalesceMs === delayMs}
+                        onClick={() => onTerminalOutputCoalesceMs(delayMs)}
+                      >
+                        {delayMs === 0 ? "Off" : delayMs}
                       </button>
                     ))}
                   </div>

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -75,7 +75,6 @@ type MobileSelectionAction = {
 
 const MAX_UPLOAD_FILES = 8;
 const TERMINAL_CONNECT_TIMEOUT_MS = 3500;
-const CONNECTING_OVERLAY_DELAY_MS = 250;
 
 export function TerminalView({
   pane,
@@ -110,9 +109,7 @@ export function TerminalView({
   const uploadConflictRef = useRef<UploadConflictState | null>(null);
   const connectionKeyRef = useRef(connectionKey);
   const terminalIdRef = useRef(pane?.terminal_id ?? null);
-  const connectingOverlayTimerRef = useRef<number | null>(null);
   const [connectionState, setConnectionState] = useState<ConnectionState>("idle");
-  const [showDelayedConnectingOverlay, setShowDelayedConnectingOverlay] = useState(false);
   const [closeReason, setCloseReason] = useState<string | null>(null);
   const [uploadStatus, setUploadStatus] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -601,38 +598,10 @@ export function TerminalView({
   }, [connectionKey, pane?.terminal_id]);
 
   useEffect(() => {
-    if (connectingOverlayTimerRef.current !== null) {
-      window.clearTimeout(connectingOverlayTimerRef.current);
-      connectingOverlayTimerRef.current = null;
-    }
-
-    if (connectionState !== "connecting") {
-      setShowDelayedConnectingOverlay(false);
-      return;
-    }
-
-    connectingOverlayTimerRef.current = window.setTimeout(() => {
-      connectingOverlayTimerRef.current = null;
-      setShowDelayedConnectingOverlay(true);
-    }, CONNECTING_OVERLAY_DELAY_MS);
-
-    return () => {
-      if (connectingOverlayTimerRef.current !== null) {
-        window.clearTimeout(connectingOverlayTimerRef.current);
-        connectingOverlayTimerRef.current = null;
-      }
-    };
-  }, [connectionState]);
-
-  useEffect(() => {
     return () => {
       if (uploadStatusTimerRef.current !== null) {
         window.clearTimeout(uploadStatusTimerRef.current);
         uploadStatusTimerRef.current = null;
-      }
-      if (connectingOverlayTimerRef.current !== null) {
-        window.clearTimeout(connectingOverlayTimerRef.current);
-        connectingOverlayTimerRef.current = null;
       }
       resolveUploadConflict(false, false);
     };
@@ -666,10 +635,6 @@ export function TerminalView({
     sendTerminalInputData(data);
   };
   const uploadDisabled = !pane || uploading;
-  const showConnectionOverlay =
-    pane !== null &&
-    connectionState !== "attached" &&
-    (connectionState !== "connecting" || showDelayedConnectingOverlay);
 
   const openSelectionUrl = () => {
     if (!mobileSelectionAction) {
@@ -852,7 +817,7 @@ export function TerminalView({
         onChange={handleFileInput}
       />
       {!pane ? <div className="terminal-overlay">No panes available</div> : null}
-      {showConnectionOverlay ? (
+      {pane && connectionState !== "attached" ? (
         <div className="terminal-overlay">{connectionCopy(connectionState, closeReason)}</div>
       ) : null}
       {uploadStatus ? (

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -75,6 +75,7 @@ type MobileSelectionAction = {
 
 const MAX_UPLOAD_FILES = 8;
 const TERMINAL_CONNECT_TIMEOUT_MS = 3500;
+const CONNECTING_OVERLAY_DELAY_MS = 250;
 
 export function TerminalView({
   pane,
@@ -109,7 +110,9 @@ export function TerminalView({
   const uploadConflictRef = useRef<UploadConflictState | null>(null);
   const connectionKeyRef = useRef(connectionKey);
   const terminalIdRef = useRef(pane?.terminal_id ?? null);
+  const connectingOverlayTimerRef = useRef<number | null>(null);
   const [connectionState, setConnectionState] = useState<ConnectionState>("idle");
+  const [showDelayedConnectingOverlay, setShowDelayedConnectingOverlay] = useState(false);
   const [closeReason, setCloseReason] = useState<string | null>(null);
   const [uploadStatus, setUploadStatus] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -598,10 +601,38 @@ export function TerminalView({
   }, [connectionKey, pane?.terminal_id]);
 
   useEffect(() => {
+    if (connectingOverlayTimerRef.current !== null) {
+      window.clearTimeout(connectingOverlayTimerRef.current);
+      connectingOverlayTimerRef.current = null;
+    }
+
+    if (connectionState !== "connecting") {
+      setShowDelayedConnectingOverlay(false);
+      return;
+    }
+
+    connectingOverlayTimerRef.current = window.setTimeout(() => {
+      connectingOverlayTimerRef.current = null;
+      setShowDelayedConnectingOverlay(true);
+    }, CONNECTING_OVERLAY_DELAY_MS);
+
+    return () => {
+      if (connectingOverlayTimerRef.current !== null) {
+        window.clearTimeout(connectingOverlayTimerRef.current);
+        connectingOverlayTimerRef.current = null;
+      }
+    };
+  }, [connectionState]);
+
+  useEffect(() => {
     return () => {
       if (uploadStatusTimerRef.current !== null) {
         window.clearTimeout(uploadStatusTimerRef.current);
         uploadStatusTimerRef.current = null;
+      }
+      if (connectingOverlayTimerRef.current !== null) {
+        window.clearTimeout(connectingOverlayTimerRef.current);
+        connectingOverlayTimerRef.current = null;
       }
       resolveUploadConflict(false, false);
     };
@@ -635,6 +666,10 @@ export function TerminalView({
     sendTerminalInputData(data);
   };
   const uploadDisabled = !pane || uploading;
+  const showConnectionOverlay =
+    pane !== null &&
+    connectionState !== "attached" &&
+    (connectionState !== "connecting" || showDelayedConnectingOverlay);
 
   const openSelectionUrl = () => {
     if (!mobileSelectionAction) {
@@ -817,7 +852,7 @@ export function TerminalView({
         onChange={handleFileInput}
       />
       {!pane ? <div className="terminal-overlay">No panes available</div> : null}
-      {pane && connectionState !== "attached" ? (
+      {showConnectionOverlay ? (
         <div className="terminal-overlay">{connectionCopy(connectionState, closeReason)}</div>
       ) : null}
       {uploadStatus ? (

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -23,6 +23,7 @@ import {
   shouldSendTerminalInputImmediately,
 } from "./terminalInputTransport";
 import type { TerminalInputTransport } from "./terminalInputTransport";
+import { DEFAULT_TERMINAL_OUTPUT_COALESCE_MS } from "./terminalOutputCoalescing";
 import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
 import type { PaneInfo } from "./types";
 
@@ -46,6 +47,8 @@ type Props = {
   terminalInputTransport?: TerminalInputTransport;
   /** Delay for coalescing short terminal input payloads. Zero disables batching. */
   terminalInputBatchDelayMs?: number;
+  /** Delay for coalescing terminal output frames. Zero disables output batching. */
+  terminalOutputCoalesceMs?: number;
   /** Incrementing token from the parent that requests an immediate fit+resize. */
   refitToken?: number;
   /** Incrementing token from the parent that requests focus on the preferred terminal input. */
@@ -89,6 +92,7 @@ export function TerminalView({
   mobileTouchSelection = false,
   terminalInputTransport = "json",
   terminalInputBatchDelayMs = 0,
+  terminalOutputCoalesceMs = DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
   refitToken = 0,
   focusToken = 0,
 }: Props) {
@@ -461,7 +465,7 @@ export function TerminalView({
             return;
           }
           const nextSocket = new WebSocket(
-            terminalSocketUrl(wsUrl, pane.terminal_id, initialSize),
+            terminalSocketUrl(wsUrl, pane.terminal_id, initialSize, terminalOutputCoalesceMs),
           );
           socket = nextSocket;
           socketRef.current = nextSocket;
@@ -573,6 +577,7 @@ export function TerminalView({
     flushBatchedTerminalInput,
     sendTerminalInputData,
     sendTerminalInputFrame,
+    terminalOutputCoalesceMs,
     wsUrl,
   ]);
 
@@ -1165,12 +1170,14 @@ function terminalSocketUrl(
   wsUrl: (path: string, query?: URLSearchParams) => string,
   terminalId: string,
   size: TerminalSize,
+  coalesceMs: number,
 ) {
   const params = new URLSearchParams({
     terminal_id: terminalId,
     cols: String(size.cols),
     rows: String(size.rows),
     takeover: "false",
+    coalesce_ms: String(coalesceMs),
   });
   return wsUrl("/ws/terminal", params);
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2034,15 +2034,6 @@ button {
   transform: translateX(0);
 }
 
-.app[data-compact="true"][data-terminal-switching="true"] .terminal-host,
-.app[data-compact="true"][data-terminal-switching="true"] .terminal-mobile-controls,
-.app[data-compact="true"][data-terminal-switching="true"] .terminal-overlay,
-.app[data-compact="true"][data-terminal-switching="true"] .terminal-upload-fab,
-.app[data-compact="true"][data-terminal-switching="true"] .terminal-upload-status,
-.app[data-compact="true"][data-terminal-switching="true"] .terminal-selection-sheet {
-  visibility: hidden;
-}
-
 .app[data-compact="true"] .sidebar {
   border-right: 0;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2034,6 +2034,15 @@ button {
   transform: translateX(0);
 }
 
+.app[data-compact="true"][data-terminal-switching="true"] .terminal-host,
+.app[data-compact="true"][data-terminal-switching="true"] .terminal-mobile-controls,
+.app[data-compact="true"][data-terminal-switching="true"] .terminal-overlay,
+.app[data-compact="true"][data-terminal-switching="true"] .terminal-upload-fab,
+.app[data-compact="true"][data-terminal-switching="true"] .terminal-upload-status,
+.app[data-compact="true"][data-terminal-switching="true"] .terminal-selection-sheet {
+  visibility: hidden;
+}
+
 .app[data-compact="true"] .sidebar {
   border-right: 0;
 }

--- a/web/src/terminalOutputCoalescing.test.ts
+++ b/web/src/terminalOutputCoalescing.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
+  parseTerminalOutputCoalesceMs,
+} from "./terminalOutputCoalescing";
+
+describe("terminal output coalescing preferences", () => {
+  it("parses supported coalescing windows", () => {
+    expect(parseTerminalOutputCoalesceMs(0)).toBe(0);
+    expect(parseTerminalOutputCoalesceMs(8)).toBe(8);
+    expect(parseTerminalOutputCoalesceMs(16)).toBe(16);
+    expect(parseTerminalOutputCoalesceMs(32)).toBe(32);
+    expect(parseTerminalOutputCoalesceMs(64)).toBe(64);
+    expect(parseTerminalOutputCoalesceMs(128)).toBe(128);
+    expect(parseTerminalOutputCoalesceMs(256)).toBe(256);
+  });
+
+  it("falls back for unsupported coalescing windows", () => {
+    expect(parseTerminalOutputCoalesceMs(24)).toBe(DEFAULT_TERMINAL_OUTPUT_COALESCE_MS);
+    expect(parseTerminalOutputCoalesceMs(512)).toBe(DEFAULT_TERMINAL_OUTPUT_COALESCE_MS);
+    expect(parseTerminalOutputCoalesceMs("16")).toBe(DEFAULT_TERMINAL_OUTPUT_COALESCE_MS);
+  });
+});

--- a/web/src/terminalOutputCoalescing.ts
+++ b/web/src/terminalOutputCoalescing.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_TERMINAL_OUTPUT_COALESCE_MS = 16;
+export const TERMINAL_OUTPUT_COALESCE_OPTIONS_MS = [0, 8, 16, 32, 64, 128, 256] as const;
+
+export function parseTerminalOutputCoalesceMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_TERMINAL_OUTPUT_COALESCE_MS;
+  }
+  return TERMINAL_OUTPUT_COALESCE_OPTIONS_MS.includes(
+    value as (typeof TERMINAL_OUTPUT_COALESCE_OPTIONS_MS)[number],
+  )
+    ? value
+    : DEFAULT_TERMINAL_OUTPUT_COALESCE_MS;
+}


### PR DESCRIPTION
## Summary
- coalesce fast terminal output bursts per browser connection
- add Terminal output batching controls with Off/8/16/32/64/128/256 ms options
- pass coalesce_ms through the terminal WebSocket and clamp it in the bridge

## Test plan
- npm run check
- ANDROID_HOME=/home/kevin/.local/android-sdk ANDROID_SDK_ROOT=/home/kevin/.local/android-sdk npm run android:build:debug
