### PR TITLE
Polish mobile terminal selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 ### Added
 
+- Added a Terminal font size setting.
+
 ### Changed
 
-- Changed mobile terminal long-press selection to use a two-stage loupe and endpoint flow; normal
-  selections copy immediately, selected URLs keep the action sheet, and tapped HTTP(S) URLs open
+- Added a Mobile setting for long-press behavior, with Off, Copy, and Loupe modes; Loupe uses a
+  two-stage endpoint flow, selected URLs keep the action sheet, and tapped HTTP(S) URLs open
   directly.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@
 
 ### Added
 
-- Added a Terminal font size setting.
+- Added a Terminal font size setting. [PR #16](https://github.com/kcosr/herdr-web/pull/16)
+- Added desktop click-to-open support for detected HTTP(S) terminal URLs.
+  [PR #16](https://github.com/kcosr/herdr-web/pull/16)
 
 ### Changed
 
 - Added a Mobile setting for long-press behavior, with Off, Copy, and Loupe modes; Loupe uses a
   two-stage endpoint flow, selected URLs keep the action sheet, and tapped HTTP(S) URLs open
-  directly.
+  directly; original mobile selection work contributed by Will Hampson.
+  [PR #16](https://github.com/kcosr/herdr-web/pull/16)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Changed
 
+- Changed mobile terminal long-press selection to use a two-stage loupe and endpoint flow; normal
+  selections copy immediately, selected URLs keep the action sheet, and tapped HTTP(S) URLs open
+  directly.
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 ### Fixed
 
+- Fixed Android/tablet bridge color picker dismissal so saving a backend after choosing a color
+  keeps the Settings dialog open. [PR #16](https://github.com/kcosr/herdr-web/pull/16)
+
 ### Removed
 
 ## [0.2.0] - 2026-06-19

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,13 +34,19 @@ import { resolveLaunchSpec } from "./launch";
 import type { LaunchTarget } from "./launch";
 import {
   DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
-  DEFAULT_MOBILE_TOUCH_SELECTION,
+  DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR,
+  DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
   DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
   parseMobileKeyboardHideRefit,
-  parseMobileTouchSelection,
+  parseMobileLongPressBehavior,
+  parseMobileTouchSelectionEndpointTimeoutMs,
   parseMobileTerminalTapTarget,
 } from "./mobileTerminalPrefs";
-import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
+import type {
+  MobileLongPressBehavior,
+  MobileTerminalTapTarget,
+  MobileTouchSelectionEndpointTimeoutMs,
+} from "./mobileTerminalPrefs";
 import { addNativeBackHandler, addNativeKeyboardHideHandler, isNativeAndroid } from "./native";
 import { ActionMenu, ConfirmDialog, RenameDialog, useLongPress } from "./overlays";
 import type { MenuItem } from "./overlays";
@@ -57,6 +63,10 @@ import {
   DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
   parseTerminalOutputCoalesceMs,
 } from "./terminalOutputCoalescing";
+import {
+  DEFAULT_TERMINAL_FONT_SIZE_PX,
+  parseTerminalFontSizePx,
+} from "./terminalPrefs";
 import {
   aggregateStatus,
   canClearTabName,
@@ -178,6 +188,7 @@ type DisplayPrefs = {
   activeWorkspace: ScopedWorkspaceRef | null;
   selectedPanesByBridgeId: Record<string, string>;
   activeWorkspacesByBridgeId: Record<string, string>;
+  terminalFontSizePx: number;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
   terminalOutputCoalesceMs: number;
@@ -185,7 +196,8 @@ type DisplayPrefs = {
   contentInsetBottomPx: number;
   mobileControlsScalePercent: number;
   mobileTerminalTapTarget: MobileTerminalTapTarget;
-  mobileTouchSelection: boolean;
+  mobileLongPressBehavior: MobileLongPressBehavior;
+  mobileTouchSelectionEndpointTimeoutMs: MobileTouchSelectionEndpointTimeoutMs;
   mobileKeyboardHideRefit: boolean;
 };
 type LegacyDisplaySelectionPrefs = {
@@ -216,6 +228,7 @@ function readDisplayPrefs(): DisplayPrefs {
     activeWorkspace: null,
     selectedPanesByBridgeId: {},
     activeWorkspacesByBridgeId: {},
+    terminalFontSizePx: DEFAULT_TERMINAL_FONT_SIZE_PX,
     terminalInputTransport: DEFAULT_TERMINAL_INPUT_TRANSPORT,
     terminalInputBatchDelayMs: DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
     terminalOutputCoalesceMs: DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
@@ -223,7 +236,8 @@ function readDisplayPrefs(): DisplayPrefs {
     contentInsetBottomPx: DEFAULT_CONTENT_INSET_BOTTOM_PX,
     mobileControlsScalePercent: DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
     mobileTerminalTapTarget: DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
-    mobileTouchSelection: DEFAULT_MOBILE_TOUCH_SELECTION,
+    mobileLongPressBehavior: DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR,
+    mobileTouchSelectionEndpointTimeoutMs: DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
     mobileKeyboardHideRefit: DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
   };
   try {
@@ -293,6 +307,7 @@ function parseDisplayPrefsValue(
     activeWorkspace: parseScopedWorkspaceRef(parsed.activeWorkspace),
     selectedPanesByBridgeId: parseStringRecord(parsed.selectedPanesByBridgeId),
     activeWorkspacesByBridgeId: parseStringRecord(parsed.activeWorkspacesByBridgeId),
+    terminalFontSizePx: parseTerminalFontSizePx(parsed.terminalFontSizePx),
     terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
     terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
     terminalOutputCoalesceMs: parseTerminalOutputCoalesceMs(
@@ -304,7 +319,10 @@ function parseDisplayPrefsValue(
       parsed.mobileControlsScalePercent,
     ),
     mobileTerminalTapTarget: parseMobileTerminalTapTarget(parsed.mobileTerminalTapTarget),
-    mobileTouchSelection: parseMobileTouchSelection(parsed.mobileTouchSelection),
+    mobileLongPressBehavior: parseMobileLongPressBehavior(parsed.mobileLongPressBehavior),
+    mobileTouchSelectionEndpointTimeoutMs: parseMobileTouchSelectionEndpointTimeoutMs(
+      parsed.mobileTouchSelectionEndpointTimeoutMs,
+    ),
     mobileKeyboardHideRefit: parseMobileKeyboardHideRefit(parsed.mobileKeyboardHideRefit),
   };
 }
@@ -365,6 +383,7 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
           : fallback.sidebarWidth,
       sidebarOpen:
         typeof parsed.sidebarOpen === "boolean" ? parsed.sidebarOpen : fallback.sidebarOpen,
+      terminalFontSizePx: parseTerminalFontSizePx(parsed.terminalFontSizePx),
       terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
       terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
       terminalOutputCoalesceMs: parseTerminalOutputCoalesceMs(
@@ -376,7 +395,10 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
         parsed.mobileControlsScalePercent,
       ),
       mobileTerminalTapTarget: parseMobileTerminalTapTarget(parsed.mobileTerminalTapTarget),
-      mobileTouchSelection: parseMobileTouchSelection(parsed.mobileTouchSelection),
+      mobileLongPressBehavior: parseMobileLongPressBehavior(parsed.mobileLongPressBehavior),
+      mobileTouchSelectionEndpointTimeoutMs: parseMobileTouchSelectionEndpointTimeoutMs(
+        parsed.mobileTouchSelectionEndpointTimeoutMs,
+      ),
       mobileKeyboardHideRefit: parseMobileKeyboardHideRefit(parsed.mobileKeyboardHideRefit),
     };
   } catch {
@@ -512,6 +534,9 @@ export function App() {
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [backendSettingsOpen, setBackendSettingsOpen] = useState(false);
+  const [terminalFontSizePx, setTerminalFontSizePx] = useState(
+    initialPrefs.terminalFontSizePx,
+  );
   const [terminalInputTransport, setTerminalInputTransport] = useState(
     initialPrefs.terminalInputTransport,
   );
@@ -531,9 +556,13 @@ export function App() {
   const [mobileTerminalTapTarget, setMobileTerminalTapTarget] = useState(
     initialPrefs.mobileTerminalTapTarget,
   );
-  const [mobileTouchSelection, setMobileTouchSelection] = useState(
-    initialPrefs.mobileTouchSelection,
+  const [mobileLongPressBehavior, setMobileLongPressBehavior] = useState(
+    initialPrefs.mobileLongPressBehavior,
   );
+  const [
+    mobileTouchSelectionEndpointTimeoutMs,
+    setMobileTouchSelectionEndpointTimeoutMs,
+  ] = useState(initialPrefs.mobileTouchSelectionEndpointTimeoutMs);
   const [mobileKeyboardHideRefit, setMobileKeyboardHideRefit] = useState(
     initialPrefs.mobileKeyboardHideRefit,
   );
@@ -581,6 +610,7 @@ export function App() {
       setActiveWorkspaceRefState(prefs.activeWorkspace);
       setSelectedPanesByBridgeId(prefs.selectedPanesByBridgeId);
       setActiveWorkspacesByBridgeId(prefs.activeWorkspacesByBridgeId);
+      setTerminalFontSizePx(prefs.terminalFontSizePx);
       setTerminalInputTransport(prefs.terminalInputTransport);
       setTerminalInputBatchDelayMs(prefs.terminalInputBatchDelayMs);
       setTerminalOutputCoalesceMs(prefs.terminalOutputCoalesceMs);
@@ -588,7 +618,8 @@ export function App() {
       setContentInsetBottomPx(prefs.contentInsetBottomPx);
       setMobileControlsScalePercent(prefs.mobileControlsScalePercent);
       setMobileTerminalTapTarget(prefs.mobileTerminalTapTarget);
-      setMobileTouchSelection(prefs.mobileTouchSelection);
+      setMobileLongPressBehavior(prefs.mobileLongPressBehavior);
+      setMobileTouchSelectionEndpointTimeoutMs(prefs.mobileTouchSelectionEndpointTimeoutMs);
       setMobileKeyboardHideRefit(prefs.mobileKeyboardHideRefit);
       setDisplayPrefsLoaded(true);
     });
@@ -863,6 +894,7 @@ export function App() {
       activeWorkspace: activeWorkspaceRefState,
       selectedPanesByBridgeId,
       activeWorkspacesByBridgeId,
+      terminalFontSizePx,
       terminalInputTransport,
       terminalInputBatchDelayMs,
       terminalOutputCoalesceMs,
@@ -870,7 +902,8 @@ export function App() {
       contentInsetBottomPx,
       mobileControlsScalePercent,
       mobileTerminalTapTarget,
-      mobileTouchSelection,
+      mobileLongPressBehavior,
+      mobileTouchSelectionEndpointTimeoutMs,
       mobileKeyboardHideRefit,
     });
   }, [
@@ -887,6 +920,7 @@ export function App() {
     activeWorkspaceRefState,
     selectedPanesByBridgeId,
     activeWorkspacesByBridgeId,
+    terminalFontSizePx,
     terminalInputTransport,
     terminalInputBatchDelayMs,
     terminalOutputCoalesceMs,
@@ -894,7 +928,8 @@ export function App() {
     contentInsetBottomPx,
     mobileControlsScalePercent,
     mobileTerminalTapTarget,
-    mobileTouchSelection,
+    mobileLongPressBehavior,
+    mobileTouchSelectionEndpointTimeoutMs,
     mobileKeyboardHideRefit,
   ]);
 
@@ -1960,8 +1995,10 @@ export function App() {
             refitToken={refitToken}
             focusToken={terminalFocusToken}
             touchInput={isTouchInput}
+            terminalFontSizePx={terminalFontSizePx}
             mobileTapTarget={mobileTerminalTapTarget}
-            mobileTouchSelection={mobileTouchSelection}
+            mobileLongPressBehavior={mobileLongPressBehavior}
+            mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
             terminalInputTransport={terminalInputTransport}
             terminalInputBatchDelayMs={terminalInputBatchDelayMs}
             terminalOutputCoalesceMs={terminalOutputCoalesceMs}
@@ -1980,8 +2017,10 @@ export function App() {
             autoFocus={!isTouchInput}
             scrollSensitivity={isTouchInput ? 2 : 0.4}
             mobileControls={isTouchInput}
+            terminalFontSizePx={terminalFontSizePx}
             mobileTapTarget={mobileTerminalTapTarget}
-            mobileTouchSelection={mobileTouchSelection}
+            mobileLongPressBehavior={mobileLongPressBehavior}
+            mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
             terminalInputTransport={terminalInputTransport}
             terminalInputBatchDelayMs={terminalInputBatchDelayMs}
             terminalOutputCoalesceMs={terminalOutputCoalesceMs}
@@ -2039,6 +2078,8 @@ export function App() {
       {backendSettingsOpen ? (
         <BackendSettingsDialog
           showMobileTerminalSettings={isTouchInput}
+          terminalFontSizePx={terminalFontSizePx}
+          onTerminalFontSizePx={setTerminalFontSizePx}
           terminalInputTransport={terminalInputTransport}
           onTerminalInputTransport={setTerminalInputTransport}
           terminalInputBatchDelayMs={terminalInputBatchDelayMs}
@@ -2053,8 +2094,12 @@ export function App() {
           onMobileControlsScalePercent={setMobileControlsScalePercent}
           mobileTerminalTapTarget={mobileTerminalTapTarget}
           onMobileTerminalTapTarget={setMobileTerminalTapTarget}
-          mobileTouchSelection={mobileTouchSelection}
-          onMobileTouchSelection={setMobileTouchSelection}
+          mobileLongPressBehavior={mobileLongPressBehavior}
+          onMobileLongPressBehavior={setMobileLongPressBehavior}
+          mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
+          onMobileTouchSelectionEndpointTimeoutMs={
+            setMobileTouchSelectionEndpointTimeoutMs
+          }
           showMobileKeyboardHideRefit={showMobileKeyboardHideRefit}
           mobileKeyboardHideRefit={mobileKeyboardHideRefit}
           onMobileKeyboardHideRefit={setMobileKeyboardHideRefit}
@@ -2461,8 +2506,10 @@ function SplitGrid({
   refitToken,
   focusToken,
   touchInput,
+  terminalFontSizePx,
   mobileTapTarget,
-  mobileTouchSelection,
+  mobileLongPressBehavior,
+  mobileTouchSelectionEndpointTimeoutMs,
   terminalInputTransport,
   terminalInputBatchDelayMs,
   terminalOutputCoalesceMs,
@@ -2477,8 +2524,10 @@ function SplitGrid({
   refitToken: number;
   focusToken: number;
   touchInput: boolean;
+  terminalFontSizePx: number;
   mobileTapTarget: MobileTerminalTapTarget;
-  mobileTouchSelection: boolean;
+  mobileLongPressBehavior: MobileLongPressBehavior;
+  mobileTouchSelectionEndpointTimeoutMs: MobileTouchSelectionEndpointTimeoutMs;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
   terminalOutputCoalesceMs: number;
@@ -2508,8 +2557,10 @@ function SplitGrid({
               autoFocus={selected && !touchInput}
               scrollSensitivity={touchInput ? 2 : 0.4}
               mobileControls={selected && touchInput}
+              terminalFontSizePx={terminalFontSizePx}
               mobileTapTarget={mobileTapTarget}
-              mobileTouchSelection={mobileTouchSelection}
+              mobileLongPressBehavior={mobileLongPressBehavior}
+              mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
               terminalInputTransport={terminalInputTransport}
               terminalInputBatchDelayMs={terminalInputBatchDelayMs}
               terminalOutputCoalesceMs={terminalOutputCoalesceMs}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -245,7 +245,9 @@ function readDisplayPrefs(): DisplayPrefs {
     if (!raw) {
       return readLegacyDisplayPrefs(fallback);
     }
-    const parsed = JSON.parse(raw) as Partial<DisplayPrefs>;
+    const parsed = JSON.parse(raw) as Partial<DisplayPrefs> & {
+      mobileTouchSelection?: unknown;
+    };
     return parseDisplayPrefsValue(parsed, fallback);
   } catch {
     return fallback;
@@ -269,7 +271,7 @@ async function loadDisplayPrefs(): Promise<DisplayPrefs> {
 }
 
 function parseDisplayPrefsValue(
-  parsed: Partial<DisplayPrefs>,
+  parsed: Partial<DisplayPrefs> & { mobileTouchSelection?: unknown },
   fallback: DisplayPrefs,
 ): DisplayPrefs {
   return {
@@ -319,7 +321,7 @@ function parseDisplayPrefsValue(
       parsed.mobileControlsScalePercent,
     ),
     mobileTerminalTapTarget: parseMobileTerminalTapTarget(parsed.mobileTerminalTapTarget),
-    mobileLongPressBehavior: parseMobileLongPressBehavior(parsed.mobileLongPressBehavior),
+    mobileLongPressBehavior: parseStoredMobileLongPressBehavior(parsed),
     mobileTouchSelectionEndpointTimeoutMs: parseMobileTouchSelectionEndpointTimeoutMs(
       parsed.mobileTouchSelectionEndpointTimeoutMs,
     ),
@@ -352,6 +354,7 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
     const parsed = JSON.parse(raw) as {
       activeSpaceId?: unknown;
       selectedPaneId?: unknown;
+      mobileTouchSelection?: unknown;
     } & Partial<DisplayPrefs>;
     return {
       ...fallback,
@@ -395,7 +398,7 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
         parsed.mobileControlsScalePercent,
       ),
       mobileTerminalTapTarget: parseMobileTerminalTapTarget(parsed.mobileTerminalTapTarget),
-      mobileLongPressBehavior: parseMobileLongPressBehavior(parsed.mobileLongPressBehavior),
+      mobileLongPressBehavior: parseStoredMobileLongPressBehavior(parsed),
       mobileTouchSelectionEndpointTimeoutMs: parseMobileTouchSelectionEndpointTimeoutMs(
         parsed.mobileTouchSelectionEndpointTimeoutMs,
       ),
@@ -461,6 +464,21 @@ async function writeDisplayPrefs(prefs: DisplayPrefs) {
 
 function isNativeApp() {
   return Capacitor.isNativePlatform();
+}
+
+function parseStoredMobileLongPressBehavior(
+  parsed: Partial<DisplayPrefs> & { mobileTouchSelection?: unknown },
+): MobileLongPressBehavior {
+  if (parsed.mobileLongPressBehavior !== undefined) {
+    return parseMobileLongPressBehavior(parsed.mobileLongPressBehavior);
+  }
+  if (parsed.mobileTouchSelection === true) {
+    return "copy";
+  }
+  if (parsed.mobileTouchSelection === false) {
+    return "off";
+  }
+  return DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -37,13 +37,28 @@ import {
   parseContentInsetTopPx,
   parseMobileControlsScalePercent,
 } from "./displayPrefs";
-import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
+import {
+  DEFAULT_TERMINAL_FONT_SIZE_PX,
+  MAX_TERMINAL_FONT_SIZE_PX,
+  MIN_TERMINAL_FONT_SIZE_PX,
+  parseTerminalFontSizePx,
+} from "./terminalPrefs";
+import {
+  MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_OPTIONS_MS,
+} from "./mobileTerminalPrefs";
+import type {
+  MobileLongPressBehavior,
+  MobileTerminalTapTarget,
+  MobileTouchSelectionEndpointTimeoutMs,
+} from "./mobileTerminalPrefs";
 import { TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS } from "./terminalInputTransport";
 import type { TerminalInputTransport } from "./terminalInputTransport";
 import { TERMINAL_OUTPUT_COALESCE_OPTIONS_MS } from "./terminalOutputCoalescing";
 
 type Props = {
   showMobileTerminalSettings: boolean;
+  terminalFontSizePx: number;
+  onTerminalFontSizePx: (value: number) => void;
   terminalInputTransport: TerminalInputTransport;
   onTerminalInputTransport: (transport: TerminalInputTransport) => void;
   terminalInputBatchDelayMs: number;
@@ -58,8 +73,12 @@ type Props = {
   onMobileControlsScalePercent: (value: number) => void;
   mobileTerminalTapTarget: MobileTerminalTapTarget;
   onMobileTerminalTapTarget: (target: MobileTerminalTapTarget) => void;
-  mobileTouchSelection: boolean;
-  onMobileTouchSelection: (enabled: boolean) => void;
+  mobileLongPressBehavior: MobileLongPressBehavior;
+  onMobileLongPressBehavior: (behavior: MobileLongPressBehavior) => void;
+  mobileTouchSelectionEndpointTimeoutMs: MobileTouchSelectionEndpointTimeoutMs;
+  onMobileTouchSelectionEndpointTimeoutMs: (
+    timeoutMs: MobileTouchSelectionEndpointTimeoutMs,
+  ) => void;
   showMobileKeyboardHideRefit: boolean;
   mobileKeyboardHideRefit: boolean;
   onMobileKeyboardHideRefit: (enabled: boolean) => void;
@@ -78,6 +97,8 @@ type SettingsArea = "bridge" | "display" | "terminal" | "mobile";
 
 export function BackendSettingsDialog({
   showMobileTerminalSettings,
+  terminalFontSizePx,
+  onTerminalFontSizePx,
   terminalInputTransport,
   onTerminalInputTransport,
   terminalInputBatchDelayMs,
@@ -92,8 +113,10 @@ export function BackendSettingsDialog({
   onMobileControlsScalePercent,
   mobileTerminalTapTarget,
   onMobileTerminalTapTarget,
-  mobileTouchSelection,
-  onMobileTouchSelection,
+  mobileLongPressBehavior,
+  onMobileLongPressBehavior,
+  mobileTouchSelectionEndpointTimeoutMs,
+  onMobileTouchSelectionEndpointTimeoutMs,
   showMobileKeyboardHideRefit,
   mobileKeyboardHideRefit,
   onMobileKeyboardHideRefit,
@@ -493,6 +516,19 @@ export function BackendSettingsDialog({
 
             {activeArea === "terminal" ? (
               <div className="settings-section settings-section-flat">
+                <div className="settings-label">Terminal appearance</div>
+                <div className="settings-row">
+                  <span>Font size</span>
+                  <NumberSettingControl
+                    ariaLabel="Terminal font size"
+                    value={terminalFontSizePx}
+                    min={MIN_TERMINAL_FONT_SIZE_PX}
+                    max={MAX_TERMINAL_FONT_SIZE_PX}
+                    unit="px"
+                    defaultValue={DEFAULT_TERMINAL_FONT_SIZE_PX}
+                    onChange={(value) => onTerminalFontSizePx(parseTerminalFontSizePx(value))}
+                  />
+                </div>
                 <div className="settings-label">Terminal transport</div>
                 <div className="settings-row">
                   <span>Input payloads</span>
@@ -575,26 +611,56 @@ export function BackendSettingsDialog({
                   </div>
                 </div>
                 <div className="settings-row">
-                  <span>Long-press selection</span>
-                  <div className="segmented-control" role="group" aria-label="Long-press selection">
+                  <span>Long-press behavior</span>
+                  <div className="segmented-control" role="group" aria-label="Long-press behavior">
                     <button
                       type="button"
-                      data-on={!mobileTouchSelection}
-                      aria-pressed={!mobileTouchSelection}
-                      onClick={() => onMobileTouchSelection(false)}
+                      data-on={mobileLongPressBehavior === "off"}
+                      aria-pressed={mobileLongPressBehavior === "off"}
+                      onClick={() => onMobileLongPressBehavior("off")}
                     >
                       Off
                     </button>
                     <button
                       type="button"
-                      data-on={mobileTouchSelection}
-                      aria-pressed={mobileTouchSelection}
-                      onClick={() => onMobileTouchSelection(true)}
+                      data-on={mobileLongPressBehavior === "copy"}
+                      aria-pressed={mobileLongPressBehavior === "copy"}
+                      onClick={() => onMobileLongPressBehavior("copy")}
                     >
-                      On
+                      Copy
+                    </button>
+                    <button
+                      type="button"
+                      data-on={mobileLongPressBehavior === "loupe"}
+                      aria-pressed={mobileLongPressBehavior === "loupe"}
+                      onClick={() => onMobileLongPressBehavior("loupe")}
+                    >
+                      Loupe
                     </button>
                   </div>
                 </div>
+                {mobileLongPressBehavior === "loupe" ? (
+                  <div className="settings-row">
+                    <span>Loupe wait (ms)</span>
+                    <div
+                      className="segmented-control"
+                      role="group"
+                      aria-label="Loupe endpoint wait"
+                    >
+                      {MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_OPTIONS_MS.map((timeoutMs) => (
+                        <button
+                          key={timeoutMs}
+                          type="button"
+                          data-on={mobileTouchSelectionEndpointTimeoutMs === timeoutMs}
+                          aria-pressed={mobileTouchSelectionEndpointTimeoutMs === timeoutMs}
+                          onClick={() => onMobileTouchSelectionEndpointTimeoutMs(timeoutMs)}
+                        >
+                          {timeoutMs}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
                 {showMobileKeyboardHideRefit ? (
                   <div className="settings-row">
                     <span>Resize after keyboard closes</span>

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -729,14 +729,14 @@ function BackendColorControl({
     if (!open) {
       return;
     }
-    const handlePointerDown = (event: PointerEvent) => {
+    const handleClick = (event: MouseEvent) => {
       if (rootRef.current?.contains(event.target as Node)) {
         return;
       }
       setOpen(false);
     };
-    document.addEventListener("pointerdown", handlePointerDown);
-    return () => document.removeEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
   }, [open]);
 
   const setColor = (nextColor: string) => {

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -24,7 +24,13 @@ import {
 } from "./terminalInputTransport";
 import type { TerminalInputTransport } from "./terminalInputTransport";
 import { DEFAULT_TERMINAL_OUTPUT_COALESCE_MS } from "./terminalOutputCoalescing";
-import type { MobileTerminalTapTarget } from "./mobileTerminalPrefs";
+import { DEFAULT_TERMINAL_FONT_SIZE_PX } from "./terminalPrefs";
+import { DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS } from "./mobileTerminalPrefs";
+import type {
+  MobileLongPressBehavior,
+  MobileTerminalTapTarget,
+  MobileTouchSelectionEndpointTimeoutMs,
+} from "./mobileTerminalPrefs";
 import type { PaneInfo } from "./types";
 
 type Props = {
@@ -39,10 +45,14 @@ type Props = {
   scrollSensitivity?: number;
   /** Supplemental browser-native input controls for narrow touch screens. */
   mobileControls?: boolean;
+  /** Terminal renderer font size in CSS pixels. */
+  terminalFontSizePx?: number;
   /** Where terminal taps should send focus on mobile. */
   mobileTapTarget?: MobileTerminalTapTarget;
-  /** Enables long-press drag selection on touch terminals. */
-  mobileTouchSelection?: boolean;
+  /** Gesture behavior for long-presses on touch terminals. */
+  mobileLongPressBehavior?: MobileLongPressBehavior;
+  /** How long the loupe endpoint waits for a second drag. */
+  mobileTouchSelectionEndpointTimeoutMs?: MobileTouchSelectionEndpointTimeoutMs;
   /** Browser-to-bridge transport for terminal input payloads. */
   terminalInputTransport?: TerminalInputTransport;
   /** Delay for coalescing short terminal input payloads. Zero disables batching. */
@@ -87,8 +97,10 @@ export function TerminalView({
   autoFocus = true,
   scrollSensitivity = 1,
   mobileControls = false,
+  terminalFontSizePx = DEFAULT_TERMINAL_FONT_SIZE_PX,
   mobileTapTarget = "command-input",
-  mobileTouchSelection = false,
+  mobileLongPressBehavior = "off",
+  mobileTouchSelectionEndpointTimeoutMs = DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
   terminalInputTransport = "json",
   terminalInputBatchDelayMs = 0,
   terminalOutputCoalesceMs = DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
@@ -126,10 +138,16 @@ export function TerminalView({
   scrollSensitivityRef.current = scrollSensitivity;
   const mobileControlsRef = useRef(mobileControls);
   mobileControlsRef.current = mobileControls;
+  const terminalFontSizePxRef = useRef(terminalFontSizePx);
+  terminalFontSizePxRef.current = terminalFontSizePx;
   const mobileTapTargetRef = useRef(mobileTapTarget);
   mobileTapTargetRef.current = mobileTapTarget;
-  const mobileTouchSelectionRef = useRef(mobileTouchSelection);
-  mobileTouchSelectionRef.current = mobileTouchSelection;
+  const mobileLongPressBehaviorRef = useRef(mobileLongPressBehavior);
+  mobileLongPressBehaviorRef.current = mobileLongPressBehavior;
+  const mobileTouchSelectionEndpointTimeoutMsRef = useRef(
+    mobileTouchSelectionEndpointTimeoutMs,
+  );
+  mobileTouchSelectionEndpointTimeoutMsRef.current = mobileTouchSelectionEndpointTimeoutMs;
   const terminalInputTransportRef = useRef(terminalInputTransport);
   terminalInputTransportRef.current = terminalInputTransport;
   const terminalInputBatchDelayMsRef = useRef(terminalInputBatchDelayMs);
@@ -359,7 +377,7 @@ export function TerminalView({
     let connectTimer: number | null = null;
     let reconnectAttempts = 0;
     let lastCloseReason: string | null = null;
-    const renderer: TerminalRenderer = new GhosttyRenderer();
+    const renderer: TerminalRenderer = new GhosttyRenderer(terminalFontSizePxRef.current);
     rendererRef.current = renderer;
     setConnectionState("connecting");
 
@@ -386,8 +404,9 @@ export function TerminalView({
               : focusTerminalKeyboardInput,
         );
         renderer.setMobileTouchSelection(
-          mobileControlsRef.current && mobileTouchSelectionRef.current,
+          mobileControlsRef.current ? mobileLongPressBehaviorRef.current : "off",
           mobileControlsRef.current ? handleMobileTerminalTouch : null,
+          mobileTouchSelectionEndpointTimeoutMsRef.current,
         );
 
         disposeInput = renderer.onInput((data) => {
@@ -601,10 +620,23 @@ export function TerminalView({
 
   useEffect(() => {
     rendererRef.current?.setMobileTouchSelection(
-      mobileControls && mobileTouchSelection,
+      mobileControls ? mobileLongPressBehavior : "off",
       mobileControls ? handleMobileTerminalTouch : null,
+      mobileTouchSelectionEndpointTimeoutMs,
     );
-  }, [handleMobileTerminalTouch, mobileControls, mobileTouchSelection]);
+  }, [
+    handleMobileTerminalTouch,
+    mobileControls,
+    mobileLongPressBehavior,
+    mobileTouchSelectionEndpointTimeoutMs,
+  ]);
+
+  useEffect(() => {
+    const size = rendererRef.current?.setFontSize(terminalFontSizePx);
+    if (size) {
+      sendResizeRef.current(size);
+    }
+  }, [terminalFontSizePx]);
 
   useEffect(() => {
     setMobileSelectionAction(null);

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -15,7 +15,7 @@ import { ConfirmDialog } from "./overlays";
 import { shellQuote } from "./shell";
 import { findFirstUrlInSelection, openableHttpUrl } from "./terminalSelection";
 import { GhosttyRenderer } from "./terminalRenderer";
-import type { TerminalRenderer, TerminalSize } from "./terminalRenderer";
+import type { MobileTerminalTouchEvent, TerminalRenderer, TerminalSize } from "./terminalRenderer";
 import {
   appendTerminalInputBatch,
   drainTerminalInputBatch,
@@ -75,7 +75,6 @@ type MobileSelectionAction = {
   text: string;
   url: string;
 };
-
 const MAX_UPLOAD_FILES = 8;
 const TERMINAL_CONNECT_TIMEOUT_MS = 3500;
 
@@ -192,11 +191,19 @@ export function TerminalView({
     [showUploadStatus],
   );
 
-  const handleMobileSelection = useCallback(
-    (text: string) => {
-      const trimmed = text.trim();
+  const handleMobileTerminalTouch = useCallback(
+    (event: MobileTerminalTouchEvent) => {
+      if (event.type === "url") {
+        const url = openableHttpUrl(event.url);
+        if (url) {
+          window.open(url, "_blank", "noopener,noreferrer");
+        }
+        return;
+      }
+      const trimmed = event.text.trim();
       setMobileSelectionAction(null);
       if (!trimmed) {
+        rendererRef.current?.clearSelection();
         return;
       }
       const url = findFirstUrlInSelection(trimmed);
@@ -204,6 +211,7 @@ export function TerminalView({
         setMobileSelectionAction({ text: trimmed, url });
         return;
       }
+      rendererRef.current?.clearSelection();
       void copyText(trimmed, "Copied selection");
     },
     [copyText],
@@ -379,7 +387,7 @@ export function TerminalView({
         );
         renderer.setMobileTouchSelection(
           mobileControlsRef.current && mobileTouchSelectionRef.current,
-          handleMobileSelection,
+          mobileControlsRef.current ? handleMobileTerminalTouch : null,
         );
 
         disposeInput = renderer.onInput((data) => {
@@ -594,12 +602,13 @@ export function TerminalView({
   useEffect(() => {
     rendererRef.current?.setMobileTouchSelection(
       mobileControls && mobileTouchSelection,
-      handleMobileSelection,
+      mobileControls ? handleMobileTerminalTouch : null,
     );
-  }, [handleMobileSelection, mobileControls, mobileTouchSelection]);
+  }, [handleMobileTerminalTouch, mobileControls, mobileTouchSelection]);
 
   useEffect(() => {
     setMobileSelectionAction(null);
+    rendererRef.current?.clearSelection();
   }, [connectionKey, pane?.terminal_id]);
 
   useEffect(() => {
@@ -641,6 +650,11 @@ export function TerminalView({
   };
   const uploadDisabled = !pane || uploading;
 
+  const closeMobileSelectionActions = () => {
+    setMobileSelectionAction(null);
+    rendererRef.current?.clearSelection();
+  };
+
   const openSelectionUrl = () => {
     if (!mobileSelectionAction) {
       return;
@@ -651,11 +665,11 @@ export function TerminalView({
     } else {
       void copyText(mobileSelectionAction.text, "Copied selection");
     }
-    setMobileSelectionAction(null);
+    closeMobileSelectionActions();
   };
 
   const copySelectionText = (text: string, successMessage: string) => {
-    setMobileSelectionAction(null);
+    closeMobileSelectionActions();
     void copyText(text, successMessage);
   };
 
@@ -860,9 +874,7 @@ export function TerminalView({
           onOpen={openSelectionUrl}
           onCopyUrl={() => copySelectionText(mobileSelectionAction.url, "Copied URL")}
           onCopyText={() => copySelectionText(mobileSelectionAction.text, "Copied selection")}
-          onClose={() => {
-            setMobileSelectionAction(null);
-          }}
+          onClose={closeMobileSelectionActions}
         />
       ) : null}
       {uploadConflict ? (

--- a/web/src/mobileTerminalPrefs.test.ts
+++ b/web/src/mobileTerminalPrefs.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR,
   DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
-  DEFAULT_MOBILE_TOUCH_SELECTION,
+  DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
   DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
+  MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_OPTIONS_MS,
+  parseMobileLongPressBehavior,
   parseMobileKeyboardHideRefit,
-  parseMobileTouchSelection,
+  parseMobileTouchSelectionEndpointTimeoutMs,
   parseMobileTerminalTapTarget,
 } from "./mobileTerminalPrefs";
 
@@ -21,10 +24,27 @@ describe("mobile terminal preferences", () => {
     expect(parseMobileTerminalTapTarget(null)).toBe(DEFAULT_MOBILE_TERMINAL_TAP_TARGET);
   });
 
-  it("parses the mobile touch selection flag", () => {
-    expect(parseMobileTouchSelection(true)).toBe(true);
-    expect(parseMobileTouchSelection(false)).toBe(false);
-    expect(parseMobileTouchSelection("true")).toBe(DEFAULT_MOBILE_TOUCH_SELECTION);
+  it("parses supported long-press behaviors", () => {
+    expect(parseMobileLongPressBehavior("off")).toBe("off");
+    expect(parseMobileLongPressBehavior("copy")).toBe("copy");
+    expect(parseMobileLongPressBehavior("loupe")).toBe("loupe");
+  });
+
+  it("falls back for unknown long-press behaviors", () => {
+    expect(parseMobileLongPressBehavior(true)).toBe(DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR);
+    expect(parseMobileLongPressBehavior("selection")).toBe(DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR);
+  });
+
+  it("parses the mobile touch selection endpoint timeout", () => {
+    for (const timeoutMs of MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_OPTIONS_MS) {
+      expect(parseMobileTouchSelectionEndpointTimeoutMs(timeoutMs)).toBe(timeoutMs);
+    }
+    expect(parseMobileTouchSelectionEndpointTimeoutMs(1250)).toBe(
+      DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
+    );
+    expect(parseMobileTouchSelectionEndpointTimeoutMs("3000")).toBe(
+      DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
+    );
   });
 
   it("parses the keyboard-hide refit flag", () => {

--- a/web/src/mobileTerminalPrefs.ts
+++ b/web/src/mobileTerminalPrefs.ts
@@ -1,7 +1,12 @@
 export type MobileTerminalTapTarget = "command-input" | "terminal";
+export type MobileLongPressBehavior = "off" | "copy" | "loupe";
 
 export const DEFAULT_MOBILE_TERMINAL_TAP_TARGET: MobileTerminalTapTarget = "command-input";
-export const DEFAULT_MOBILE_TOUCH_SELECTION = false;
+export const DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR: MobileLongPressBehavior = "off";
+export const MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_OPTIONS_MS = [1500, 3000, 5000] as const;
+export type MobileTouchSelectionEndpointTimeoutMs =
+  (typeof MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_OPTIONS_MS)[number];
+export const DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS: MobileTouchSelectionEndpointTimeoutMs = 1500;
 export const DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT = true;
 
 export function parseMobileTerminalTapTarget(value: unknown): MobileTerminalTapTarget {
@@ -10,8 +15,20 @@ export function parseMobileTerminalTapTarget(value: unknown): MobileTerminalTapT
     : DEFAULT_MOBILE_TERMINAL_TAP_TARGET;
 }
 
-export function parseMobileTouchSelection(value: unknown) {
-  return typeof value === "boolean" ? value : DEFAULT_MOBILE_TOUCH_SELECTION;
+export function parseMobileLongPressBehavior(value: unknown): MobileLongPressBehavior {
+  return value === "off" || value === "copy" || value === "loupe"
+    ? value
+    : DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR;
+}
+
+export function parseMobileTouchSelectionEndpointTimeoutMs(
+  value: unknown,
+): MobileTouchSelectionEndpointTimeoutMs {
+  return MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_OPTIONS_MS.includes(
+    value as MobileTouchSelectionEndpointTimeoutMs,
+  )
+    ? (value as MobileTouchSelectionEndpointTimeoutMs)
+    : DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS;
 }
 
 export function parseMobileKeyboardHideRefit(value: unknown) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -40,6 +40,7 @@
   --line-soft: #1d1d2b;
   --accent: var(--lavender);
   --accent-soft: rgba(180, 190, 254, 0.14);
+  --terminal-touch-marker: #c2caff;
 
   /* Status -> color (matches herdr TUI semantics) */
   --st-blocked: var(--red);
@@ -930,6 +931,7 @@ button {
 }
 
 .terminal-host {
+  position: relative;
   flex: 1 1 auto;
   width: 100%;
   min-width: 0;
@@ -1098,23 +1100,18 @@ button {
   left: 0;
   top: 0;
   z-index: 7;
-  display: grid;
-  width: 46px;
-  height: 46px;
-  place-items: center;
-  border: 1px solid color-mix(in srgb, var(--accent) 72%, white);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 78%, var(--mantle));
-  box-shadow: 0 10px 28px rgb(0 0 0 / 38%);
+  width: 72px;
+  height: 72px;
+  background: transparent;
   touch-action: none;
   will-change: transform;
 }
 
-.terminal-touch-endpoint::before {
+.terminal-touch-endpoint[data-hint]::before {
   content: attr(data-hint);
   position: absolute;
   left: 50%;
-  bottom: calc(100% + 5px);
+  top: calc(100% + 2px);
   transform: translateX(-50%);
   border: 1px solid var(--line);
   border-radius: 999px;
@@ -1126,7 +1123,48 @@ button {
   white-space: nowrap;
 }
 
-.terminal-touch-endpoint::after {
+.terminal-touch-endpoint-line {
+  position: absolute;
+  left: 50%;
+  top: 8px;
+  width: 2px;
+  height: 18px;
+  transform: translateX(-50%);
+  border-radius: 999px;
+  background: var(--terminal-touch-marker);
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 26%);
+  pointer-events: none;
+}
+
+.terminal-touch-endpoint-line::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -2px;
+  width: 10px;
+  height: 2px;
+  transform: translateX(-50%);
+  border-radius: inherit;
+  background: inherit;
+  box-shadow: inherit;
+}
+
+.terminal-touch-endpoint-knob {
+  position: absolute;
+  left: 13px;
+  top: 22px;
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--accent) 72%, white);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 78%, var(--mantle));
+  box-shadow: 0 10px 28px rgb(0 0 0 / 38%);
+  pointer-events: none;
+}
+
+.terminal-touch-endpoint-knob::after {
   content: "";
   width: 10px;
   height: 10px;
@@ -2389,7 +2427,7 @@ button {
 }
 
 .app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-upload-status {
-  bottom: calc(122px * var(--mobile-controls-scale));
+  bottom: calc(90px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-selection-sheet {
@@ -2405,7 +2443,7 @@ button {
 .app[data-touch="true"]
   .terminal-stage:has(.terminal-mobile-controls[data-expanded="true"])
   .terminal-upload-status {
-  bottom: calc(160px * var(--mobile-controls-scale));
+  bottom: calc(126px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"]

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1106,6 +1106,10 @@ button {
   will-change: transform;
 }
 
+.terminal-touch-endpoint[data-dragging="true"] {
+  opacity: 0;
+}
+
 .terminal-touch-endpoint[data-hint]::before {
   content: attr(data-hint);
   position: absolute;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1030,13 +1030,12 @@ button {
   left: 12px;
   right: 12px;
   bottom: 12px;
-  z-index: 6;
-  display: grid;
+  z-index: 9;
+  display: flex;
+  align-items: center;
   gap: 10px;
-  max-width: 620px;
-  margin: 0 auto;
   border: 1px solid var(--line);
-  border-radius: var(--r-sm);
+  border-radius: var(--r-md);
   padding: 10px;
   background: color-mix(in srgb, var(--mantle) 94%, black);
   box-shadow: var(--shadow);
@@ -1046,9 +1045,9 @@ button {
   min-width: 0;
   max-height: 48px;
   overflow: hidden;
-  color: var(--subtext0);
+  color: var(--subtext);
   font-size: 12px;
-  line-height: 1.35;
+  line-height: 1.3;
   overflow-wrap: anywhere;
 }
 
@@ -1064,13 +1063,76 @@ button {
   display: inline-flex;
   gap: 6px;
   align-items: center;
-  min-height: 34px;
   padding-inline: 10px;
 }
 
 .terminal-selection-actions .icon-btn {
   margin-left: auto;
   flex: 0 0 auto;
+}
+
+.terminal-touch-loupe {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 8;
+  width: 132px;
+  height: 82px;
+  overflow: hidden;
+  pointer-events: none;
+  border: 1px solid color-mix(in srgb, var(--accent) 68%, white);
+  border-radius: 18px;
+  background: var(--term-bg);
+  box-shadow: 0 12px 34px rgb(0 0 0 / 44%), 0 0 0 1px rgb(255 255 255 / 8%) inset;
+  will-change: transform;
+}
+
+.terminal-touch-loupe canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.terminal-touch-endpoint {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 7;
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--accent) 72%, white);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 78%, var(--mantle));
+  box-shadow: 0 10px 28px rgb(0 0 0 / 38%);
+  touch-action: none;
+  will-change: transform;
+}
+
+.terminal-touch-endpoint::before {
+  content: attr(data-hint);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 5px);
+  transform: translateX(-50%);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 2px 7px;
+  background: color-mix(in srgb, var(--mantle) 92%, black);
+  color: var(--text);
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.terminal-touch-endpoint::after {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: inherit;
+  background: var(--base);
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 42%);
 }
 
 .terminal-mobile-controls {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2430,7 +2430,7 @@ button {
 }
 
 .app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-selection-sheet {
-  bottom: calc(122px * var(--mobile-controls-scale));
+  bottom: calc(90px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"]
@@ -2448,5 +2448,5 @@ button {
 .app[data-touch="true"]
   .terminal-stage:has(.terminal-mobile-controls[data-expanded="true"])
   .terminal-selection-sheet {
-  bottom: calc(160px * var(--mobile-controls-scale));
+  bottom: calc(126px * var(--mobile-controls-scale));
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1033,9 +1033,8 @@ button {
   right: 12px;
   bottom: 12px;
   z-index: 9;
-  display: flex;
-  align-items: center;
-  gap: 10px;
+  display: grid;
+  gap: 9px;
   border: 1px solid var(--line);
   border-radius: var(--r-md);
   padding: 10px;
@@ -1045,12 +1044,12 @@ button {
 
 .terminal-selection-url {
   min-width: 0;
-  max-height: 48px;
   overflow: hidden;
   color: var(--subtext);
   font-size: 12px;
   line-height: 1.3;
-  overflow-wrap: anywhere;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .terminal-selection-actions {

--- a/web/src/terminalPrefs.test.ts
+++ b/web/src/terminalPrefs.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TERMINAL_FONT_SIZE_PX,
+  MAX_TERMINAL_FONT_SIZE_PX,
+  MIN_TERMINAL_FONT_SIZE_PX,
+  parseTerminalFontSizePx,
+} from "./terminalPrefs";
+
+describe("terminal preferences", () => {
+  it("parses and clamps the terminal font size", () => {
+    expect(parseTerminalFontSizePx(13)).toBe(13);
+    expect(parseTerminalFontSizePx(16.7)).toBe(17);
+    expect(parseTerminalFontSizePx(4)).toBe(MIN_TERMINAL_FONT_SIZE_PX);
+    expect(parseTerminalFontSizePx(999)).toBe(MAX_TERMINAL_FONT_SIZE_PX);
+  });
+
+  it("falls back for invalid terminal font sizes", () => {
+    expect(parseTerminalFontSizePx(null)).toBe(DEFAULT_TERMINAL_FONT_SIZE_PX);
+    expect(parseTerminalFontSizePx("13")).toBe(DEFAULT_TERMINAL_FONT_SIZE_PX);
+    expect(parseTerminalFontSizePx(Number.NaN)).toBe(DEFAULT_TERMINAL_FONT_SIZE_PX);
+  });
+});

--- a/web/src/terminalPrefs.ts
+++ b/web/src/terminalPrefs.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_TERMINAL_FONT_SIZE_PX = 13;
+export const MIN_TERMINAL_FONT_SIZE_PX = 10;
+export const MAX_TERMINAL_FONT_SIZE_PX = 24;
+
+export function parseTerminalFontSizePx(value: unknown) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_TERMINAL_FONT_SIZE_PX;
+  }
+  return Math.min(
+    MAX_TERMINAL_FONT_SIZE_PX,
+    Math.max(MIN_TERMINAL_FONT_SIZE_PX, Math.round(value)),
+  );
+}

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -375,6 +375,8 @@ export class GhosttyRenderer implements TerminalRenderer {
     let selectionClearTimer: number | null = null;
     let endpointTimer: number | null = null;
     let loupeRenderFrame: number | null = null;
+    let mouseDownX: number | null = null;
+    let mouseDownY: number | null = null;
     let selectionState: TerminalTouchSelectionState = idleTouchSelectionState;
     let endpointBubble: HTMLDivElement | null = null;
     let loupe: { root: HTMLDivElement; canvas: HTMLCanvasElement } | null = null;
@@ -774,6 +776,14 @@ export class GhosttyRenderer implements TerminalRenderer {
       const position = positionFromTouch(touch);
       return terminalUrlTapTarget(terminalLinkAt(terminal, position), mouseTracking);
     };
+    const mouseLinkText = (event: MouseEvent) => {
+      const mouseTracking = this.#hasMouseTracking(terminal);
+      if (mouseTracking) {
+        return null;
+      }
+      const position = touchCellPosition(terminal, event.clientX, event.clientY);
+      return terminalUrlTapTarget(terminalLinkAt(terminal, position), mouseTracking);
+    };
     const redirectTapFocus = (event: TouchEvent | MouseEvent) => {
       const terminalHadFocusOrGrace =
         document.activeElement === terminal.textarea ||
@@ -966,6 +976,8 @@ export class GhosttyRenderer implements TerminalRenderer {
       return false;
     };
     const onMouseDown = (event: MouseEvent) => {
+      mouseDownX = event.clientX;
+      mouseDownY = event.clientY;
       if (this.#hasMouseTracking(terminal)) {
         return;
       }
@@ -980,7 +992,30 @@ export class GhosttyRenderer implements TerminalRenderer {
       suppressCompatMouseEvent(event);
     };
     const onClick = (event: MouseEvent) => {
-      suppressCompatMouseEvent(event);
+      if (suppressCompatMouseEvent(event)) {
+        return;
+      }
+      const moved =
+        mouseDownX !== null &&
+        mouseDownY !== null &&
+        Math.hypot(event.clientX - mouseDownX, event.clientY - mouseDownY) >
+          TOUCH_SELECTION_TOLERANCE_PX;
+      mouseDownX = null;
+      mouseDownY = null;
+      if (moved) {
+        return;
+      }
+      const linkText = mouseLinkText(event);
+      if (!linkText?.trim()) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      if (typeof event.stopImmediatePropagation === "function") {
+        event.stopImmediatePropagation();
+      }
+      terminal.textarea?.blur();
+      window.open(linkText, "_blank", "noopener,noreferrer");
     };
 
     container.addEventListener("touchstart", onTouchStart, {

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -13,6 +13,12 @@ import {
   startTouchSelectionPlacement,
 } from "./terminalTouchSelection";
 import type { TerminalTouchSelectionState } from "./terminalTouchSelection";
+import { DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS } from "./mobileTerminalPrefs";
+import type {
+  MobileLongPressBehavior,
+  MobileTouchSelectionEndpointTimeoutMs,
+} from "./mobileTerminalPrefs";
+import { DEFAULT_TERMINAL_FONT_SIZE_PX } from "./terminalPrefs";
 
 const TERMINAL_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace';
@@ -20,14 +26,17 @@ const TERMINAL_TEXT_INPUT_TAP_GRACE_MS = 4000;
 const TOUCH_SELECTION_LONG_PRESS_MS = 600;
 const TOUCH_SELECTION_TOLERANCE_PX = 10;
 const TOUCH_SELECTION_SCROLL_INTENT_PX = 5;
-const TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS = 1500;
+const TOUCH_SELECTION_CLEAR_DELAY_MS = 1200;
 const TOUCH_COMPAT_MOUSE_SUPPRESS_MS = 1200;
 const TOUCH_LOUPE_WIDTH_PX = 132;
 const TOUCH_LOUPE_HEIGHT_PX = 82;
 const TOUCH_LOUPE_SOURCE_WIDTH_PX = 70;
 const TOUCH_LOUPE_SOURCE_HEIGHT_PX = 44;
-const TOUCH_LOUPE_OFFSET_Y_PX = 108;
-const TOUCH_ENDPOINT_SIZE_PX = 46;
+const TOUCH_LOUPE_OFFSET_Y_PX = 132;
+const TOUCH_LOUPE_TARGET_OFFSET_Y_PX = 48;
+const TOUCH_ENDPOINT_HIT_WIDTH_PX = 72;
+const TOUCH_ENDPOINT_HIT_HEIGHT_PX = 72;
+const TOUCH_ENDPOINT_HANDLE_OFFSET_Y_PX = TOUCH_LOUPE_TARGET_OFFSET_Y_PX;
 const TAP_URL_PATTERN = /\bhttps?:\/\/[^\s"'<>`]+/giu;
 
 type GhosttyModule = typeof import("ghostty-web");
@@ -92,9 +101,14 @@ export type TerminalRenderer = {
   onInput(callback: (data: string) => void): () => void;
   onScroll(callback: (lines: number) => void): () => void;
   setTapFocusHandler(callback: (() => TerminalTapFocusResult) | null): void;
-  setMobileTouchSelection(enabled: boolean, callback: ((event: MobileTerminalTouchEvent) => void) | null): void;
+  setMobileTouchSelection(
+    behavior: MobileLongPressBehavior,
+    callback: ((event: MobileTerminalTouchEvent) => void) | null,
+    endpointTimeoutMs: MobileTouchSelectionEndpointTimeoutMs,
+  ): void;
   fit(): TerminalSize;
   refreshMetrics(): TerminalSize;
+  setFontSize(fontSizePx: number): TerminalSize | null;
   focus(): void;
   focusTextInput(): void;
   clearSelection(): void;
@@ -111,9 +125,16 @@ export class GhosttyRenderer implements TerminalRenderer {
   #touchCleanup: (() => void) | null = null;
   #mobileInputCleanup: (() => void) | null = null;
   #tapFocusHandler: (() => TerminalTapFocusResult) | null = null;
-  #mobileTouchSelectionEnabled = false;
+  #mobileLongPressBehavior: MobileLongPressBehavior = "off";
   #mobileTouchSelectionHandler: ((event: MobileTerminalTouchEvent) => void) | null = null;
+  #mobileTouchSelectionEndpointTimeoutMs: MobileTouchSelectionEndpointTimeoutMs =
+    DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS;
   #textInputTapGraceUntil = 0;
+  #fontSizePx: number;
+
+  constructor(fontSizePx = DEFAULT_TERMINAL_FONT_SIZE_PX) {
+    this.#fontSizePx = fontSizePx;
+  }
 
   async mount(container: HTMLElement) {
     const { FitAddon, Terminal } = await loadGhosttyModule();
@@ -123,7 +144,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       convertEol: false,
       cursorBlink: true,
       fontFamily: TERMINAL_FONT_FAMILY,
-      fontSize: 13,
+      fontSize: this.#fontSizePx,
       scrollback: 8000,
       smoothScrollDuration: 0,
       theme: {
@@ -198,10 +219,15 @@ export class GhosttyRenderer implements TerminalRenderer {
     this.#tapFocusHandler = callback;
   }
 
-  setMobileTouchSelection(enabled: boolean, callback: ((event: MobileTerminalTouchEvent) => void) | null) {
-    const changed = this.#mobileTouchSelectionEnabled !== enabled;
-    this.#mobileTouchSelectionEnabled = enabled;
+  setMobileTouchSelection(
+    behavior: MobileLongPressBehavior,
+    callback: ((event: MobileTerminalTouchEvent) => void) | null,
+    endpointTimeoutMs: MobileTouchSelectionEndpointTimeoutMs,
+  ) {
+    const changed = this.#mobileLongPressBehavior !== behavior;
+    this.#mobileLongPressBehavior = behavior;
     this.#mobileTouchSelectionHandler = callback;
+    this.#mobileTouchSelectionEndpointTimeoutMs = endpointTimeoutMs;
     if (changed && this.#terminal && this.#container) {
       this.#installTouchHandlers();
     }
@@ -219,8 +245,17 @@ export class GhosttyRenderer implements TerminalRenderer {
   refreshMetrics() {
     const terminal = this.#requireTerminal();
     terminal.options.fontFamily = TERMINAL_FONT_FAMILY;
+    terminal.options.fontSize = this.#fontSizePx;
     terminal.renderer?.remeasureFont();
     return this.fit();
+  }
+
+  setFontSize(fontSizePx: number) {
+    this.#fontSizePx = fontSizePx;
+    if (!this.#terminal) {
+      return null;
+    }
+    return this.refreshMetrics();
   }
 
   focus() {
@@ -329,7 +364,12 @@ export class GhosttyRenderer implements TerminalRenderer {
     let pendingTouchLines = 0;
     let suppressMouseUntil = 0;
     let selectionTimer: number | null = null;
+    let selectingFromTouch = false;
+    let simpleSelectionStart: TerminalCellPosition | null = null;
+    let simpleSelectionEnd: TerminalCellPosition | null = null;
+    let selectionClearTimer: number | null = null;
     let endpointTimer: number | null = null;
+    let loupeRenderFrame: number | null = null;
     let selectionState: TerminalTouchSelectionState = idleTouchSelectionState;
     let endpointBubble: HTMLDivElement | null = null;
     let loupe: { root: HTMLDivElement; canvas: HTMLCanvasElement } | null = null;
@@ -352,17 +392,37 @@ export class GhosttyRenderer implements TerminalRenderer {
         endpointTimer = null;
       }
     };
+    const clearLoupeRenderFrame = () => {
+      if (loupeRenderFrame !== null) {
+        window.cancelAnimationFrame(loupeRenderFrame);
+        loupeRenderFrame = null;
+      }
+    };
+    const clearSelectionClearTimer = () => {
+      if (selectionClearTimer !== null) {
+        window.clearTimeout(selectionClearTimer);
+        selectionClearTimer = null;
+      }
+    };
+    const stopSimpleTouchSelection = () => {
+      clearSelectionTimer();
+      selectingFromTouch = false;
+      simpleSelectionStart = null;
+      simpleSelectionEnd = null;
+    };
     const removeEndpointBubble = () => {
       endpointBubble?.remove();
       endpointBubble = null;
     };
     const removeLoupe = () => {
+      clearLoupeRenderFrame();
       loupe?.root.remove();
       loupe = null;
     };
     const resetTouchSelection = (clearTerminalSelection = true) => {
       clearSelectionTimer();
       clearEndpointTimer();
+      stopSimpleTouchSelection();
       selectionState = idleTouchSelectionState;
       removeEndpointBubble();
       removeLoupe();
@@ -382,6 +442,21 @@ export class GhosttyRenderer implements TerminalRenderer {
     };
     const positionFromTouch = (touch: Touch) => touchCellPosition(terminal, touch.clientX, touch.clientY);
     const clientFromTouch = (touch: Touch) => ({ clientX: touch.clientX, clientY: touch.clientY });
+    const loupePositionFromClient = (clientX: number, clientY: number) =>
+      touchCellPosition(terminal, clientX, clientY - TOUCH_LOUPE_TARGET_OFFSET_Y_PX);
+    const loupePositionFromTouch = (touch: Touch) =>
+      loupePositionFromClient(touch.clientX, touch.clientY);
+    const endpointPositionFromTouch = (touch: Touch) =>
+      touchCellPosition(terminal, touch.clientX, touch.clientY - TOUCH_ENDPOINT_HANDLE_OFFSET_Y_PX);
+    const updateSimpleTouchSelection = (touch: Touch) => {
+      if (!simpleSelectionStart) {
+        return;
+      }
+      const current = positionFromTouch(touch);
+      const range = terminalSelectionRange(simpleSelectionStart, current, terminal.cols);
+      simpleSelectionEnd = current;
+      selectTerminalViewportRange(terminal, range.from, range.to);
+    };
     const selectCurrentTouchRange = () => {
       if (selectionState.phase === "idle") {
         return;
@@ -470,16 +545,52 @@ export class GhosttyRenderer implements TerminalRenderer {
         TOUCH_LOUPE_WIDTH_PX,
         TOUCH_LOUPE_HEIGHT_PX,
       );
-      const caretX = ((centerX - sxCss) / sourceWidth) * TOUCH_LOUPE_WIDTH_PX;
-      ctx.strokeStyle = "rgba(245, 224, 220, 0.95)";
+      const markerLeft = ((point.col * cellWidth - sxCss) / sourceWidth) * TOUCH_LOUPE_WIDTH_PX;
+      const markerRight = (((point.col + 1) * cellWidth - sxCss) / sourceWidth) * TOUCH_LOUPE_WIDTH_PX;
+      const markerY = (((point.row + 1) * cellHeight - syCss) / sourceHeight) * TOUCH_LOUPE_HEIGHT_PX - 2;
+      const anchorLeft = clampNumber(markerLeft, 4, TOUCH_LOUPE_WIDTH_PX - 4);
+      const anchorRight = clampNumber(markerRight, 4, TOUCH_LOUPE_WIDTH_PX - 4);
+      const anchorY = clampNumber(markerY, 8, TOUCH_LOUPE_HEIGHT_PX - 18);
+      const anchorCenter = (anchorLeft + anchorRight) / 2;
+      const markerBottom = TOUCH_LOUPE_HEIGHT_PX - 2;
+      const markerColor = cssColor(
+        container,
+        "--terminal-touch-marker",
+        cssColor(container, "--accent", "#b4befe"),
+      );
+      ctx.lineCap = "round";
+      ctx.strokeStyle = "rgba(17, 17, 27, 0.78)";
+      ctx.lineWidth = 4;
+      ctx.beginPath();
+      ctx.moveTo(anchorLeft, anchorY + 1);
+      ctx.lineTo(anchorRight, anchorY + 1);
+      ctx.moveTo(anchorCenter, anchorY + 1);
+      ctx.lineTo(anchorCenter, markerBottom);
+      ctx.stroke();
+      ctx.strokeStyle = markerColor;
       ctx.lineWidth = 2;
       ctx.beginPath();
-      ctx.moveTo(caretX, 10);
-      ctx.lineTo(caretX, TOUCH_LOUPE_HEIGHT_PX - 10);
+      ctx.moveTo(anchorLeft, anchorY);
+      ctx.lineTo(anchorRight, anchorY);
+      ctx.moveTo(anchorCenter, anchorY);
+      ctx.lineTo(anchorCenter, markerBottom);
       ctx.stroke();
+      ctx.lineCap = "butt";
       ctx.strokeStyle = "rgba(17, 17, 27, 0.85)";
       ctx.lineWidth = 1;
       ctx.strokeRect(1, 1, TOUCH_LOUPE_WIDTH_PX - 2, TOUCH_LOUPE_HEIGHT_PX - 2);
+    };
+    const renderLoupeAfterTerminalPaint = (
+      point: TerminalCellPosition,
+      client: { clientX: number; clientY: number },
+    ) => {
+      clearLoupeRenderFrame();
+      loupeRenderFrame = window.requestAnimationFrame(() => {
+        loupeRenderFrame = null;
+        if (selectionState.phase === "dragging-endpoint") {
+          renderLoupe(point, client);
+        }
+      });
     };
     const ensureEndpointBubble = () => {
       if (endpointBubble) {
@@ -489,6 +600,11 @@ export class GhosttyRenderer implements TerminalRenderer {
       endpointBubble.className = "terminal-touch-endpoint";
       endpointBubble.setAttribute("aria-hidden", "true");
       endpointBubble.setAttribute("data-hint", "Drag");
+      const line = document.createElement("span");
+      line.className = "terminal-touch-endpoint-line";
+      const knob = document.createElement("span");
+      knob.className = "terminal-touch-endpoint-knob";
+      endpointBubble.append(line, knob);
       container.append(endpointBubble);
       return endpointBubble;
     };
@@ -498,23 +614,38 @@ export class GhosttyRenderer implements TerminalRenderer {
         bubble,
         client.clientX,
         client.clientY,
-        TOUCH_ENDPOINT_SIZE_PX,
-        TOUCH_ENDPOINT_SIZE_PX,
-        TOUCH_ENDPOINT_SIZE_PX / 2,
+        TOUCH_ENDPOINT_HIT_WIDTH_PX,
+        TOUCH_ENDPOINT_HIT_HEIGHT_PX,
+        0,
       );
     };
     const startTouchSelection = () => {
       selectionTimer = null;
       if (
-        !this.#mobileTouchSelectionEnabled ||
+        this.#mobileLongPressBehavior === "off" ||
         this.#hasMouseTracking(terminal) ||
         touchStartX === null ||
         touchStartY === null
       ) {
         return;
       }
-      const position = touchCellPosition(terminal, touchStartX, touchStartY);
       const client = { clientX: touchStartX, clientY: touchStartY };
+      if (this.#mobileLongPressBehavior === "copy") {
+        const position = touchCellPosition(terminal, touchStartX, touchStartY);
+        simpleSelectionStart = position;
+        simpleSelectionEnd = position;
+        selectingFromTouch = true;
+        touchMoved = true;
+        suppressMouseEvents();
+        terminal.textarea?.blur();
+        terminal.clearSelection();
+        selectTerminalViewportRange(terminal, position, position);
+        if (navigator.vibrate) {
+          navigator.vibrate(35);
+        }
+        return;
+      }
+      const position = loupePositionFromClient(touchStartX, touchStartY);
       selectionState = startTouchSelectionPlacement(position, client);
       touchMoved = true;
       suppressMouseEvents();
@@ -527,7 +658,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
     };
     const updateStartPlacement = (touch: Touch) => {
-      const position = positionFromTouch(touch);
+      const position = loupePositionFromTouch(touch);
       const client = clientFromTouch(touch);
       selectionState = moveTouchSelectionPlacement(selectionState, position, client);
       selectCurrentTouchRange();
@@ -544,7 +675,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       clearEndpointTimer();
       endpointTimer = window.setTimeout(() => {
         resetTouchSelection(true);
-      }, TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS);
+      }, this.#mobileTouchSelectionEndpointTimeoutMs);
     };
     const beginEndpointDrag = (touch: Touch) => {
       clearEndpointTimer();
@@ -554,32 +685,35 @@ export class GhosttyRenderer implements TerminalRenderer {
       endpointDragStartX = touch.clientX;
       endpointDragStartY = touch.clientY;
       endpointDragMoved = false;
+      const position = endpointPositionFromTouch(touch);
       const client = clientFromTouch(touch);
-      selectionState = beginTouchSelectionEndpointDrag(selectionState, selectionState.endpoint, client);
+      selectionState = beginTouchSelectionEndpointDrag(selectionState, position, client);
       if (selectionState.phase !== "dragging-endpoint") {
         return;
       }
       selectCurrentTouchRange();
-      positionEndpointBubble(client);
+      positionEndpointBubble(cellClientCenter(selectionState.endpoint));
       renderLoupe(selectionState.endpoint, client);
+      renderLoupeAfterTerminalPaint(selectionState.endpoint, client);
       suppressMouseEvents();
       terminal.textarea?.blur();
     };
     const updateEndpointDrag = (touch: Touch, force = false) => {
+      clearLoupeRenderFrame();
       if (endpointDragStartX !== null && endpointDragStartY !== null) {
         const deltaX = touch.clientX - endpointDragStartX;
         const deltaY = touch.clientY - endpointDragStartY;
         if (!endpointDragMoved && Math.hypot(deltaX, deltaY) <= TOUCH_SELECTION_TOLERANCE_PX && !force) {
-          positionEndpointBubble(clientFromTouch(touch));
+          positionEndpointBubble(cellClientCenter(endpointPositionFromTouch(touch)));
           return;
         }
         endpointDragMoved = true;
       }
-      const position = positionFromTouch(touch);
+      const position = endpointPositionFromTouch(touch);
       const client = clientFromTouch(touch);
       selectionState = moveTouchSelectionEndpoint(selectionState, position, client);
       selectCurrentTouchRange();
-      positionEndpointBubble(client);
+      positionEndpointBubble(cellClientCenter(position));
       renderLoupe(position, client);
     };
     const completeEndpointDrag = (event: TouchEvent) => {
@@ -601,9 +735,32 @@ export class GhosttyRenderer implements TerminalRenderer {
         terminal.textarea?.blur();
       }
     };
+    const completeSimpleTouchSelection = (event: TouchEvent) => {
+      preventTouchEvent(event);
+      suppressMouseEvents();
+      const selectedText =
+        simpleSelectionStart && simpleSelectionEnd
+          ? terminalSelectedTextFromViewportRange(terminal, simpleSelectionStart, simpleSelectionEnd)
+          : "";
+      stopSimpleTouchSelection();
+      terminal.textarea?.blur();
+      if (selectedText.trim() && this.#mobileTouchSelectionHandler) {
+        this.#mobileTouchSelectionHandler({ type: "selection", text: selectedText });
+        clearSelectionClearTimer();
+        selectionClearTimer = window.setTimeout(() => {
+          selectionClearTimer = null;
+          terminal.clearSelection();
+        }, TOUCH_SELECTION_CLEAR_DELAY_MS);
+      }
+    };
     const touchLinkText = (event: TouchEvent) => {
       const mouseTracking = this.#hasMouseTracking(terminal);
-      if (!this.#mobileTouchSelectionHandler || event.changedTouches.length === 0 || mouseTracking) {
+      if (
+        this.#mobileLongPressBehavior === "off" ||
+        !this.#mobileTouchSelectionHandler ||
+        event.changedTouches.length === 0 ||
+        mouseTracking
+      ) {
         return null;
       }
       const touch = event.changedTouches[0];
@@ -641,6 +798,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       clearSelectionTimer();
       if (selectionState.phase === "waiting-endpoint") {
         if (
+          this.#mobileLongPressBehavior === "loupe" &&
           event.touches.length === 1 &&
           endpointBubble &&
           event.target instanceof Node &&
@@ -654,7 +812,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
       if (event.touches.length === 1) {
         const mouseTracking = this.#hasMouseTracking(terminal);
-        if (this.#mobileTouchSelectionEnabled && !mouseTracking) {
+        if (this.#mobileLongPressBehavior !== "off" && !mouseTracking) {
           preventTouchEvent(event);
           suppressMouseEvents(TOUCH_SELECTION_LONG_PRESS_MS + TOUCH_COMPAT_MOUSE_SUPPRESS_MS);
         }
@@ -664,7 +822,11 @@ export class GhosttyRenderer implements TerminalRenderer {
         lastTouchY = touch.clientY;
         touchMoved = false;
         touchScrolled = false;
-        if (this.#mobileTouchSelectionEnabled && !mouseTracking) {
+        selectingFromTouch = false;
+        simpleSelectionStart = null;
+        simpleSelectionEnd = null;
+        if (this.#mobileLongPressBehavior !== "off" && !mouseTracking) {
+          clearSelectionClearTimer();
           selectionTimer = window.setTimeout(startTouchSelection, TOUCH_SELECTION_LONG_PRESS_MS);
         }
       }
@@ -684,6 +846,11 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
       if (selectionState.phase === "placing-start" && event.touches.length === 1) {
         updateStartPlacement(event.touches[0]);
+        preventTouchEvent(event);
+        return;
+      }
+      if (selectingFromTouch && event.touches.length === 1) {
+        updateSimpleTouchSelection(event.touches[0]);
         preventTouchEvent(event);
         return;
       }
@@ -729,6 +896,12 @@ export class GhosttyRenderer implements TerminalRenderer {
         if (selectionState.phase !== "idle") {
           resetTouchSelection(true);
         }
+        stopSimpleTouchSelection();
+        resetTouchTracking();
+        return;
+      }
+      if (selectingFromTouch) {
+        completeSimpleTouchSelection(event);
         resetTouchTracking();
         return;
       }
@@ -767,7 +940,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     };
     const onTouchCancel = () => {
       clearSelectionTimer();
-      if (selectionState.phase !== "idle") {
+      if (selectionState.phase !== "idle" || selectingFromTouch) {
         suppressMouseEvents();
       }
       resetTouchSelection(true);
@@ -805,7 +978,7 @@ export class GhosttyRenderer implements TerminalRenderer {
 
     container.addEventListener("touchstart", onTouchStart, {
       capture: true,
-      passive: !this.#mobileTouchSelectionEnabled,
+      passive: this.#mobileLongPressBehavior === "off",
     });
     container.addEventListener("touchmove", onTouchMove, { capture: true, passive: false });
     container.addEventListener("touchend", onTouchEnd, { capture: true });
@@ -816,6 +989,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     this.#touchCleanup = () => {
       resetTouchSelection(true);
       resetTouchTracking();
+      clearSelectionClearTimer();
       container.removeEventListener("touchstart", onTouchStart, { capture: true });
       container.removeEventListener("touchmove", onTouchMove, { capture: true });
       container.removeEventListener("touchend", onTouchEnd, { capture: true });
@@ -1216,6 +1390,11 @@ function clampInteger(value: number, min: number, max: number) {
 
 function clampNumber(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
+}
+
+function cssColor(element: Element, property: string, fallback: string) {
+  const value = getComputedStyle(element).getPropertyValue(property).trim();
+  return value || fallback;
 }
 
 function normalizeWheelLines(event: WheelEvent, rows: number, sensitivity: number) {

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -1,8 +1,18 @@
 import type { FitAddon, Terminal } from "ghostty-web";
-import { selectedTextFromVisibleRows, terminalSelectionRange } from "./terminalSelection";
+import { terminalSelectionRange, terminalUrlTapTarget, trimUrlPunctuation } from "./terminalSelection";
 import type { TerminalSelectionPoint } from "./terminalSelection";
 import { terminalTapFocusAction } from "./terminalTapFocus";
 import type { TerminalTapFocusResult } from "./terminalTapFocus";
+import {
+  beginTouchSelectionEndpointDrag,
+  commitTouchSelectionStart,
+  completeTouchSelection,
+  idleTouchSelectionState,
+  moveTouchSelectionEndpoint,
+  moveTouchSelectionPlacement,
+  startTouchSelectionPlacement,
+} from "./terminalTouchSelection";
+import type { TerminalTouchSelectionState } from "./terminalTouchSelection";
 
 const TERMINAL_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace';
@@ -10,11 +20,15 @@ const TERMINAL_TEXT_INPUT_TAP_GRACE_MS = 4000;
 const TOUCH_SELECTION_LONG_PRESS_MS = 600;
 const TOUCH_SELECTION_TOLERANCE_PX = 10;
 const TOUCH_SELECTION_SCROLL_INTENT_PX = 5;
-const TOUCH_SELECTION_CLEAR_DELAY_MS = 1200;
+const TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS = 1500;
 const TOUCH_COMPAT_MOUSE_SUPPRESS_MS = 1200;
-const TAP_URL_PATTERN =
-  /(?:https?:\/\/|mailto:|ftp:\/\/|ssh:\/\/|git:\/\/|tel:|magnet:|gemini:\/\/|gopher:\/\/|news:)[\w\-.~:/?#@!$&*+,;=%]+/giu;
-const TAP_URL_TRAILING_PUNCTUATION = /[.,;!?)\]]+$/u;
+const TOUCH_LOUPE_WIDTH_PX = 132;
+const TOUCH_LOUPE_HEIGHT_PX = 82;
+const TOUCH_LOUPE_SOURCE_WIDTH_PX = 70;
+const TOUCH_LOUPE_SOURCE_HEIGHT_PX = 44;
+const TOUCH_LOUPE_OFFSET_Y_PX = 108;
+const TOUCH_ENDPOINT_SIZE_PX = 46;
+const TAP_URL_PATTERN = /\bhttps?:\/\/[^\s"'<>`]+/giu;
 
 type GhosttyModule = typeof import("ghostty-web");
 
@@ -68,17 +82,22 @@ type TerminalBufferLine = {
     | undefined;
 };
 
+export type MobileTerminalTouchEvent =
+  | { type: "selection"; text: string }
+  | { type: "url"; url: string };
+
 export type TerminalRenderer = {
   mount(container: HTMLElement): Promise<TerminalSize>;
   write(data: string | Uint8Array): void;
   onInput(callback: (data: string) => void): () => void;
   onScroll(callback: (lines: number) => void): () => void;
   setTapFocusHandler(callback: (() => TerminalTapFocusResult) | null): void;
-  setMobileTouchSelection(enabled: boolean, callback: ((text: string) => void) | null): void;
+  setMobileTouchSelection(enabled: boolean, callback: ((event: MobileTerminalTouchEvent) => void) | null): void;
   fit(): TerminalSize;
   refreshMetrics(): TerminalSize;
   focus(): void;
   focusTextInput(): void;
+  clearSelection(): void;
   setScrollSensitivity(value: number): void;
   dispose(): void;
 };
@@ -93,7 +112,7 @@ export class GhosttyRenderer implements TerminalRenderer {
   #mobileInputCleanup: (() => void) | null = null;
   #tapFocusHandler: (() => TerminalTapFocusResult) | null = null;
   #mobileTouchSelectionEnabled = false;
-  #mobileTouchSelectionHandler: ((text: string) => void) | null = null;
+  #mobileTouchSelectionHandler: ((event: MobileTerminalTouchEvent) => void) | null = null;
   #textInputTapGraceUntil = 0;
 
   async mount(container: HTMLElement) {
@@ -179,7 +198,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     this.#tapFocusHandler = callback;
   }
 
-  setMobileTouchSelection(enabled: boolean, callback: ((text: string) => void) | null) {
+  setMobileTouchSelection(enabled: boolean, callback: ((event: MobileTerminalTouchEvent) => void) | null) {
     const changed = this.#mobileTouchSelectionEnabled !== enabled;
     this.#mobileTouchSelectionEnabled = enabled;
     this.#mobileTouchSelectionHandler = callback;
@@ -223,6 +242,10 @@ export class GhosttyRenderer implements TerminalRenderer {
         textarea.focus({ preventScroll: true });
       }
     }, 0);
+  }
+
+  clearSelection() {
+    this.#terminal?.clearSelection();
   }
 
   setScrollSensitivity(value: number) {
@@ -306,10 +329,14 @@ export class GhosttyRenderer implements TerminalRenderer {
     let pendingTouchLines = 0;
     let suppressMouseUntil = 0;
     let selectionTimer: number | null = null;
-    let selectingFromTouch = false;
-    let selectionStart: TerminalCellPosition | null = null;
-    let selectionEnd: TerminalCellPosition | null = null;
-    let selectionClearTimer: number | null = null;
+    let endpointTimer: number | null = null;
+    let selectionState: TerminalTouchSelectionState = idleTouchSelectionState;
+    let endpointBubble: HTMLDivElement | null = null;
+    let loupe: { root: HTMLDivElement; canvas: HTMLCanvasElement } | null = null;
+    let endpointDragStartX: number | null = null;
+    let endpointDragStartY: number | null = null;
+    let endpointDragMoved = false;
+
     const suppressMouseEvents = (duration = TOUCH_COMPAT_MOUSE_SUPPRESS_MS) => {
       suppressMouseUntil = performance.now() + duration;
     };
@@ -319,17 +346,32 @@ export class GhosttyRenderer implements TerminalRenderer {
         selectionTimer = null;
       }
     };
-    const clearSelectionClearTimer = () => {
-      if (selectionClearTimer !== null) {
-        window.clearTimeout(selectionClearTimer);
-        selectionClearTimer = null;
+    const clearEndpointTimer = () => {
+      if (endpointTimer !== null) {
+        window.clearTimeout(endpointTimer);
+        endpointTimer = null;
       }
     };
-    const stopTouchSelection = () => {
+    const removeEndpointBubble = () => {
+      endpointBubble?.remove();
+      endpointBubble = null;
+    };
+    const removeLoupe = () => {
+      loupe?.root.remove();
+      loupe = null;
+    };
+    const resetTouchSelection = (clearTerminalSelection = true) => {
       clearSelectionTimer();
-      selectingFromTouch = false;
-      selectionStart = null;
-      selectionEnd = null;
+      clearEndpointTimer();
+      selectionState = idleTouchSelectionState;
+      removeEndpointBubble();
+      removeLoupe();
+      endpointDragStartX = null;
+      endpointDragStartY = null;
+      endpointDragMoved = false;
+      if (clearTerminalSelection) {
+        terminal.clearSelection();
+      }
     };
     const preventTouchEvent = (event: TouchEvent) => {
       event.preventDefault();
@@ -339,14 +381,127 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
     };
     const positionFromTouch = (touch: Touch) => touchCellPosition(terminal, touch.clientX, touch.clientY);
-    const updateTouchSelection = (touch: Touch) => {
-      if (!selectionStart) {
+    const clientFromTouch = (touch: Touch) => ({ clientX: touch.clientX, clientY: touch.clientY });
+    const selectCurrentTouchRange = () => {
+      if (selectionState.phase === "idle") {
         return;
       }
-      const current = positionFromTouch(touch);
-      const range = terminalSelectionRange(selectionStart, current, terminal.cols);
-      selectionEnd = current;
+      const range = terminalSelectionRange(selectionState.start, selectionState.endpoint, terminal.cols);
       selectTerminalViewportRange(terminal, range.from, range.to);
+    };
+    const cellClientCenter = (point: TerminalCellPosition) => {
+      const canvas = terminal.renderer?.getCanvas();
+      const rect = (canvas ?? terminal.element)?.getBoundingClientRect();
+      const metrics = terminal.renderer?.getMetrics();
+      const cellWidth = metrics?.width ?? 9;
+      const cellHeight = metrics?.height ?? 16;
+      return {
+        clientX: (rect?.left ?? 0) + (point.col + 0.5) * cellWidth,
+        clientY: (rect?.top ?? 0) + (point.row + 0.5) * cellHeight,
+      };
+    };
+    const positionOverlay = (
+      element: HTMLElement,
+      clientX: number,
+      clientY: number,
+      width: number,
+      height: number,
+      offsetY: number,
+    ) => {
+      const rect = container.getBoundingClientRect();
+      const left = clampInteger(clientX - rect.left - width / 2, 4, Math.max(4, rect.width - width - 4));
+      const top = clampInteger(clientY - rect.top - offsetY, 4, Math.max(4, rect.height - height - 4));
+      element.style.transform = `translate(${left}px, ${top}px)`;
+    };
+    const ensureLoupe = () => {
+      if (loupe) {
+        return loupe;
+      }
+      const root = document.createElement("div");
+      root.className = "terminal-touch-loupe";
+      const canvas = document.createElement("canvas");
+      canvas.width = TOUCH_LOUPE_WIDTH_PX;
+      canvas.height = TOUCH_LOUPE_HEIGHT_PX;
+      root.append(canvas);
+      container.append(root);
+      loupe = { root, canvas };
+      return loupe;
+    };
+    const renderLoupe = (point: TerminalCellPosition, client: { clientX: number; clientY: number }) => {
+      const source = terminal.renderer?.getCanvas();
+      if (!source) {
+        return;
+      }
+      const current = ensureLoupe();
+      positionOverlay(
+        current.root,
+        client.clientX,
+        client.clientY,
+        TOUCH_LOUPE_WIDTH_PX,
+        TOUCH_LOUPE_HEIGHT_PX,
+        TOUCH_LOUPE_OFFSET_Y_PX,
+      );
+      const rect = source.getBoundingClientRect();
+      const metrics = terminal.renderer?.getMetrics();
+      const cellWidth = metrics?.width ?? 9;
+      const cellHeight = metrics?.height ?? 16;
+      const centerX = (point.col + 0.5) * cellWidth;
+      const centerY = (point.row + 0.5) * cellHeight;
+      const sourceWidth = Math.min(TOUCH_LOUPE_SOURCE_WIDTH_PX, rect.width || TOUCH_LOUPE_SOURCE_WIDTH_PX);
+      const sourceHeight = Math.min(TOUCH_LOUPE_SOURCE_HEIGHT_PX, rect.height || TOUCH_LOUPE_SOURCE_HEIGHT_PX);
+      const sxCss = clampNumber(centerX - sourceWidth / 2, 0, Math.max(0, rect.width - sourceWidth));
+      const syCss = clampNumber(centerY - sourceHeight / 2, 0, Math.max(0, rect.height - sourceHeight));
+      const scaleX = rect.width > 0 ? source.width / rect.width : 1;
+      const scaleY = rect.height > 0 ? source.height / rect.height : 1;
+      const ctx = current.canvas.getContext("2d");
+      if (!ctx) {
+        return;
+      }
+      ctx.clearRect(0, 0, current.canvas.width, current.canvas.height);
+      ctx.imageSmoothingEnabled = false;
+      ctx.drawImage(
+        source,
+        sxCss * scaleX,
+        syCss * scaleY,
+        sourceWidth * scaleX,
+        sourceHeight * scaleY,
+        0,
+        0,
+        TOUCH_LOUPE_WIDTH_PX,
+        TOUCH_LOUPE_HEIGHT_PX,
+      );
+      const caretX = ((centerX - sxCss) / sourceWidth) * TOUCH_LOUPE_WIDTH_PX;
+      ctx.strokeStyle = "rgba(245, 224, 220, 0.95)";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(caretX, 10);
+      ctx.lineTo(caretX, TOUCH_LOUPE_HEIGHT_PX - 10);
+      ctx.stroke();
+      ctx.strokeStyle = "rgba(17, 17, 27, 0.85)";
+      ctx.lineWidth = 1;
+      ctx.strokeRect(1, 1, TOUCH_LOUPE_WIDTH_PX - 2, TOUCH_LOUPE_HEIGHT_PX - 2);
+    };
+    const ensureEndpointBubble = () => {
+      if (endpointBubble) {
+        return endpointBubble;
+      }
+      endpointBubble = document.createElement("div");
+      endpointBubble.className = "terminal-touch-endpoint";
+      endpointBubble.setAttribute("aria-hidden", "true");
+      endpointBubble.setAttribute("data-hint", "Drag");
+      container.append(endpointBubble);
+      return endpointBubble;
+    };
+    const positionEndpointBubble = (client: { clientX: number; clientY: number }) => {
+      const bubble = ensureEndpointBubble();
+      positionOverlay(
+        bubble,
+        client.clientX,
+        client.clientY,
+        TOUCH_ENDPOINT_SIZE_PX,
+        TOUCH_ENDPOINT_SIZE_PX,
+        TOUCH_ENDPOINT_SIZE_PX / 2,
+      );
     };
     const startTouchSelection = () => {
       selectionTimer = null;
@@ -359,50 +514,101 @@ export class GhosttyRenderer implements TerminalRenderer {
         return;
       }
       const position = touchCellPosition(terminal, touchStartX, touchStartY);
-      selectionStart = position;
-      selectionEnd = position;
-      selectingFromTouch = true;
+      const client = { clientX: touchStartX, clientY: touchStartY };
+      selectionState = startTouchSelectionPlacement(position, client);
       touchMoved = true;
       suppressMouseEvents();
       terminal.textarea?.blur();
       terminal.clearSelection();
-      selectTerminalViewportRange(terminal, position, position);
+      selectCurrentTouchRange();
+      renderLoupe(position, client);
       if (navigator.vibrate) {
         navigator.vibrate(35);
       }
     };
-    const completeTouchSelection = (event: TouchEvent) => {
+    const updateStartPlacement = (touch: Touch) => {
+      const position = positionFromTouch(touch);
+      const client = clientFromTouch(touch);
+      selectionState = moveTouchSelectionPlacement(selectionState, position, client);
+      selectCurrentTouchRange();
+      renderLoupe(position, client);
+    };
+    const waitForEndpointDrag = () => {
+      selectionState = commitTouchSelectionStart(selectionState);
+      removeLoupe();
+      if (selectionState.phase !== "waiting-endpoint") {
+        return;
+      }
+      selectCurrentTouchRange();
+      positionEndpointBubble(cellClientCenter(selectionState.start));
+      clearEndpointTimer();
+      endpointTimer = window.setTimeout(() => {
+        resetTouchSelection(true);
+      }, TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS);
+    };
+    const beginEndpointDrag = (touch: Touch) => {
+      clearEndpointTimer();
+      if (selectionState.phase !== "waiting-endpoint") {
+        return;
+      }
+      endpointDragStartX = touch.clientX;
+      endpointDragStartY = touch.clientY;
+      endpointDragMoved = false;
+      const client = clientFromTouch(touch);
+      selectionState = beginTouchSelectionEndpointDrag(selectionState, selectionState.endpoint, client);
+      if (selectionState.phase !== "dragging-endpoint") {
+        return;
+      }
+      selectCurrentTouchRange();
+      positionEndpointBubble(client);
+      renderLoupe(selectionState.endpoint, client);
+      suppressMouseEvents();
+      terminal.textarea?.blur();
+    };
+    const updateEndpointDrag = (touch: Touch, force = false) => {
+      if (endpointDragStartX !== null && endpointDragStartY !== null) {
+        const deltaX = touch.clientX - endpointDragStartX;
+        const deltaY = touch.clientY - endpointDragStartY;
+        if (!endpointDragMoved && Math.hypot(deltaX, deltaY) <= TOUCH_SELECTION_TOLERANCE_PX && !force) {
+          positionEndpointBubble(clientFromTouch(touch));
+          return;
+        }
+        endpointDragMoved = true;
+      }
+      const position = positionFromTouch(touch);
+      const client = clientFromTouch(touch);
+      selectionState = moveTouchSelectionEndpoint(selectionState, position, client);
+      selectCurrentTouchRange();
+      positionEndpointBubble(client);
+      renderLoupe(position, client);
+    };
+    const completeEndpointDrag = (event: TouchEvent) => {
+      if (event.changedTouches.length > 0 && endpointDragMoved) {
+        updateEndpointDrag(event.changedTouches[0], true);
+      }
       preventTouchEvent(event);
       suppressMouseEvents();
-      const selectedText =
-        selectionStart && selectionEnd
-          ? terminalSelectedTextFromViewportRange(terminal, selectionStart, selectionEnd)
-          : "";
-      stopTouchSelection();
-      terminal.textarea?.blur();
-      if (selectedText.trim()) {
-        this.#mobileTouchSelectionHandler?.(selectedText);
-        clearSelectionClearTimer();
-        selectionClearTimer = window.setTimeout(() => {
-          selectionClearTimer = null;
-          terminal.clearSelection();
-        }, TOUCH_SELECTION_CLEAR_DELAY_MS);
+      const selection = completeTouchSelection(selectionState);
+      const selectedText = selection
+        ? terminalSelectedTextFromViewportRange(terminal, selection.start, selection.end)
+        : "";
+      if (selectedText.length > 0 && this.#mobileTouchSelectionHandler) {
+        resetTouchSelection(false);
+        terminal.textarea?.blur();
+        this.#mobileTouchSelectionHandler({ type: "selection", text: selectedText });
+      } else {
+        resetTouchSelection(true);
+        terminal.textarea?.blur();
       }
     };
     const touchLinkText = (event: TouchEvent) => {
-      if (
-        !this.#mobileTouchSelectionEnabled ||
-        !this.#mobileTouchSelectionHandler ||
-        event.changedTouches.length === 0
-      ) {
-        return null;
-      }
-      if (this.#hasMouseTracking(terminal)) {
+      const mouseTracking = this.#hasMouseTracking(terminal);
+      if (!this.#mobileTouchSelectionHandler || event.changedTouches.length === 0 || mouseTracking) {
         return null;
       }
       const touch = event.changedTouches[0];
       const position = positionFromTouch(touch);
-      return terminalLinkAt(terminal, position);
+      return terminalUrlTapTarget(terminalLinkAt(terminal, position), mouseTracking);
     };
     const redirectTapFocus = (event: TouchEvent | MouseEvent) => {
       const terminalHadFocusOrGrace =
@@ -423,8 +629,29 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
       return true;
     };
+    const resetTouchTracking = () => {
+      lastTouchY = null;
+      touchStartX = null;
+      touchStartY = null;
+      touchMoved = false;
+      touchScrolled = false;
+      pendingTouchLines = 0;
+    };
     const onTouchStart = (event: TouchEvent) => {
       clearSelectionTimer();
+      if (selectionState.phase === "waiting-endpoint") {
+        if (
+          event.touches.length === 1 &&
+          endpointBubble &&
+          event.target instanceof Node &&
+          endpointBubble.contains(event.target)
+        ) {
+          preventTouchEvent(event);
+          beginEndpointDrag(event.touches[0]);
+          return;
+        }
+        resetTouchSelection(true);
+      }
       if (event.touches.length === 1) {
         const mouseTracking = this.#hasMouseTracking(terminal);
         if (this.#mobileTouchSelectionEnabled && !mouseTracking) {
@@ -437,11 +664,7 @@ export class GhosttyRenderer implements TerminalRenderer {
         lastTouchY = touch.clientY;
         touchMoved = false;
         touchScrolled = false;
-        selectingFromTouch = false;
-        selectionStart = null;
-        selectionEnd = null;
         if (this.#mobileTouchSelectionEnabled && !mouseTracking) {
-          clearSelectionClearTimer();
           selectionTimer = window.setTimeout(startTouchSelection, TOUCH_SELECTION_LONG_PRESS_MS);
         }
       }
@@ -459,8 +682,13 @@ export class GhosttyRenderer implements TerminalRenderer {
           clearSelectionTimer();
         }
       }
-      if (selectingFromTouch && event.touches.length === 1) {
-        updateTouchSelection(event.touches[0]);
+      if (selectionState.phase === "placing-start" && event.touches.length === 1) {
+        updateStartPlacement(event.touches[0]);
+        preventTouchEvent(event);
+        return;
+      }
+      if (selectionState.phase === "dragging-endpoint" && event.touches.length === 1) {
+        updateEndpointDrag(event.touches[0]);
         preventTouchEvent(event);
         return;
       }
@@ -473,7 +701,7 @@ export class GhosttyRenderer implements TerminalRenderer {
       if (touchStartX !== null && touchStartY !== null) {
         const deltaX = event.touches[0].clientX - touchStartX;
         const totalDeltaY = currentY - touchStartY;
-        if (Math.hypot(deltaX, totalDeltaY) > 2) {
+        if (Math.hypot(deltaX, totalDeltaY) > TOUCH_SELECTION_TOLERANCE_PX) {
           touchMoved = true;
         }
       }
@@ -498,22 +726,22 @@ export class GhosttyRenderer implements TerminalRenderer {
     const onTouchEnd = (event: TouchEvent) => {
       clearSelectionTimer();
       if (this.#hasMouseTracking(terminal)) {
-        lastTouchY = null;
-        touchStartX = null;
-        touchStartY = null;
-        touchMoved = false;
-        touchScrolled = false;
-        pendingTouchLines = 0;
+        if (selectionState.phase !== "idle") {
+          resetTouchSelection(true);
+        }
+        resetTouchTracking();
         return;
       }
-      if (selectingFromTouch) {
-        completeTouchSelection(event);
-        lastTouchY = null;
-        touchStartX = null;
-        touchStartY = null;
-        touchMoved = false;
-        touchScrolled = false;
-        pendingTouchLines = 0;
+      if (selectionState.phase === "placing-start") {
+        preventTouchEvent(event);
+        suppressMouseEvents();
+        waitForEndpointDrag();
+        resetTouchTracking();
+        return;
+      }
+      if (selectionState.phase === "dragging-endpoint") {
+        completeEndpointDrag(event);
+        resetTouchTracking();
         return;
       }
       if (touchMoved || touchScrolled) {
@@ -530,31 +758,20 @@ export class GhosttyRenderer implements TerminalRenderer {
           preventTouchEvent(event);
           suppressMouseEvents();
           terminal.textarea?.blur();
-          this.#mobileTouchSelectionHandler?.(linkText);
+          this.#mobileTouchSelectionHandler?.({ type: "url", url: linkText });
         } else {
           redirectTapFocus(event);
         }
       }
-      lastTouchY = null;
-      touchStartX = null;
-      touchStartY = null;
-      touchMoved = false;
-      touchScrolled = false;
-      pendingTouchLines = 0;
+      resetTouchTracking();
     };
     const onTouchCancel = () => {
       clearSelectionTimer();
-      if (selectingFromTouch) {
-        terminal.clearSelection();
+      if (selectionState.phase !== "idle") {
         suppressMouseEvents();
       }
-      stopTouchSelection();
-      lastTouchY = null;
-      touchStartX = null;
-      touchStartY = null;
-      touchMoved = false;
-      touchScrolled = false;
-      pendingTouchLines = 0;
+      resetTouchSelection(true);
+      resetTouchTracking();
       terminal.textarea?.blur();
     };
     const suppressCompatMouseEvent = (event: MouseEvent) => {
@@ -597,8 +814,8 @@ export class GhosttyRenderer implements TerminalRenderer {
     container.addEventListener("mouseup", onMouseUp, { capture: true });
     container.addEventListener("click", onClick, { capture: true });
     this.#touchCleanup = () => {
-      clearSelectionTimer();
-      clearSelectionClearTimer();
+      resetTouchSelection(true);
+      resetTouchTracking();
       container.removeEventListener("touchstart", onTouchStart, { capture: true });
       container.removeEventListener("touchmove", onTouchMove, { capture: true });
       container.removeEventListener("touchend", onTouchEnd, { capture: true });
@@ -860,6 +1077,11 @@ function selectTerminalViewportRange(
     return;
   }
 
+  if (start.row === end.row && start.col === end.col) {
+    terminal.select(start.col, start.row, 1);
+    return;
+  }
+
   markSelectionRowsDirty(selectionManager, selectionManager.getSelectionCoords());
   selectionManager.selectionStart = {
     col: start.col,
@@ -916,17 +1138,29 @@ function terminalSelectedTextFromViewportRange(
   end: TerminalSelectionPoint,
 ) {
   const range = terminalSelectionRange(start, end, terminal.cols);
-  if (range.length <= 1) {
-    return "";
-  }
 
-  const rows: string[] = [];
+  const selectedLines: string[] = [];
   for (let row = range.from.row; row <= range.to.row; row += 1) {
     const bufferRow = terminalBufferRow(terminal, row);
     const line = terminal.buffer.active.getLine(bufferRow) as TerminalBufferLine | undefined;
-    rows[row] = line ? terminalBufferLineText(line).text : "";
+    const startCol = row === range.from.row ? range.from.col : 0;
+    const endCol = row === range.to.row ? range.to.col : terminal.cols - 1;
+    selectedLines.push(line ? terminalBufferLineCellText(line, startCol, endCol).trimEnd() : "");
   }
-  return selectedTextFromVisibleRows(rows, start, end, terminal.cols);
+  return selectedLines.join("\n");
+}
+
+function terminalBufferLineCellText(line: TerminalBufferLine, startCol: number, endCol: number) {
+  let text = "";
+  for (let col = startCol; col <= endCol && col < line.length; col += 1) {
+    const cell = line.getCell(col);
+    const codepoint = cell?.getCodepoint() ?? 0;
+    if (codepoint === 0 && cell?.getWidth() === 0) {
+      continue;
+    }
+    text += codepoint === 0 || codepoint < 32 ? " " : String.fromCodePoint(codepoint);
+  }
+  return text;
 }
 
 function terminalLinkAt(terminal: Terminal, position: TerminalCellPosition) {
@@ -947,7 +1181,7 @@ function terminalLinkAt(terminal: Terminal, position: TerminalCellPosition) {
   let match = TAP_URL_PATTERN.exec(text);
   while (match) {
     const rawUrl = match[0];
-    const url = rawUrl.replace(TAP_URL_TRAILING_PUNCTUATION, "");
+    const url = trimUrlPunctuation(rawUrl);
     const start = columns[match.index];
     const end = columns[match.index + url.length - 1];
     if (url.length > 8 && position.col >= start && position.col <= end) {
@@ -977,6 +1211,10 @@ function terminalBufferLineText(line: TerminalBufferLine) {
 }
 
 function clampInteger(value: number, min: number, max: number) {
+  return Math.round(clampNumber(value, min, max));
+}
+
+function clampNumber(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -615,8 +615,16 @@ export class GhosttyRenderer implements TerminalRenderer {
       container.append(endpointBubble);
       return endpointBubble;
     };
+    const hideEndpointBubble = () => {
+      if (endpointBubble) {
+        endpointBubble.dataset.dragging = "true";
+        endpointBubble.removeAttribute("data-hint");
+      }
+    };
     const positionEndpointBubble = (client: { clientX: number; clientY: number }) => {
       const bubble = ensureEndpointBubble();
+      delete bubble.dataset.dragging;
+      bubble.setAttribute("data-hint", "Drag");
       positionOverlay(
         bubble,
         client.clientX,
@@ -699,7 +707,7 @@ export class GhosttyRenderer implements TerminalRenderer {
         return;
       }
       selectCurrentTouchRange();
-      positionEndpointBubble(cellClientCenter(selectionState.endpoint));
+      hideEndpointBubble();
       renderLoupe(selectionState.endpoint, client);
       renderLoupeAfterTerminalPaint(selectionState.endpoint, client);
       suppressMouseEvents();
@@ -711,7 +719,6 @@ export class GhosttyRenderer implements TerminalRenderer {
         const deltaX = touch.clientX - endpointDragStartX;
         const deltaY = touch.clientY - endpointDragStartY;
         if (!endpointDragMoved && Math.hypot(deltaX, deltaY) <= TOUCH_SELECTION_TOLERANCE_PX && !force) {
-          positionEndpointBubble(cellClientCenter(endpointPositionFromTouch(touch)));
           return;
         }
         endpointDragMoved = true;
@@ -720,7 +727,6 @@ export class GhosttyRenderer implements TerminalRenderer {
       const client = clientFromTouch(touch);
       selectionState = moveTouchSelectionEndpoint(selectionState, position, client);
       selectCurrentTouchRange();
-      positionEndpointBubble(cellClientCenter(position));
       renderLoupe(position, client);
     };
     const completeEndpointDrag = (event: TouchEvent) => {

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -1,5 +1,10 @@
 import type { FitAddon, Terminal } from "ghostty-web";
-import { terminalSelectionRange, terminalUrlTapTarget, trimUrlPunctuation } from "./terminalSelection";
+import {
+  findFirstUrlInSelection,
+  terminalSelectionRange,
+  terminalUrlTapTarget,
+  trimUrlPunctuation,
+} from "./terminalSelection";
 import type { TerminalSelectionPoint } from "./terminalSelection";
 import { terminalTapFocusAction } from "./terminalTapFocus";
 import type { TerminalTapFocusResult } from "./terminalTapFocus";
@@ -746,11 +751,13 @@ export class GhosttyRenderer implements TerminalRenderer {
       terminal.textarea?.blur();
       if (selectedText.trim() && this.#mobileTouchSelectionHandler) {
         this.#mobileTouchSelectionHandler({ type: "selection", text: selectedText });
-        clearSelectionClearTimer();
-        selectionClearTimer = window.setTimeout(() => {
-          selectionClearTimer = null;
-          terminal.clearSelection();
-        }, TOUCH_SELECTION_CLEAR_DELAY_MS);
+        if (!findFirstUrlInSelection(selectedText.trim())) {
+          clearSelectionClearTimer();
+          selectionClearTimer = window.setTimeout(() => {
+            selectionClearTimer = null;
+            terminal.clearSelection();
+          }, TOUCH_SELECTION_CLEAR_DELAY_MS);
+        }
       }
     };
     const touchLinkText = (event: TouchEvent) => {

--- a/web/src/terminalSelection.test.ts
+++ b/web/src/terminalSelection.test.ts
@@ -5,6 +5,7 @@ import {
   openableHttpUrl,
   selectedTextFromVisibleRows,
   terminalSelectionRange,
+  terminalUrlTapTarget,
 } from "./terminalSelection";
 
 describe("terminal selection helpers", () => {
@@ -57,6 +58,15 @@ describe("terminal selection helpers", () => {
     expect(openableHttpUrl("tel:+15555555555")).toBeNull();
   });
 
+  it("opens tapped terminal URLs only when mouse tracking is inactive", () => {
+    expect(terminalUrlTapTarget("https://example.com/path", false)).toBe(
+      "https://example.com/path",
+    );
+    expect(terminalUrlTapTarget("https://example.com/path", true)).toBeNull();
+    expect(terminalUrlTapTarget("mailto:test@example.com", false)).toBeNull();
+    expect(terminalUrlTapTarget(null, false)).toBeNull();
+  });
+
   it("orders forward and backward terminal selection ranges", () => {
     expect(terminalSelectionRange({ col: 2, row: 1 }, { col: 5, row: 3 }, 10)).toEqual({
       from: { col: 2, row: 1 },
@@ -89,9 +99,9 @@ describe("terminal selection helpers", () => {
     );
   });
 
-  it("ignores single-cell selections to match terminal hasSelection behavior", () => {
+  it("extracts a single character for same-cell selections", () => {
     expect(selectedTextFromVisibleRows(["alpha"], { col: 1, row: 0 }, { col: 1, row: 0 }, 10)).toBe(
-      "",
+      "l",
     );
   });
 });

--- a/web/src/terminalSelection.ts
+++ b/web/src/terminalSelection.ts
@@ -31,9 +31,6 @@ export function selectedTextFromVisibleRows(
   cols: number,
 ) {
   const range = terminalSelectionRange(start, end, cols);
-  if (range.length <= 1) {
-    return "";
-  }
 
   const selectedLines: string[] = [];
   for (let row = range.from.row; row <= range.to.row; row += 1) {
@@ -69,6 +66,13 @@ export function openableHttpUrl(value: string) {
   }
 }
 
+export function terminalUrlTapTarget(value: string | null, mouseTracking: boolean) {
+  if (mouseTracking || !value) {
+    return null;
+  }
+  return openableHttpUrl(value);
+}
+
 export function normalizeSelectionForUrl(selection: string) {
   return selection.replace(/\s*\n\s*/gu, "").replace(/[ \t\r\f\v]+/gu, " ").trim();
 }
@@ -96,7 +100,7 @@ function shouldJoinWrappedUrl(url: string, continuation: string) {
   return /[/?#&=._~%+-]$/u.test(url) || /^[/?#&=._~%+-]/u.test(continuation);
 }
 
-function trimUrlPunctuation(value: string) {
+export function trimUrlPunctuation(value: string) {
   let next = value.replace(TRAILING_URL_PUNCTUATION, "");
   while (TRAILING_BALANCED_CLOSERS.test(next) && hasUnmatchedTrailingCloser(next)) {
     next = next.slice(0, -1);

--- a/web/src/terminalTouchSelection.test.ts
+++ b/web/src/terminalTouchSelection.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  beginTouchSelectionEndpointDrag,
+  commitTouchSelectionStart,
+  completeTouchSelection,
+  moveTouchSelectionEndpoint,
+  moveTouchSelectionPlacement,
+  startTouchSelectionPlacement,
+} from "./terminalTouchSelection";
+
+describe("terminal touch selection flow", () => {
+  it("commits a refined long-press point as the selection start", () => {
+    const placing = startTouchSelectionPlacement(
+      { col: 1, row: 2 },
+      { clientX: 20, clientY: 40 },
+    );
+    const refined = moveTouchSelectionPlacement(placing, { col: 3, row: 2 }, { clientX: 42, clientY: 40 });
+    const waiting = commitTouchSelectionStart(refined);
+
+    expect(waiting).toMatchObject({
+      phase: "waiting-endpoint",
+      start: { col: 3, row: 2 },
+      endpoint: { col: 3, row: 2 },
+    });
+  });
+
+  it("completes forward endpoint drags", () => {
+    const waiting = commitTouchSelectionStart(
+      startTouchSelectionPlacement({ col: 2, row: 1 }, { clientX: 18, clientY: 30 }),
+    );
+    const dragging = beginTouchSelectionEndpointDrag(waiting, { col: 7, row: 1 }, { clientX: 63, clientY: 30 });
+
+    expect(completeTouchSelection(dragging)).toEqual({
+      start: { col: 2, row: 1 },
+      end: { col: 7, row: 1 },
+    });
+  });
+
+  it("completes backward endpoint drags without reordering the anchor", () => {
+    const waiting = commitTouchSelectionStart(
+      startTouchSelectionPlacement({ col: 8, row: 3 }, { clientX: 72, clientY: 58 }),
+    );
+    const dragging = beginTouchSelectionEndpointDrag(waiting, { col: 4, row: 2 }, { clientX: 36, clientY: 42 });
+    const moved = moveTouchSelectionEndpoint(dragging, { col: 1, row: 2 }, { clientX: 9, clientY: 42 });
+
+    expect(completeTouchSelection(moved)).toEqual({
+      start: { col: 8, row: 3 },
+      end: { col: 1, row: 2 },
+    });
+  });
+});

--- a/web/src/terminalTouchSelection.ts
+++ b/web/src/terminalTouchSelection.ts
@@ -1,0 +1,90 @@
+import type { TerminalSelectionPoint } from "./terminalSelection";
+
+export type TerminalTouchClientPoint = {
+  clientX: number;
+  clientY: number;
+};
+
+export type TerminalTouchSelectionState =
+  | { phase: "idle" }
+  | {
+      phase: "placing-start";
+      start: TerminalSelectionPoint;
+      endpoint: TerminalSelectionPoint;
+      client: TerminalTouchClientPoint;
+    }
+  | {
+      phase: "waiting-endpoint";
+      start: TerminalSelectionPoint;
+      endpoint: TerminalSelectionPoint;
+      client: TerminalTouchClientPoint;
+    }
+  | {
+      phase: "dragging-endpoint";
+      start: TerminalSelectionPoint;
+      endpoint: TerminalSelectionPoint;
+      client: TerminalTouchClientPoint;
+    };
+
+export const idleTouchSelectionState: TerminalTouchSelectionState = { phase: "idle" };
+
+export function startTouchSelectionPlacement(
+  point: TerminalSelectionPoint,
+  client: TerminalTouchClientPoint,
+): TerminalTouchSelectionState {
+  return { phase: "placing-start", start: point, endpoint: point, client };
+}
+
+export function moveTouchSelectionPlacement(
+  state: TerminalTouchSelectionState,
+  point: TerminalSelectionPoint,
+  client: TerminalTouchClientPoint,
+): TerminalTouchSelectionState {
+  if (state.phase !== "placing-start") {
+    return state;
+  }
+  return { ...state, start: point, endpoint: point, client };
+}
+
+export function commitTouchSelectionStart(
+  state: TerminalTouchSelectionState,
+): TerminalTouchSelectionState {
+  if (state.phase !== "placing-start") {
+    return state;
+  }
+  return {
+    phase: "waiting-endpoint",
+    start: state.start,
+    endpoint: state.start,
+    client: state.client,
+  };
+}
+
+export function beginTouchSelectionEndpointDrag(
+  state: TerminalTouchSelectionState,
+  point: TerminalSelectionPoint,
+  client: TerminalTouchClientPoint,
+): TerminalTouchSelectionState {
+  if (state.phase !== "waiting-endpoint") {
+    return state;
+  }
+  return { phase: "dragging-endpoint", start: state.start, endpoint: point, client };
+}
+
+export function moveTouchSelectionEndpoint(
+  state: TerminalTouchSelectionState,
+  point: TerminalSelectionPoint,
+  client: TerminalTouchClientPoint,
+): TerminalTouchSelectionState {
+  if (state.phase !== "dragging-endpoint") {
+    return state;
+  }
+  return { ...state, endpoint: point, client };
+}
+
+export function completeTouchSelection(state: TerminalTouchSelectionState) {
+  if (state.phase !== "dragging-endpoint") {
+    return null;
+  }
+  return { start: state.start, end: state.endpoint };
+}


### PR DESCRIPTION
## Summary

- supersedes #15
- builds on Will Hampson's original mobile long-press selection work while preserving his commit attribution
- adds Mobile long-press behavior modes: Off, Copy, and Loupe
- adds the two-stage mobile Loupe selection flow, including the fixed resume handle and hidden handle while dragging
- adds configurable loupe wait and Terminal font size settings
- improves the mobile selection action sheet layout, including full-width selected URLs with actions below
- opens detected HTTP(S) terminal URLs from desktop clicks and mobile taps
- fixes Android/tablet bridge color picker dismissal so saving after choosing a color keeps Settings open

## Validation

- npm run lint:web
- npm run test:web
- npm run android:build:debug