### PR TITLE
Improve mobile terminal long-press selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Changed
 
+- Changed mobile terminal long-press selection to use a two-stage loupe and endpoint flow; normal
+  selections copy immediately, selected URLs keep the action sheet, and tapped HTTP(S) URLs open
+  directly.
+
 ### Fixed
 
 ### Removed

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -15,7 +15,7 @@ import { ConfirmDialog } from "./overlays";
 import { shellQuote } from "./shell";
 import { findFirstUrlInSelection, openableHttpUrl } from "./terminalSelection";
 import { GhosttyRenderer } from "./terminalRenderer";
-import type { TerminalRenderer, TerminalSize } from "./terminalRenderer";
+import type { MobileTerminalTouchEvent, TerminalRenderer, TerminalSize } from "./terminalRenderer";
 import {
   appendTerminalInputBatch,
   drainTerminalInputBatch,
@@ -75,7 +75,6 @@ type MobileSelectionAction = {
   text: string;
   url: string;
 };
-
 const MAX_UPLOAD_FILES = 8;
 const TERMINAL_CONNECT_TIMEOUT_MS = 3500;
 
@@ -192,11 +191,19 @@ export function TerminalView({
     [showUploadStatus],
   );
 
-  const handleMobileSelection = useCallback(
-    (text: string) => {
-      const trimmed = text.trim();
+  const handleMobileTerminalTouch = useCallback(
+    (event: MobileTerminalTouchEvent) => {
+      if (event.type === "url") {
+        const url = openableHttpUrl(event.url);
+        if (url) {
+          window.open(url, "_blank", "noopener,noreferrer");
+        }
+        return;
+      }
+      const trimmed = event.text.trim();
       setMobileSelectionAction(null);
       if (!trimmed) {
+        rendererRef.current?.clearSelection();
         return;
       }
       const url = findFirstUrlInSelection(trimmed);
@@ -204,6 +211,7 @@ export function TerminalView({
         setMobileSelectionAction({ text: trimmed, url });
         return;
       }
+      rendererRef.current?.clearSelection();
       void copyText(trimmed, "Copied selection");
     },
     [copyText],
@@ -379,7 +387,7 @@ export function TerminalView({
         );
         renderer.setMobileTouchSelection(
           mobileControlsRef.current && mobileTouchSelectionRef.current,
-          handleMobileSelection,
+          mobileControlsRef.current ? handleMobileTerminalTouch : null,
         );
 
         disposeInput = renderer.onInput((data) => {
@@ -594,12 +602,13 @@ export function TerminalView({
   useEffect(() => {
     rendererRef.current?.setMobileTouchSelection(
       mobileControls && mobileTouchSelection,
-      handleMobileSelection,
+      mobileControls ? handleMobileTerminalTouch : null,
     );
-  }, [handleMobileSelection, mobileControls, mobileTouchSelection]);
+  }, [handleMobileTerminalTouch, mobileControls, mobileTouchSelection]);
 
   useEffect(() => {
     setMobileSelectionAction(null);
+    rendererRef.current?.clearSelection();
   }, [connectionKey, pane?.terminal_id]);
 
   useEffect(() => {
@@ -641,6 +650,11 @@ export function TerminalView({
   };
   const uploadDisabled = !pane || uploading;
 
+  const closeMobileSelectionActions = () => {
+    setMobileSelectionAction(null);
+    rendererRef.current?.clearSelection();
+  };
+
   const openSelectionUrl = () => {
     if (!mobileSelectionAction) {
       return;
@@ -651,11 +665,11 @@ export function TerminalView({
     } else {
       void copyText(mobileSelectionAction.text, "Copied selection");
     }
-    setMobileSelectionAction(null);
+    closeMobileSelectionActions();
   };
 
   const copySelectionText = (text: string, successMessage: string) => {
-    setMobileSelectionAction(null);
+    closeMobileSelectionActions();
     void copyText(text, successMessage);
   };
 
@@ -860,9 +874,7 @@ export function TerminalView({
           onOpen={openSelectionUrl}
           onCopyUrl={() => copySelectionText(mobileSelectionAction.url, "Copied URL")}
           onCopyText={() => copySelectionText(mobileSelectionAction.text, "Copied selection")}
-          onClose={() => {
-            setMobileSelectionAction(null);
-          }}
+          onClose={closeMobileSelectionActions}
         />
       ) : null}
       {uploadConflict ? (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1075,6 +1075,70 @@ button {
   flex: 0 0 auto;
 }
 
+.terminal-touch-loupe {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 8;
+  width: 132px;
+  height: 82px;
+  overflow: hidden;
+  pointer-events: none;
+  border: 1px solid color-mix(in srgb, var(--accent) 68%, white);
+  border-radius: 18px;
+  background: var(--term-bg);
+  box-shadow: 0 12px 34px rgb(0 0 0 / 44%), 0 0 0 1px rgb(255 255 255 / 8%) inset;
+  will-change: transform;
+}
+
+.terminal-touch-loupe canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.terminal-touch-endpoint {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 7;
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--accent) 72%, white);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 78%, var(--mantle));
+  box-shadow: 0 10px 28px rgb(0 0 0 / 38%);
+  touch-action: none;
+  will-change: transform;
+}
+
+.terminal-touch-endpoint::before {
+  content: attr(data-hint);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 5px);
+  transform: translateX(-50%);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 2px 7px;
+  background: color-mix(in srgb, var(--mantle) 92%, black);
+  color: var(--text);
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.terminal-touch-endpoint::after {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: inherit;
+  background: var(--base);
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 42%);
+}
+
 .terminal-mobile-controls {
   --mobile-control-gap: calc(5px * var(--mobile-controls-scale));
   --mobile-key-height: calc(30px * var(--mobile-controls-scale));

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -1,8 +1,18 @@
 import type { FitAddon, Terminal } from "ghostty-web";
-import { selectedTextFromVisibleRows, terminalSelectionRange } from "./terminalSelection";
+import { terminalSelectionRange, terminalUrlTapTarget, trimUrlPunctuation } from "./terminalSelection";
 import type { TerminalSelectionPoint } from "./terminalSelection";
 import { terminalTapFocusAction } from "./terminalTapFocus";
 import type { TerminalTapFocusResult } from "./terminalTapFocus";
+import {
+  beginTouchSelectionEndpointDrag,
+  commitTouchSelectionStart,
+  completeTouchSelection,
+  idleTouchSelectionState,
+  moveTouchSelectionEndpoint,
+  moveTouchSelectionPlacement,
+  startTouchSelectionPlacement,
+} from "./terminalTouchSelection";
+import type { TerminalTouchSelectionState } from "./terminalTouchSelection";
 
 const TERMINAL_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace';
@@ -10,11 +20,16 @@ const TERMINAL_TEXT_INPUT_TAP_GRACE_MS = 4000;
 const TOUCH_SELECTION_LONG_PRESS_MS = 600;
 const TOUCH_SELECTION_TOLERANCE_PX = 10;
 const TOUCH_SELECTION_SCROLL_INTENT_PX = 5;
-const TOUCH_SELECTION_CLEAR_DELAY_MS = 1200;
+const TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS = 1500;
 const TOUCH_COMPAT_MOUSE_SUPPRESS_MS = 1200;
+const TOUCH_LOUPE_WIDTH_PX = 132;
+const TOUCH_LOUPE_HEIGHT_PX = 82;
+const TOUCH_LOUPE_SOURCE_WIDTH_PX = 70;
+const TOUCH_LOUPE_SOURCE_HEIGHT_PX = 44;
+const TOUCH_LOUPE_OFFSET_Y_PX = 108;
+const TOUCH_ENDPOINT_SIZE_PX = 46;
 const TAP_URL_PATTERN =
   /(?:https?:\/\/|mailto:|ftp:\/\/|ssh:\/\/|git:\/\/|tel:|magnet:|gemini:\/\/|gopher:\/\/|news:)[\w\-.~:/?#@!$&*+,;=%]+/giu;
-const TAP_URL_TRAILING_PUNCTUATION = /[.,;!?)\]]+$/u;
 
 type GhosttyModule = typeof import("ghostty-web");
 
@@ -68,17 +83,22 @@ type TerminalBufferLine = {
     | undefined;
 };
 
+export type MobileTerminalTouchEvent =
+  | { type: "selection"; text: string }
+  | { type: "url"; url: string };
+
 export type TerminalRenderer = {
   mount(container: HTMLElement): Promise<TerminalSize>;
   write(data: string | Uint8Array): void;
   onInput(callback: (data: string) => void): () => void;
   onScroll(callback: (lines: number) => void): () => void;
   setTapFocusHandler(callback: (() => TerminalTapFocusResult) | null): void;
-  setMobileTouchSelection(enabled: boolean, callback: ((text: string) => void) | null): void;
+  setMobileTouchSelection(enabled: boolean, callback: ((event: MobileTerminalTouchEvent) => void) | null): void;
   fit(): TerminalSize;
   refreshMetrics(): TerminalSize;
   focus(): void;
   focusTextInput(): void;
+  clearSelection(): void;
   setScrollSensitivity(value: number): void;
   dispose(): void;
 };
@@ -93,7 +113,7 @@ export class GhosttyRenderer implements TerminalRenderer {
   #mobileInputCleanup: (() => void) | null = null;
   #tapFocusHandler: (() => TerminalTapFocusResult) | null = null;
   #mobileTouchSelectionEnabled = false;
-  #mobileTouchSelectionHandler: ((text: string) => void) | null = null;
+  #mobileTouchSelectionHandler: ((event: MobileTerminalTouchEvent) => void) | null = null;
   #textInputTapGraceUntil = 0;
 
   async mount(container: HTMLElement) {
@@ -179,7 +199,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     this.#tapFocusHandler = callback;
   }
 
-  setMobileTouchSelection(enabled: boolean, callback: ((text: string) => void) | null) {
+  setMobileTouchSelection(enabled: boolean, callback: ((event: MobileTerminalTouchEvent) => void) | null) {
     const changed = this.#mobileTouchSelectionEnabled !== enabled;
     this.#mobileTouchSelectionEnabled = enabled;
     this.#mobileTouchSelectionHandler = callback;
@@ -223,6 +243,10 @@ export class GhosttyRenderer implements TerminalRenderer {
         textarea.focus({ preventScroll: true });
       }
     }, 0);
+  }
+
+  clearSelection() {
+    this.#terminal?.clearSelection();
   }
 
   setScrollSensitivity(value: number) {
@@ -306,10 +330,14 @@ export class GhosttyRenderer implements TerminalRenderer {
     let pendingTouchLines = 0;
     let suppressMouseUntil = 0;
     let selectionTimer: number | null = null;
-    let selectingFromTouch = false;
-    let selectionStart: TerminalCellPosition | null = null;
-    let selectionEnd: TerminalCellPosition | null = null;
-    let selectionClearTimer: number | null = null;
+    let endpointTimer: number | null = null;
+    let selectionState: TerminalTouchSelectionState = idleTouchSelectionState;
+    let endpointBubble: HTMLDivElement | null = null;
+    let loupe: { root: HTMLDivElement; canvas: HTMLCanvasElement } | null = null;
+    let endpointDragStartX: number | null = null;
+    let endpointDragStartY: number | null = null;
+    let endpointDragMoved = false;
+
     const suppressMouseEvents = (duration = TOUCH_COMPAT_MOUSE_SUPPRESS_MS) => {
       suppressMouseUntil = performance.now() + duration;
     };
@@ -319,17 +347,32 @@ export class GhosttyRenderer implements TerminalRenderer {
         selectionTimer = null;
       }
     };
-    const clearSelectionClearTimer = () => {
-      if (selectionClearTimer !== null) {
-        window.clearTimeout(selectionClearTimer);
-        selectionClearTimer = null;
+    const clearEndpointTimer = () => {
+      if (endpointTimer !== null) {
+        window.clearTimeout(endpointTimer);
+        endpointTimer = null;
       }
     };
-    const stopTouchSelection = () => {
+    const removeEndpointBubble = () => {
+      endpointBubble?.remove();
+      endpointBubble = null;
+    };
+    const removeLoupe = () => {
+      loupe?.root.remove();
+      loupe = null;
+    };
+    const resetTouchSelection = (clearTerminalSelection = true) => {
       clearSelectionTimer();
-      selectingFromTouch = false;
-      selectionStart = null;
-      selectionEnd = null;
+      clearEndpointTimer();
+      selectionState = idleTouchSelectionState;
+      removeEndpointBubble();
+      removeLoupe();
+      endpointDragStartX = null;
+      endpointDragStartY = null;
+      endpointDragMoved = false;
+      if (clearTerminalSelection) {
+        terminal.clearSelection();
+      }
     };
     const preventTouchEvent = (event: TouchEvent) => {
       event.preventDefault();
@@ -339,14 +382,127 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
     };
     const positionFromTouch = (touch: Touch) => touchCellPosition(terminal, touch.clientX, touch.clientY);
-    const updateTouchSelection = (touch: Touch) => {
-      if (!selectionStart) {
+    const clientFromTouch = (touch: Touch) => ({ clientX: touch.clientX, clientY: touch.clientY });
+    const selectCurrentTouchRange = () => {
+      if (selectionState.phase === "idle") {
         return;
       }
-      const current = positionFromTouch(touch);
-      const range = terminalSelectionRange(selectionStart, current, terminal.cols);
-      selectionEnd = current;
+      const range = terminalSelectionRange(selectionState.start, selectionState.endpoint, terminal.cols);
       selectTerminalViewportRange(terminal, range.from, range.to);
+    };
+    const cellClientCenter = (point: TerminalCellPosition) => {
+      const canvas = terminal.renderer?.getCanvas();
+      const rect = (canvas ?? terminal.element)?.getBoundingClientRect();
+      const metrics = terminal.renderer?.getMetrics();
+      const cellWidth = metrics?.width ?? 9;
+      const cellHeight = metrics?.height ?? 16;
+      return {
+        clientX: (rect?.left ?? 0) + (point.col + 0.5) * cellWidth,
+        clientY: (rect?.top ?? 0) + (point.row + 0.5) * cellHeight,
+      };
+    };
+    const positionOverlay = (
+      element: HTMLElement,
+      clientX: number,
+      clientY: number,
+      width: number,
+      height: number,
+      offsetY: number,
+    ) => {
+      const rect = container.getBoundingClientRect();
+      const left = clampInteger(clientX - rect.left - width / 2, 4, Math.max(4, rect.width - width - 4));
+      const top = clampInteger(clientY - rect.top - offsetY, 4, Math.max(4, rect.height - height - 4));
+      element.style.transform = `translate(${left}px, ${top}px)`;
+    };
+    const ensureLoupe = () => {
+      if (loupe) {
+        return loupe;
+      }
+      const root = document.createElement("div");
+      root.className = "terminal-touch-loupe";
+      const canvas = document.createElement("canvas");
+      canvas.width = TOUCH_LOUPE_WIDTH_PX;
+      canvas.height = TOUCH_LOUPE_HEIGHT_PX;
+      root.append(canvas);
+      container.append(root);
+      loupe = { root, canvas };
+      return loupe;
+    };
+    const renderLoupe = (point: TerminalCellPosition, client: { clientX: number; clientY: number }) => {
+      const source = terminal.renderer?.getCanvas();
+      if (!source) {
+        return;
+      }
+      const current = ensureLoupe();
+      positionOverlay(
+        current.root,
+        client.clientX,
+        client.clientY,
+        TOUCH_LOUPE_WIDTH_PX,
+        TOUCH_LOUPE_HEIGHT_PX,
+        TOUCH_LOUPE_OFFSET_Y_PX,
+      );
+      const rect = source.getBoundingClientRect();
+      const metrics = terminal.renderer?.getMetrics();
+      const cellWidth = metrics?.width ?? 9;
+      const cellHeight = metrics?.height ?? 16;
+      const centerX = (point.col + 0.5) * cellWidth;
+      const centerY = (point.row + 0.5) * cellHeight;
+      const sourceWidth = Math.min(TOUCH_LOUPE_SOURCE_WIDTH_PX, rect.width || TOUCH_LOUPE_SOURCE_WIDTH_PX);
+      const sourceHeight = Math.min(TOUCH_LOUPE_SOURCE_HEIGHT_PX, rect.height || TOUCH_LOUPE_SOURCE_HEIGHT_PX);
+      const sxCss = clampNumber(centerX - sourceWidth / 2, 0, Math.max(0, rect.width - sourceWidth));
+      const syCss = clampNumber(centerY - sourceHeight / 2, 0, Math.max(0, rect.height - sourceHeight));
+      const scaleX = rect.width > 0 ? source.width / rect.width : 1;
+      const scaleY = rect.height > 0 ? source.height / rect.height : 1;
+      const ctx = current.canvas.getContext("2d");
+      if (!ctx) {
+        return;
+      }
+      ctx.clearRect(0, 0, current.canvas.width, current.canvas.height);
+      ctx.imageSmoothingEnabled = false;
+      ctx.drawImage(
+        source,
+        sxCss * scaleX,
+        syCss * scaleY,
+        sourceWidth * scaleX,
+        sourceHeight * scaleY,
+        0,
+        0,
+        TOUCH_LOUPE_WIDTH_PX,
+        TOUCH_LOUPE_HEIGHT_PX,
+      );
+      const caretX = ((centerX - sxCss) / sourceWidth) * TOUCH_LOUPE_WIDTH_PX;
+      ctx.strokeStyle = "rgba(245, 224, 220, 0.95)";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(caretX, 10);
+      ctx.lineTo(caretX, TOUCH_LOUPE_HEIGHT_PX - 10);
+      ctx.stroke();
+      ctx.strokeStyle = "rgba(17, 17, 27, 0.85)";
+      ctx.lineWidth = 1;
+      ctx.strokeRect(1, 1, TOUCH_LOUPE_WIDTH_PX - 2, TOUCH_LOUPE_HEIGHT_PX - 2);
+    };
+    const ensureEndpointBubble = () => {
+      if (endpointBubble) {
+        return endpointBubble;
+      }
+      endpointBubble = document.createElement("div");
+      endpointBubble.className = "terminal-touch-endpoint";
+      endpointBubble.setAttribute("aria-hidden", "true");
+      endpointBubble.setAttribute("data-hint", "Drag");
+      container.append(endpointBubble);
+      return endpointBubble;
+    };
+    const positionEndpointBubble = (client: { clientX: number; clientY: number }) => {
+      const bubble = ensureEndpointBubble();
+      positionOverlay(
+        bubble,
+        client.clientX,
+        client.clientY,
+        TOUCH_ENDPOINT_SIZE_PX,
+        TOUCH_ENDPOINT_SIZE_PX,
+        TOUCH_ENDPOINT_SIZE_PX / 2,
+      );
     };
     const startTouchSelection = () => {
       selectionTimer = null;
@@ -359,50 +515,101 @@ export class GhosttyRenderer implements TerminalRenderer {
         return;
       }
       const position = touchCellPosition(terminal, touchStartX, touchStartY);
-      selectionStart = position;
-      selectionEnd = position;
-      selectingFromTouch = true;
+      const client = { clientX: touchStartX, clientY: touchStartY };
+      selectionState = startTouchSelectionPlacement(position, client);
       touchMoved = true;
       suppressMouseEvents();
       terminal.textarea?.blur();
       terminal.clearSelection();
-      selectTerminalViewportRange(terminal, position, position);
+      selectCurrentTouchRange();
+      renderLoupe(position, client);
       if (navigator.vibrate) {
         navigator.vibrate(35);
       }
     };
-    const completeTouchSelection = (event: TouchEvent) => {
+    const updateStartPlacement = (touch: Touch) => {
+      const position = positionFromTouch(touch);
+      const client = clientFromTouch(touch);
+      selectionState = moveTouchSelectionPlacement(selectionState, position, client);
+      selectCurrentTouchRange();
+      renderLoupe(position, client);
+    };
+    const waitForEndpointDrag = () => {
+      selectionState = commitTouchSelectionStart(selectionState);
+      removeLoupe();
+      if (selectionState.phase !== "waiting-endpoint") {
+        return;
+      }
+      selectCurrentTouchRange();
+      positionEndpointBubble(cellClientCenter(selectionState.start));
+      clearEndpointTimer();
+      endpointTimer = window.setTimeout(() => {
+        resetTouchSelection(true);
+      }, TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS);
+    };
+    const beginEndpointDrag = (touch: Touch) => {
+      clearEndpointTimer();
+      if (selectionState.phase !== "waiting-endpoint") {
+        return;
+      }
+      endpointDragStartX = touch.clientX;
+      endpointDragStartY = touch.clientY;
+      endpointDragMoved = false;
+      const client = clientFromTouch(touch);
+      selectionState = beginTouchSelectionEndpointDrag(selectionState, selectionState.endpoint, client);
+      if (selectionState.phase !== "dragging-endpoint") {
+        return;
+      }
+      selectCurrentTouchRange();
+      positionEndpointBubble(client);
+      renderLoupe(selectionState.endpoint, client);
+      suppressMouseEvents();
+      terminal.textarea?.blur();
+    };
+    const updateEndpointDrag = (touch: Touch, force = false) => {
+      if (endpointDragStartX !== null && endpointDragStartY !== null) {
+        const deltaX = touch.clientX - endpointDragStartX;
+        const deltaY = touch.clientY - endpointDragStartY;
+        if (!endpointDragMoved && Math.hypot(deltaX, deltaY) <= TOUCH_SELECTION_TOLERANCE_PX && !force) {
+          positionEndpointBubble(clientFromTouch(touch));
+          return;
+        }
+        endpointDragMoved = true;
+      }
+      const position = positionFromTouch(touch);
+      const client = clientFromTouch(touch);
+      selectionState = moveTouchSelectionEndpoint(selectionState, position, client);
+      selectCurrentTouchRange();
+      positionEndpointBubble(client);
+      renderLoupe(position, client);
+    };
+    const completeEndpointDrag = (event: TouchEvent) => {
+      if (event.changedTouches.length > 0 && endpointDragMoved) {
+        updateEndpointDrag(event.changedTouches[0], true);
+      }
       preventTouchEvent(event);
       suppressMouseEvents();
-      const selectedText =
-        selectionStart && selectionEnd
-          ? terminalSelectedTextFromViewportRange(terminal, selectionStart, selectionEnd)
-          : "";
-      stopTouchSelection();
-      terminal.textarea?.blur();
-      if (selectedText.trim()) {
-        this.#mobileTouchSelectionHandler?.(selectedText);
-        clearSelectionClearTimer();
-        selectionClearTimer = window.setTimeout(() => {
-          selectionClearTimer = null;
-          terminal.clearSelection();
-        }, TOUCH_SELECTION_CLEAR_DELAY_MS);
+      const selection = completeTouchSelection(selectionState);
+      const selectedText = selection
+        ? terminalSelectedTextFromViewportRange(terminal, selection.start, selection.end)
+        : "";
+      if (selectedText.length > 0 && this.#mobileTouchSelectionHandler) {
+        resetTouchSelection(false);
+        terminal.textarea?.blur();
+        this.#mobileTouchSelectionHandler({ type: "selection", text: selectedText });
+      } else {
+        resetTouchSelection(true);
+        terminal.textarea?.blur();
       }
     };
     const touchLinkText = (event: TouchEvent) => {
-      if (
-        !this.#mobileTouchSelectionEnabled ||
-        !this.#mobileTouchSelectionHandler ||
-        event.changedTouches.length === 0
-      ) {
-        return null;
-      }
-      if (this.#hasMouseTracking(terminal)) {
+      const mouseTracking = this.#hasMouseTracking(terminal);
+      if (!this.#mobileTouchSelectionHandler || event.changedTouches.length === 0 || mouseTracking) {
         return null;
       }
       const touch = event.changedTouches[0];
       const position = positionFromTouch(touch);
-      return terminalLinkAt(terminal, position);
+      return terminalUrlTapTarget(terminalLinkAt(terminal, position), mouseTracking);
     };
     const redirectTapFocus = (event: TouchEvent | MouseEvent) => {
       const terminalHadFocusOrGrace =
@@ -423,8 +630,29 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
       return true;
     };
+    const resetTouchTracking = () => {
+      lastTouchY = null;
+      touchStartX = null;
+      touchStartY = null;
+      touchMoved = false;
+      touchScrolled = false;
+      pendingTouchLines = 0;
+    };
     const onTouchStart = (event: TouchEvent) => {
       clearSelectionTimer();
+      if (selectionState.phase === "waiting-endpoint") {
+        if (
+          event.touches.length === 1 &&
+          endpointBubble &&
+          event.target instanceof Node &&
+          endpointBubble.contains(event.target)
+        ) {
+          preventTouchEvent(event);
+          beginEndpointDrag(event.touches[0]);
+          return;
+        }
+        resetTouchSelection(true);
+      }
       if (event.touches.length === 1) {
         const mouseTracking = this.#hasMouseTracking(terminal);
         if (this.#mobileTouchSelectionEnabled && !mouseTracking) {
@@ -437,11 +665,7 @@ export class GhosttyRenderer implements TerminalRenderer {
         lastTouchY = touch.clientY;
         touchMoved = false;
         touchScrolled = false;
-        selectingFromTouch = false;
-        selectionStart = null;
-        selectionEnd = null;
         if (this.#mobileTouchSelectionEnabled && !mouseTracking) {
-          clearSelectionClearTimer();
           selectionTimer = window.setTimeout(startTouchSelection, TOUCH_SELECTION_LONG_PRESS_MS);
         }
       }
@@ -459,8 +683,13 @@ export class GhosttyRenderer implements TerminalRenderer {
           clearSelectionTimer();
         }
       }
-      if (selectingFromTouch && event.touches.length === 1) {
-        updateTouchSelection(event.touches[0]);
+      if (selectionState.phase === "placing-start" && event.touches.length === 1) {
+        updateStartPlacement(event.touches[0]);
+        preventTouchEvent(event);
+        return;
+      }
+      if (selectionState.phase === "dragging-endpoint" && event.touches.length === 1) {
+        updateEndpointDrag(event.touches[0]);
         preventTouchEvent(event);
         return;
       }
@@ -498,22 +727,22 @@ export class GhosttyRenderer implements TerminalRenderer {
     const onTouchEnd = (event: TouchEvent) => {
       clearSelectionTimer();
       if (this.#hasMouseTracking(terminal)) {
-        lastTouchY = null;
-        touchStartX = null;
-        touchStartY = null;
-        touchMoved = false;
-        touchScrolled = false;
-        pendingTouchLines = 0;
+        if (selectionState.phase !== "idle") {
+          resetTouchSelection(true);
+        }
+        resetTouchTracking();
         return;
       }
-      if (selectingFromTouch) {
-        completeTouchSelection(event);
-        lastTouchY = null;
-        touchStartX = null;
-        touchStartY = null;
-        touchMoved = false;
-        touchScrolled = false;
-        pendingTouchLines = 0;
+      if (selectionState.phase === "placing-start") {
+        preventTouchEvent(event);
+        suppressMouseEvents();
+        waitForEndpointDrag();
+        resetTouchTracking();
+        return;
+      }
+      if (selectionState.phase === "dragging-endpoint") {
+        completeEndpointDrag(event);
+        resetTouchTracking();
         return;
       }
       if (touchMoved || touchScrolled) {
@@ -530,31 +759,20 @@ export class GhosttyRenderer implements TerminalRenderer {
           preventTouchEvent(event);
           suppressMouseEvents();
           terminal.textarea?.blur();
-          this.#mobileTouchSelectionHandler?.(linkText);
+          this.#mobileTouchSelectionHandler?.({ type: "url", url: linkText });
         } else {
           redirectTapFocus(event);
         }
       }
-      lastTouchY = null;
-      touchStartX = null;
-      touchStartY = null;
-      touchMoved = false;
-      touchScrolled = false;
-      pendingTouchLines = 0;
+      resetTouchTracking();
     };
     const onTouchCancel = () => {
       clearSelectionTimer();
-      if (selectingFromTouch) {
-        terminal.clearSelection();
+      if (selectionState.phase !== "idle") {
         suppressMouseEvents();
       }
-      stopTouchSelection();
-      lastTouchY = null;
-      touchStartX = null;
-      touchStartY = null;
-      touchMoved = false;
-      touchScrolled = false;
-      pendingTouchLines = 0;
+      resetTouchSelection(true);
+      resetTouchTracking();
       terminal.textarea?.blur();
     };
     const suppressCompatMouseEvent = (event: MouseEvent) => {
@@ -597,8 +815,8 @@ export class GhosttyRenderer implements TerminalRenderer {
     container.addEventListener("mouseup", onMouseUp, { capture: true });
     container.addEventListener("click", onClick, { capture: true });
     this.#touchCleanup = () => {
-      clearSelectionTimer();
-      clearSelectionClearTimer();
+      resetTouchSelection(true);
+      resetTouchTracking();
       container.removeEventListener("touchstart", onTouchStart, { capture: true });
       container.removeEventListener("touchmove", onTouchMove, { capture: true });
       container.removeEventListener("touchend", onTouchEnd, { capture: true });
@@ -860,6 +1078,11 @@ function selectTerminalViewportRange(
     return;
   }
 
+  if (start.row === end.row && start.col === end.col) {
+    terminal.select(start.col, start.row, 1);
+    return;
+  }
+
   markSelectionRowsDirty(selectionManager, selectionManager.getSelectionCoords());
   selectionManager.selectionStart = {
     col: start.col,
@@ -916,17 +1139,29 @@ function terminalSelectedTextFromViewportRange(
   end: TerminalSelectionPoint,
 ) {
   const range = terminalSelectionRange(start, end, terminal.cols);
-  if (range.length <= 1) {
-    return "";
-  }
 
-  const rows: string[] = [];
+  const selectedLines: string[] = [];
   for (let row = range.from.row; row <= range.to.row; row += 1) {
     const bufferRow = terminalBufferRow(terminal, row);
     const line = terminal.buffer.active.getLine(bufferRow) as TerminalBufferLine | undefined;
-    rows[row] = line ? terminalBufferLineText(line).text : "";
+    const startCol = row === range.from.row ? range.from.col : 0;
+    const endCol = row === range.to.row ? range.to.col : terminal.cols - 1;
+    selectedLines.push(line ? terminalBufferLineCellText(line, startCol, endCol).trimEnd() : "");
   }
-  return selectedTextFromVisibleRows(rows, start, end, terminal.cols);
+  return selectedLines.join("\n");
+}
+
+function terminalBufferLineCellText(line: TerminalBufferLine, startCol: number, endCol: number) {
+  let text = "";
+  for (let col = startCol; col <= endCol && col < line.length; col += 1) {
+    const cell = line.getCell(col);
+    const codepoint = cell?.getCodepoint() ?? 0;
+    if (codepoint === 0 && cell?.getWidth() === 0) {
+      continue;
+    }
+    text += codepoint === 0 || codepoint < 32 ? " " : String.fromCodePoint(codepoint);
+  }
+  return text;
 }
 
 function terminalLinkAt(terminal: Terminal, position: TerminalCellPosition) {
@@ -947,7 +1182,7 @@ function terminalLinkAt(terminal: Terminal, position: TerminalCellPosition) {
   let match = TAP_URL_PATTERN.exec(text);
   while (match) {
     const rawUrl = match[0];
-    const url = rawUrl.replace(TAP_URL_TRAILING_PUNCTUATION, "");
+    const url = trimUrlPunctuation(rawUrl);
     const start = columns[match.index];
     const end = columns[match.index + url.length - 1];
     if (url.length > 8 && position.col >= start && position.col <= end) {
@@ -977,6 +1212,10 @@ function terminalBufferLineText(line: TerminalBufferLine) {
 }
 
 function clampInteger(value: number, min: number, max: number) {
+  return Math.round(clampNumber(value, min, max));
+}
+
+function clampNumber(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 

--- a/web/src/terminalSelection.test.ts
+++ b/web/src/terminalSelection.test.ts
@@ -5,6 +5,7 @@ import {
   openableHttpUrl,
   selectedTextFromVisibleRows,
   terminalSelectionRange,
+  terminalUrlTapTarget,
 } from "./terminalSelection";
 
 describe("terminal selection helpers", () => {
@@ -57,6 +58,15 @@ describe("terminal selection helpers", () => {
     expect(openableHttpUrl("tel:+15555555555")).toBeNull();
   });
 
+  it("opens tapped terminal URLs only when mouse tracking is inactive", () => {
+    expect(terminalUrlTapTarget("https://example.com/path", false)).toBe(
+      "https://example.com/path",
+    );
+    expect(terminalUrlTapTarget("https://example.com/path", true)).toBeNull();
+    expect(terminalUrlTapTarget("mailto:test@example.com", false)).toBeNull();
+    expect(terminalUrlTapTarget(null, false)).toBeNull();
+  });
+
   it("orders forward and backward terminal selection ranges", () => {
     expect(terminalSelectionRange({ col: 2, row: 1 }, { col: 5, row: 3 }, 10)).toEqual({
       from: { col: 2, row: 1 },
@@ -89,9 +99,9 @@ describe("terminal selection helpers", () => {
     );
   });
 
-  it("ignores single-cell selections to match terminal hasSelection behavior", () => {
+  it("extracts a single character for same-cell selections", () => {
     expect(selectedTextFromVisibleRows(["alpha"], { col: 1, row: 0 }, { col: 1, row: 0 }, 10)).toBe(
-      "",
+      "l",
     );
   });
 });

--- a/web/src/terminalSelection.ts
+++ b/web/src/terminalSelection.ts
@@ -31,9 +31,6 @@ export function selectedTextFromVisibleRows(
   cols: number,
 ) {
   const range = terminalSelectionRange(start, end, cols);
-  if (range.length <= 1) {
-    return "";
-  }
 
   const selectedLines: string[] = [];
   for (let row = range.from.row; row <= range.to.row; row += 1) {
@@ -69,6 +66,13 @@ export function openableHttpUrl(value: string) {
   }
 }
 
+export function terminalUrlTapTarget(value: string | null, mouseTracking: boolean) {
+  if (mouseTracking || !value) {
+    return null;
+  }
+  return openableHttpUrl(value);
+}
+
 export function normalizeSelectionForUrl(selection: string) {
   return selection.replace(/\s*\n\s*/gu, "").replace(/[ \t\r\f\v]+/gu, " ").trim();
 }
@@ -96,7 +100,7 @@ function shouldJoinWrappedUrl(url: string, continuation: string) {
   return /[/?#&=._~%+-]$/u.test(url) || /^[/?#&=._~%+-]/u.test(continuation);
 }
 
-function trimUrlPunctuation(value: string) {
+export function trimUrlPunctuation(value: string) {
   let next = value.replace(TRAILING_URL_PUNCTUATION, "");
   while (TRAILING_BALANCED_CLOSERS.test(next) && hasUnmatchedTrailingCloser(next)) {
     next = next.slice(0, -1);

--- a/web/src/terminalTouchSelection.test.ts
+++ b/web/src/terminalTouchSelection.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  beginTouchSelectionEndpointDrag,
+  commitTouchSelectionStart,
+  completeTouchSelection,
+  moveTouchSelectionEndpoint,
+  moveTouchSelectionPlacement,
+  startTouchSelectionPlacement,
+} from "./terminalTouchSelection";
+
+describe("terminal touch selection flow", () => {
+  it("commits a refined long-press point as the selection start", () => {
+    const placing = startTouchSelectionPlacement(
+      { col: 1, row: 2 },
+      { clientX: 20, clientY: 40 },
+    );
+    const refined = moveTouchSelectionPlacement(placing, { col: 3, row: 2 }, { clientX: 42, clientY: 40 });
+    const waiting = commitTouchSelectionStart(refined);
+
+    expect(waiting).toMatchObject({
+      phase: "waiting-endpoint",
+      start: { col: 3, row: 2 },
+      endpoint: { col: 3, row: 2 },
+    });
+  });
+
+  it("completes forward endpoint drags", () => {
+    const waiting = commitTouchSelectionStart(
+      startTouchSelectionPlacement({ col: 2, row: 1 }, { clientX: 18, clientY: 30 }),
+    );
+    const dragging = beginTouchSelectionEndpointDrag(waiting, { col: 7, row: 1 }, { clientX: 63, clientY: 30 });
+
+    expect(completeTouchSelection(dragging)).toEqual({
+      start: { col: 2, row: 1 },
+      end: { col: 7, row: 1 },
+    });
+  });
+
+  it("completes backward endpoint drags without reordering the anchor", () => {
+    const waiting = commitTouchSelectionStart(
+      startTouchSelectionPlacement({ col: 8, row: 3 }, { clientX: 72, clientY: 58 }),
+    );
+    const dragging = beginTouchSelectionEndpointDrag(waiting, { col: 4, row: 2 }, { clientX: 36, clientY: 42 });
+    const moved = moveTouchSelectionEndpoint(dragging, { col: 1, row: 2 }, { clientX: 9, clientY: 42 });
+
+    expect(completeTouchSelection(moved)).toEqual({
+      start: { col: 8, row: 3 },
+      end: { col: 1, row: 2 },
+    });
+  });
+});

--- a/web/src/terminalTouchSelection.ts
+++ b/web/src/terminalTouchSelection.ts
@@ -1,0 +1,90 @@
+import type { TerminalSelectionPoint } from "./terminalSelection";
+
+export type TerminalTouchClientPoint = {
+  clientX: number;
+  clientY: number;
+};
+
+export type TerminalTouchSelectionState =
+  | { phase: "idle" }
+  | {
+      phase: "placing-start";
+      start: TerminalSelectionPoint;
+      endpoint: TerminalSelectionPoint;
+      client: TerminalTouchClientPoint;
+    }
+  | {
+      phase: "waiting-endpoint";
+      start: TerminalSelectionPoint;
+      endpoint: TerminalSelectionPoint;
+      client: TerminalTouchClientPoint;
+    }
+  | {
+      phase: "dragging-endpoint";
+      start: TerminalSelectionPoint;
+      endpoint: TerminalSelectionPoint;
+      client: TerminalTouchClientPoint;
+    };
+
+export const idleTouchSelectionState: TerminalTouchSelectionState = { phase: "idle" };
+
+export function startTouchSelectionPlacement(
+  point: TerminalSelectionPoint,
+  client: TerminalTouchClientPoint,
+): TerminalTouchSelectionState {
+  return { phase: "placing-start", start: point, endpoint: point, client };
+}
+
+export function moveTouchSelectionPlacement(
+  state: TerminalTouchSelectionState,
+  point: TerminalSelectionPoint,
+  client: TerminalTouchClientPoint,
+): TerminalTouchSelectionState {
+  if (state.phase !== "placing-start") {
+    return state;
+  }
+  return { ...state, start: point, endpoint: point, client };
+}
+
+export function commitTouchSelectionStart(
+  state: TerminalTouchSelectionState,
+): TerminalTouchSelectionState {
+  if (state.phase !== "placing-start") {
+    return state;
+  }
+  return {
+    phase: "waiting-endpoint",
+    start: state.start,
+    endpoint: state.start,
+    client: state.client,
+  };
+}
+
+export function beginTouchSelectionEndpointDrag(
+  state: TerminalTouchSelectionState,
+  point: TerminalSelectionPoint,
+  client: TerminalTouchClientPoint,
+): TerminalTouchSelectionState {
+  if (state.phase !== "waiting-endpoint") {
+    return state;
+  }
+  return { phase: "dragging-endpoint", start: state.start, endpoint: point, client };
+}
+
+export function moveTouchSelectionEndpoint(
+  state: TerminalTouchSelectionState,
+  point: TerminalSelectionPoint,
+  client: TerminalTouchClientPoint,
+): TerminalTouchSelectionState {
+  if (state.phase !== "dragging-endpoint") {
+    return state;
+  }
+  return { ...state, endpoint: point, client };
+}
+
+export function completeTouchSelection(state: TerminalTouchSelectionState) {
+  if (state.phase !== "dragging-endpoint") {
+    return null;
+  }
+  return { start: state.start, end: state.endpoint };
+}


### PR DESCRIPTION
I love the long-press functionality you added. My finger had trouble selecting text because the text I want often starts near the edge of the screen. This PR adds a magnifying-glass-style selection flow: long-press, drag the magnified section to the exact starting point, release, then drag and release again to set the endpoint.

The new flow keeps the existing URL action menu behavior. Plain text selections copy immediately. URL selections keep the Open / Copy URL / Copy text / Close menu. Direct taps on HTTP(S) URLs still open when terminal mouse tracking is inactive.

Demo video in follow up comment below

changes:
- Add a two-stage mobile terminal touch-selection state machine.
- Add canvas-pixel loupe and endpoint bubble overlays.
- Preserve the selected URL action sheet after endpoint release.
- Allow one-cell selections to copy one character.
- Keep long-press selection and URL taps disabled while terminal mouse tracking is active.

Validation:
- `npm run check`
- Android debug build with `mise exec -- npm run android:build:debug`
