### PR TITLE
Improve terminal reconnect lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
+  keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.
+  [PR #19](https://github.com/kcosr/herdr-web/pull/19)
+
 ### Removed
 
 ## [0.2.1] - 2026-06-20

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ import {
 import { LaunchDialog } from "./LaunchDialog";
 import { resolveLaunchSpec } from "./launch";
 import type { LaunchTarget } from "./launch";
+import { fetchWithTimeout } from "./fetchWithTimeout";
 import {
   DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
   DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR,
@@ -4201,7 +4202,7 @@ function stageBreadcrumb(
 }
 
 async function fetchSnapshot(httpUrl: (path: string, query?: URLSearchParams) => string) {
-  const response = await fetch(httpUrl("/api/snapshot"));
+  const response = await fetchWithTimeout(httpUrl("/api/snapshot"));
   if (!response.ok) {
     throw new Error(`snapshot failed: ${response.status}`);
   }

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -12,7 +12,14 @@ import {
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent, RefObject } from "react";
 import { ConfirmDialog } from "./overlays";
+import { addNativeResumeHandler } from "./native";
 import { shellQuote } from "./shell";
+import {
+  isNonRetryableTerminalClose,
+  parseTerminalCloseReason,
+  terminalConnectionCopy,
+} from "./terminalConnectionStatus";
+import type { TerminalConnectionState } from "./terminalConnectionStatus";
 import { findFirstUrlInSelection, openableHttpUrl } from "./terminalSelection";
 import { GhosttyRenderer } from "./terminalRenderer";
 import type { MobileTerminalTouchEvent, TerminalRenderer, TerminalSize } from "./terminalRenderer";
@@ -25,6 +32,14 @@ import {
 import type { TerminalInputTransport } from "./terminalInputTransport";
 import { DEFAULT_TERMINAL_OUTPUT_COALESCE_MS } from "./terminalOutputCoalescing";
 import { DEFAULT_TERMINAL_FONT_SIZE_PX } from "./terminalPrefs";
+import {
+  TERMINAL_FOREGROUND_FAST_ATTEMPTS,
+  TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS,
+  TERMINAL_FOREGROUND_SIGNAL_COALESCE_MS,
+  TERMINAL_RECONNECT_OVERLAY_DELAY_MS,
+  terminalReconnectPolicy,
+} from "./terminalReconnectPolicy";
+import type { TerminalReconnectMode } from "./terminalReconnectPolicy";
 import { DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS } from "./mobileTerminalPrefs";
 import type {
   MobileLongPressBehavior,
@@ -65,7 +80,6 @@ type Props = {
   focusToken?: number;
 };
 
-type ConnectionState = "idle" | "connecting" | "attached" | "closed" | "error";
 type UploadCandidate = {
   blob: Blob;
   name: string | null;
@@ -85,8 +99,24 @@ type MobileSelectionAction = {
   text: string;
   url: string;
 };
+type ReconnectReason =
+  | "initial"
+  | "close"
+  | "error"
+  | "stalled"
+  | "resume"
+  | "visible"
+  | "online"
+  | "resize"
+  | "manual";
+type TerminalRendererReady = {
+  terminalId: string;
+  generation: number;
+  renderer: TerminalRenderer;
+  measure: (mode?: "fit" | "refresh") => TerminalSize | null;
+};
 const MAX_UPLOAD_FILES = 8;
-const TERMINAL_CONNECT_TIMEOUT_MS = 3500;
+const DEBUG_TERMINAL_RECONNECT = false;
 
 export function TerminalView({
   pane,
@@ -111,7 +141,11 @@ export function TerminalView({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const mobileCommandInputRef = useRef<HTMLInputElement | null>(null);
   const rendererRef = useRef<TerminalRenderer | null>(null);
+  const rendererGenerationRef = useRef(0);
+  const rendererReadyRef = useRef<TerminalRendererReady | null>(null);
   const socketRef = useRef<WebSocket | null>(null);
+  const requestReconnectRef = useRef<(reason: ReconnectReason) => void>(() => {});
+  const terminalInputBlockedRef = useRef(false);
   const uploadInputId = useId();
   const sendResizeRef = useRef<(size: TerminalSize) => void>(() => {});
   const inputQueueRef = useRef<string[]>([]);
@@ -124,8 +158,11 @@ export function TerminalView({
   const uploadConflictRef = useRef<UploadConflictState | null>(null);
   const connectionKeyRef = useRef(connectionKey);
   const terminalIdRef = useRef(pane?.terminal_id ?? null);
-  const [connectionState, setConnectionState] = useState<ConnectionState>("idle");
+  const [connectionState, setConnectionState] = useState<TerminalConnectionState>("idle");
   const [closeReason, setCloseReason] = useState<string | null>(null);
+  const [rendererReady, setRendererReady] = useState<TerminalRendererReady | null>(null);
+  const [hasAttachedForTerminal, setHasAttachedForTerminal] = useState(false);
+  const [showConnectionOverlay, setShowConnectionOverlay] = useState(false);
   const [uploadStatus, setUploadStatus] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadConflict, setUploadConflict] = useState<UploadConflictState | null>(null);
@@ -283,6 +320,36 @@ export function TerminalView({
     }
   }, []);
 
+  const clearQueuedTerminalInput = useCallback(() => {
+    inputQueueRef.current = [];
+    if (inputFlushTimerRef.current !== null) {
+      window.clearTimeout(inputFlushTimerRef.current);
+      inputFlushTimerRef.current = null;
+    }
+  }, []);
+
+  const flushQueuedTerminalInput = useCallback(() => {
+    if (inputFlushTimerRef.current !== null) {
+      window.clearTimeout(inputFlushTimerRef.current);
+      inputFlushTimerRef.current = null;
+    }
+    const flush = () => {
+      inputFlushTimerRef.current = null;
+      const socket = socketRef.current;
+      if (socket?.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      const next = inputQueueRef.current.shift();
+      if (next !== undefined) {
+        sendTerminalInputFrame(socket, next);
+      }
+      if (inputQueueRef.current.length > 0) {
+        inputFlushTimerRef.current = window.setTimeout(flush, 35);
+      }
+    };
+    flush();
+  }, [sendTerminalInputFrame]);
+
   const flushBatchedTerminalInput = useCallback(() => {
     clearBatchedInputTimer();
     const pending = batchedInputRef.current;
@@ -362,31 +429,46 @@ export function TerminalView({
 
   useEffect(() => {
     const host = hostRef.current;
-    if (!host || !pane) {
+    const terminalId = pane?.terminal_id ?? null;
+    rendererReadyRef.current = null;
+    setRendererReady(null);
+    setHasAttachedForTerminal(false);
+    setShowConnectionOverlay(false);
+    setCloseReason(null);
+    terminalInputBlockedRef.current = false;
+    if (!host || !terminalId) {
       setConnectionState("idle");
+      host?.replaceChildren();
       return;
     }
 
     host.replaceChildren();
     let disposed = false;
-    let socket: WebSocket | null = null;
     let disposeInput: (() => void) | null = null;
     let disposeScroll: (() => void) | null = null;
     let resizeObserver: ResizeObserver | null = null;
-    let reconnectTimer: number | null = null;
-    let connectTimer: number | null = null;
-    let reconnectAttempts = 0;
-    let lastCloseReason: string | null = null;
+    const generation = rendererGenerationRef.current + 1;
+    rendererGenerationRef.current = generation;
     const renderer: TerminalRenderer = new GhosttyRenderer(terminalFontSizePxRef.current);
     rendererRef.current = renderer;
     setConnectionState("connecting");
 
-    const sendResize = (size: TerminalSize) => {
-      if (socket?.readyState === WebSocket.OPEN) {
-        socket.send(JSON.stringify({ type: "resize", cols: size.cols, rows: size.rows }));
+    const measure = (mode: "fit" | "refresh" = "fit") => measureTerminal(renderer, mode);
+    const publishReady = (mode: "fit" | "refresh" = "fit") => {
+      if (disposed || rendererRef.current !== renderer) {
+        return;
       }
+      const size = measure(mode);
+      if (!size) {
+        return;
+      }
+      if (rendererReadyRef.current?.generation !== generation) {
+        const ready = { terminalId, generation, renderer, measure };
+        rendererReadyRef.current = ready;
+        setRendererReady(ready);
+      }
+      sendResizeRef.current(size);
     };
-    sendResizeRef.current = sendResize;
 
     void renderer
       .mount(host)
@@ -413,6 +495,7 @@ export function TerminalView({
           sendTerminalInputData(data);
         });
         disposeScroll = renderer.onScroll((lines) => {
+          const socket = socketRef.current;
           if (socket?.readyState !== WebSocket.OPEN || lines === 0) {
             return;
           }
@@ -426,9 +509,9 @@ export function TerminalView({
         });
 
         resizeObserver = new ResizeObserver(() => {
-          const size = measureTerminal(renderer);
-          if (size) {
-            sendResize(size);
+          publishReady();
+          if (socketRef.current?.readyState !== WebSocket.OPEN) {
+            requestReconnectRef.current("resize");
           }
         });
         resizeObserver.observe(host);
@@ -437,128 +520,12 @@ export function TerminalView({
         if (fontReady) {
           void fontReady.then(() => {
             if (!disposed) {
-              const size = measureTerminal(renderer, "refresh");
-              if (size) {
-                sendResize(size);
-              }
+              publishReady("refresh");
             }
           });
         }
 
-        const scheduleReconnect = () => {
-          if (disposed || reconnectTimer !== null) {
-            return;
-          }
-          const delay = Math.min(500 * 2 ** reconnectAttempts, 5000);
-          reconnectAttempts += 1;
-          setConnectionState("connecting");
-          reconnectTimer = window.setTimeout(() => {
-            reconnectTimer = null;
-            connectSocket();
-          }, delay);
-        };
-
-        const clearConnectTimer = () => {
-          if (connectTimer !== null) {
-            window.clearTimeout(connectTimer);
-            connectTimer = null;
-          }
-        };
-
-        const retryStalledConnect = (stalledSocket: WebSocket) => {
-          if (
-            disposed ||
-            socket !== stalledSocket ||
-            stalledSocket.readyState !== WebSocket.CONNECTING
-          ) {
-            return;
-          }
-          socket = null;
-          if (socketRef.current === stalledSocket) {
-            socketRef.current = null;
-          }
-          stalledSocket.close();
-          scheduleReconnect();
-        };
-
-        const connectSocket = () => {
-          if (disposed) {
-            return;
-          }
-          clearConnectTimer();
-          const initialSize = measureTerminal(renderer);
-          if (!initialSize) {
-            scheduleReconnect();
-            return;
-          }
-          const nextSocket = new WebSocket(
-            terminalSocketUrl(wsUrl, pane.terminal_id, initialSize, terminalOutputCoalesceMs),
-          );
-          socket = nextSocket;
-          socketRef.current = nextSocket;
-          nextSocket.binaryType = "arraybuffer";
-          connectTimer = window.setTimeout(
-            () => retryStalledConnect(nextSocket),
-            TERMINAL_CONNECT_TIMEOUT_MS,
-          );
-
-          nextSocket.addEventListener("open", () => {
-            if (!disposed && socket === nextSocket) {
-              clearConnectTimer();
-              reconnectAttempts = 0;
-              lastCloseReason = null;
-              setCloseReason(null);
-              setConnectionState("attached");
-              const size = measureTerminal(renderer);
-              if (size) {
-                sendResize(size);
-              }
-              if (autoFocusRef.current) {
-                window.setTimeout(() => renderer.focus(), 0);
-              }
-              flushBatchedTerminalInput();
-            }
-          });
-          nextSocket.addEventListener("message", (event) => {
-            if (typeof event.data === "string") {
-              lastCloseReason = parseCloseReason(event.data) ?? lastCloseReason;
-              return;
-            }
-            if (event.data instanceof ArrayBuffer) {
-              renderer.write(new Uint8Array(event.data));
-              return;
-            }
-            if (event.data instanceof Blob) {
-              void event.data.arrayBuffer().then((buffer) => {
-                if (!disposed && socket === nextSocket) {
-                  renderer.write(new Uint8Array(buffer));
-                }
-              });
-            }
-          });
-          nextSocket.addEventListener("close", () => {
-            if (!disposed && socket === nextSocket) {
-              clearConnectTimer();
-              if (lastCloseReason) {
-                console.warn("terminal websocket closed", lastCloseReason);
-              }
-              if (isNonRetryableAttachClose(lastCloseReason)) {
-                setCloseReason(lastCloseReason);
-                setConnectionState("closed");
-              } else {
-                scheduleReconnect();
-              }
-            }
-          });
-          nextSocket.addEventListener("error", () => {
-            if (!disposed && socket === nextSocket) {
-              clearConnectTimer();
-              setConnectionState("error");
-            }
-          });
-        };
-
-        connectSocket();
+        publishReady();
       })
       .catch((error: unknown) => {
         console.error("failed to mount terminal renderer", error);
@@ -571,42 +538,454 @@ export function TerminalView({
       disposed = true;
       flushBatchedTerminalInput();
       batchedInputRef.current = emptyTerminalInputBatch();
-      inputQueueRef.current = [];
-      if (inputFlushTimerRef.current !== null) {
-        window.clearTimeout(inputFlushTimerRef.current);
-        inputFlushTimerRef.current = null;
-      }
+      clearQueuedTerminalInput();
       disposeInput?.();
       disposeScroll?.();
       resizeObserver?.disconnect();
-      if (reconnectTimer !== null) {
-        window.clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
-      if (connectTimer !== null) {
-        window.clearTimeout(connectTimer);
-        connectTimer = null;
-      }
-      socket?.close();
-      if (socketRef.current === socket) {
-        socketRef.current = null;
+      if (rendererReadyRef.current?.generation === generation) {
+        rendererReadyRef.current = null;
+        setRendererReady(null);
       }
       sendResizeRef.current = () => {};
       renderer.dispose();
-      rendererRef.current = null;
+      if (rendererRef.current === renderer) {
+        rendererRef.current = null;
+      }
       host.replaceChildren();
     };
   }, [
     connectionKey,
+    clearQueuedTerminalInput,
+    flushBatchedTerminalInput,
+    focusMobileCommandInput,
+    focusTerminalKeyboardInput,
+    handleMobileTerminalTouch,
     measureTerminal,
     pane?.terminal_id,
-    resumeToken,
-    flushBatchedTerminalInput,
     sendTerminalInputData,
-    sendTerminalInputFrame,
+  ]);
+
+  useEffect(() => {
+    const terminalId = pane?.terminal_id ?? null;
+    const ready = rendererReady;
+    if (!terminalId) {
+      setConnectionState("idle");
+      requestReconnectRef.current = () => {};
+      return;
+    }
+    if (
+      !ready ||
+      ready.terminalId !== terminalId ||
+      rendererReadyRef.current !== ready ||
+      rendererRef.current !== ready.renderer
+    ) {
+      setConnectionState("connecting");
+      requestReconnectRef.current = () => {};
+      return;
+    }
+
+    let disposed = false;
+    let socket: WebSocket | null = null;
+    let reconnectTimer: number | null = null;
+    let connectTimer: number | null = null;
+    let foregroundCoalesceTimer: number | null = null;
+    let reconnectAttempts = 0;
+    let foregroundFastAttemptsRemaining = 0;
+    let lastCloseReason: string | null = null;
+    let socketGeneration = 0;
+    let socketStartedAt = 0;
+    let lastForegroundReconnectAt = Number.NEGATIVE_INFINITY;
+    let reconnectStopped = false;
+    const reconnectScheduledForSocket = new Set<number>();
+    const pendingForegroundReasons = new Set<ReconnectReason>();
+
+    const debugReconnect = (event: string, details: Record<string, unknown> = {}) => {
+      if (DEBUG_TERMINAL_RECONNECT) {
+        console.debug("terminal reconnect:", event, { terminalId, ...details });
+      }
+    };
+
+    const clearReconnectTimer = () => {
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+    };
+
+    const clearConnectTimer = () => {
+      if (connectTimer !== null) {
+        window.clearTimeout(connectTimer);
+        connectTimer = null;
+      }
+    };
+
+    const clearForegroundCoalesceTimer = () => {
+      if (foregroundCoalesceTimer !== null) {
+        window.clearTimeout(foregroundCoalesceTimer);
+        foregroundCoalesceTimer = null;
+      }
+    };
+
+    const sendResize = (size: TerminalSize) => {
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ type: "resize", cols: size.cols, rows: size.rows }));
+      }
+    };
+    sendResizeRef.current = sendResize;
+
+    const closeActiveSocket = () => {
+      const current = socket;
+      socket = null;
+      if (socketRef.current === current) {
+        socketRef.current = null;
+      }
+      current?.close();
+    };
+
+    const writeTerminalData = (socketId: number, data: Uint8Array) => {
+      if (
+        disposed ||
+        socketId !== socketGeneration ||
+        rendererReadyRef.current?.generation !== ready.generation
+      ) {
+        return;
+      }
+      ready.renderer.write(data);
+    };
+
+    const connectSocket = (reason: ReconnectReason, connectTimeoutMs: number) => {
+      if (disposed || reconnectStopped) {
+        return;
+      }
+      clearConnectTimer();
+      const initialSize = ready.measure();
+      if (!initialSize) {
+        scheduleReconnect("resize");
+        return;
+      }
+      if (socket) {
+        closeActiveSocket();
+      }
+      reconnectScheduledForSocket.clear();
+      const nextSocket = new WebSocket(
+        terminalSocketUrl(wsUrl, terminalId, initialSize, terminalOutputCoalesceMs),
+      );
+      socket = nextSocket;
+      socketRef.current = nextSocket;
+      nextSocket.binaryType = "arraybuffer";
+      const currentSocketGeneration = socketGeneration + 1;
+      socketGeneration = currentSocketGeneration;
+      socketStartedAt = performance.now();
+      setConnectionState("connecting");
+      debugReconnect("connect_start", { reason, socketGeneration, connectTimeoutMs });
+      connectTimer = window.setTimeout(
+        () => retryStalledConnect(nextSocket, currentSocketGeneration),
+        connectTimeoutMs,
+      );
+
+      nextSocket.addEventListener("open", () => {
+        if (disposed || socket !== nextSocket || socketGeneration !== currentSocketGeneration) {
+          return;
+        }
+        clearConnectTimer();
+        clearReconnectTimer();
+        reconnectAttempts = 0;
+        foregroundFastAttemptsRemaining = 0;
+        reconnectScheduledForSocket.delete(currentSocketGeneration);
+        lastCloseReason = null;
+        terminalInputBlockedRef.current = false;
+        setCloseReason(null);
+        setHasAttachedForTerminal(true);
+        setConnectionState("attached");
+        debugReconnect("open", { socketGeneration: currentSocketGeneration });
+        const size = ready.measure();
+        if (size) {
+          sendResize(size);
+        }
+        if (autoFocusRef.current) {
+          window.setTimeout(() => ready.renderer.focus(), 0);
+        }
+        flushBatchedTerminalInput();
+        flushQueuedTerminalInput();
+      });
+      nextSocket.addEventListener("message", (event) => {
+        if (disposed || socket !== nextSocket || socketGeneration !== currentSocketGeneration) {
+          return;
+        }
+        if (typeof event.data === "string") {
+          lastCloseReason = parseTerminalCloseReason(event.data) ?? lastCloseReason;
+          return;
+        }
+        if (event.data instanceof ArrayBuffer) {
+          writeTerminalData(currentSocketGeneration, new Uint8Array(event.data));
+          return;
+        }
+        if (event.data instanceof Blob) {
+          void event.data.arrayBuffer().then((buffer) => {
+            writeTerminalData(currentSocketGeneration, new Uint8Array(buffer));
+          });
+        }
+      });
+      nextSocket.addEventListener("close", () => {
+        if (disposed || socket !== nextSocket || socketGeneration !== currentSocketGeneration) {
+          return;
+        }
+        clearConnectTimer();
+        if (socketRef.current === nextSocket) {
+          socketRef.current = null;
+        }
+        socket = null;
+        if (lastCloseReason) {
+          console.warn("terminal websocket closed", lastCloseReason);
+        }
+        if (isNonRetryableTerminalClose(lastCloseReason)) {
+          reconnectStopped = true;
+          terminalInputBlockedRef.current = true;
+          clearReconnectTimer();
+          clearQueuedTerminalInput();
+          setCloseReason(lastCloseReason);
+          setConnectionState("closed");
+          return;
+        }
+        scheduleSocketReconnect("close", currentSocketGeneration);
+      });
+      nextSocket.addEventListener("error", () => {
+        if (disposed || socket !== nextSocket || socketGeneration !== currentSocketGeneration) {
+          return;
+        }
+        clearConnectTimer();
+        debugReconnect("error", { socketGeneration: currentSocketGeneration });
+        scheduleSocketReconnect("error", currentSocketGeneration);
+        nextSocket.close();
+      });
+    };
+
+    const scheduleConnect = (
+      reason: ReconnectReason,
+      mode: TerminalReconnectMode,
+      immediate: boolean,
+    ) => {
+      if (disposed || reconnectStopped) {
+        return;
+      }
+      if (reconnectTimer !== null) {
+        if (!immediate) {
+          return;
+        }
+        clearReconnectTimer();
+      }
+      const policy = terminalReconnectPolicy({
+        attempt: reconnectAttempts,
+        mode,
+        immediate,
+        foregroundFastAttemptsRemaining,
+      });
+      reconnectAttempts = policy.nextAttempt;
+      foregroundFastAttemptsRemaining = policy.nextForegroundFastAttemptsRemaining;
+      setConnectionState("connecting");
+      debugReconnect("scheduled", {
+        reason,
+        mode,
+        delayMs: policy.delayMs,
+        connectTimeoutMs: policy.connectTimeoutMs,
+      });
+      const run = () => {
+        reconnectTimer = null;
+        connectSocket(reason, policy.connectTimeoutMs);
+      };
+      if (policy.delayMs === 0) {
+        run();
+        return;
+      }
+      reconnectTimer = window.setTimeout(run, policy.delayMs);
+    };
+
+    function scheduleReconnect(reason: ReconnectReason) {
+      const mode: TerminalReconnectMode =
+        foregroundFastAttemptsRemaining > 0 ? "foreground" : "normal";
+      scheduleConnect(reason, mode, false);
+    }
+
+    function scheduleSocketReconnect(reason: ReconnectReason, socketId: number) {
+      if (reconnectScheduledForSocket.has(socketId)) {
+        return;
+      }
+      reconnectScheduledForSocket.add(socketId);
+      scheduleReconnect(reason);
+    }
+
+    function retryStalledConnect(stalledSocket: WebSocket, socketId: number) {
+      if (
+        disposed ||
+        socket !== stalledSocket ||
+        socketGeneration !== socketId ||
+        stalledSocket.readyState !== WebSocket.CONNECTING
+      ) {
+        return;
+      }
+      debugReconnect("stalled", { socketGeneration: socketId });
+      socket = null;
+      if (socketRef.current === stalledSocket) {
+        socketRef.current = null;
+      }
+      stalledSocket.close();
+      scheduleSocketReconnect("stalled", socketId);
+    }
+
+    const processForegroundReconnect = (reason: ReconnectReason) => {
+      if (reconnectStopped) {
+        return;
+      }
+      const now = performance.now();
+      lastForegroundReconnectAt = now;
+      const reasons = Array.from(pendingForegroundReasons);
+      pendingForegroundReasons.clear();
+      debugReconnect("signal", { reason, reasons });
+      const currentSocket = socket;
+      if (currentSocket?.readyState === WebSocket.OPEN) {
+        const size = ready.measure("refresh");
+        if (size) {
+          sendResize(size);
+        }
+        return;
+      }
+      if (
+        currentSocket?.readyState === WebSocket.CONNECTING &&
+        now - socketStartedAt < TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS
+      ) {
+        const socketId = socketGeneration;
+        const remainingMs = Math.max(1, TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS - (now - socketStartedAt));
+        clearConnectTimer();
+        connectTimer = window.setTimeout(
+          () => retryStalledConnect(currentSocket, socketId),
+          remainingMs,
+        );
+        return;
+      }
+      reconnectAttempts = 0;
+      foregroundFastAttemptsRemaining = TERMINAL_FOREGROUND_FAST_ATTEMPTS;
+      clearReconnectTimer();
+      if (currentSocket) {
+        closeActiveSocket();
+      }
+      scheduleConnect(reason, "foreground", true);
+    };
+
+    const requestForegroundReconnect = (reason: ReconnectReason) => {
+      if (reconnectStopped) {
+        return;
+      }
+      pendingForegroundReasons.add(reason);
+      const now = performance.now();
+      const remainingCoalesceMs =
+        TERMINAL_FOREGROUND_SIGNAL_COALESCE_MS - (now - lastForegroundReconnectAt);
+      if (remainingCoalesceMs > 0) {
+        debugReconnect("signal_coalesced", { reason });
+        if (foregroundCoalesceTimer === null) {
+          foregroundCoalesceTimer = window.setTimeout(() => {
+            foregroundCoalesceTimer = null;
+            processForegroundReconnect(reason);
+          }, remainingCoalesceMs);
+        }
+        return;
+      }
+      clearForegroundCoalesceTimer();
+      processForegroundReconnect(reason);
+    };
+
+    const requestReconnect = (reason: ReconnectReason) => {
+      if (reconnectStopped) {
+        return;
+      }
+      if (reason === "resume" || reason === "visible" || reason === "online") {
+        requestForegroundReconnect(reason);
+        return;
+      }
+      if (reason === "resize") {
+        if (socket?.readyState === WebSocket.OPEN) {
+          const size = ready.measure("refresh");
+          if (size) {
+            sendResize(size);
+          }
+          return;
+        }
+        if (socket?.readyState === WebSocket.CONNECTING) {
+          return;
+        }
+        scheduleReconnect(reason);
+        return;
+      }
+      scheduleConnect(reason, "normal", reason === "initial" || reason === "manual");
+    };
+
+    requestReconnectRef.current = requestReconnect;
+    const removeNativeResumeHandler = addNativeResumeHandler(() => requestReconnect("resume"));
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        requestReconnect("visible");
+      }
+    };
+    const handleOnline = () => requestReconnect("online");
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("online", handleOnline);
+
+    requestReconnect("initial");
+
+    return () => {
+      disposed = true;
+      removeNativeResumeHandler();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("online", handleOnline);
+      requestReconnectRef.current = () => {};
+      flushBatchedTerminalInput();
+      batchedInputRef.current = emptyTerminalInputBatch();
+      clearReconnectTimer();
+      clearConnectTimer();
+      clearForegroundCoalesceTimer();
+      closeActiveSocket();
+      sendResizeRef.current = () => {};
+    };
+  }, [
+    connectionKey,
+    clearQueuedTerminalInput,
+    flushBatchedTerminalInput,
+    flushQueuedTerminalInput,
+    pane?.terminal_id,
+    rendererReady,
     terminalOutputCoalesceMs,
     wsUrl,
   ]);
+
+  useEffect(() => {
+    if (resumeToken > 0) {
+      requestReconnectRef.current("resume");
+    }
+  }, [resumeToken]);
+
+  useEffect(() => {
+    let overlayTimer: number | null = null;
+    if (!pane || connectionState === "idle" || connectionState === "attached") {
+      setShowConnectionOverlay(false);
+      return;
+    }
+    if (connectionState === "connecting" && hasAttachedForTerminal) {
+      setShowConnectionOverlay(false);
+      overlayTimer = window.setTimeout(() => {
+        setShowConnectionOverlay(true);
+      }, TERMINAL_RECONNECT_OVERLAY_DELAY_MS);
+      return () => {
+        if (overlayTimer !== null) {
+          window.clearTimeout(overlayTimer);
+        }
+      };
+    }
+    setShowConnectionOverlay(true);
+    return () => {
+      if (overlayTimer !== null) {
+        window.clearTimeout(overlayTimer);
+      }
+    };
+  }, [connectionState, hasAttachedForTerminal, pane?.terminal_id]);
 
   useEffect(() => {
     rendererRef.current?.setTapFocusHandler(
@@ -767,13 +1146,14 @@ export function TerminalView({
         return;
       }
       if (uploaded.length > 0) {
-        enqueueTerminalInput([uploaded.map((file) => shellQuote(file.path)).join(" ")]);
-        showUploadStatus(
-          `Uploaded ${uploaded.length} file${uploaded.length === 1 ? "" : "s"}${
-            skippedCount > 0 ? `; skipped ${skippedCount}` : ""
-          }`,
-          2500,
-        );
+        if (enqueueTerminalInput([uploaded.map((file) => shellQuote(file.path)).join(" ")])) {
+          showUploadStatus(
+            `Uploaded ${uploaded.length} file${uploaded.length === 1 ? "" : "s"}${
+              skippedCount > 0 ? `; skipped ${skippedCount}` : ""
+            }`,
+            2500,
+          );
+        }
       } else {
         showUploadStatus(null);
       }
@@ -818,31 +1198,17 @@ export function TerminalView({
   };
 
   const enqueueTerminalInput = (parts: string[]) => {
-    inputQueueRef.current.push(...parts.filter((part) => part.length > 0));
-    if (inputFlushTimerRef.current !== null) {
-      return;
+    if (terminalInputBlockedRef.current) {
+      showUploadStatus("Terminal detached", 2500);
+      return false;
     }
-    let retryCount = 0;
-    const flush = () => {
-      inputFlushTimerRef.current = null;
-      const socket = socketRef.current;
-      if (socket?.readyState !== WebSocket.OPEN) {
-        if (inputQueueRef.current.length > 0 && retryCount < 80) {
-          retryCount += 1;
-          inputFlushTimerRef.current = window.setTimeout(flush, 125);
-        }
-        return;
-      }
-      retryCount = 0;
-      const next = inputQueueRef.current.shift();
-      if (next !== undefined) {
-        sendTerminalInputFrame(socket, next);
-      }
-      if (inputQueueRef.current.length > 0) {
-        inputFlushTimerRef.current = window.setTimeout(flush, 35);
-      }
-    };
-    inputFlushTimerRef.current = window.setTimeout(flush, 0);
+    const filteredParts = parts.filter((part) => part.length > 0);
+    if (filteredParts.length === 0) {
+      return false;
+    }
+    inputQueueRef.current.push(...filteredParts);
+    flushQueuedTerminalInput();
+    return true;
   };
 
   return (
@@ -868,8 +1234,10 @@ export function TerminalView({
         onChange={handleFileInput}
       />
       {!pane ? <div className="terminal-overlay">No panes available</div> : null}
-      {pane && connectionState !== "attached" ? (
-        <div className="terminal-overlay">{connectionCopy(connectionState, closeReason)}</div>
+      {pane && showConnectionOverlay && connectionState !== "attached" ? (
+        <div className="terminal-overlay">
+          {terminalConnectionCopy(connectionState, closeReason, hasAttachedForTerminal)}
+        </div>
       ) : null}
       {uploadStatus ? (
         <div className="terminal-upload-status" role="status" aria-live="polite">
@@ -1224,43 +1592,6 @@ function terminalSocketUrl(
     coalesce_ms: String(coalesceMs),
   });
   return wsUrl("/ws/terminal", params);
-}
-
-function parseCloseReason(message: string) {
-  try {
-    const parsed = JSON.parse(message) as { type?: unknown; reason?: unknown };
-    return parsed.type === "closed" && typeof parsed.reason === "string" ? parsed.reason : null;
-  } catch {
-    return null;
-  }
-}
-
-function isNonRetryableAttachClose(reason: string | null) {
-  return (
-    reason?.includes("already has an attached client") ||
-    reason?.includes("terminal attach taken over") ||
-    reason?.includes("terminal attach failed: terminal")
-  );
-}
-
-function connectionCopy(state: ConnectionState, reason: string | null) {
-  if (reason?.includes("already has an attached client")) {
-    return "Attached elsewhere";
-  }
-  if (reason?.includes("terminal attach taken over")) {
-    return "Detached elsewhere";
-  }
-  switch (state) {
-    case "connecting":
-      return "Connecting";
-    case "closed":
-      return "Detached";
-    case "error":
-      return "Connection failed";
-    case "idle":
-    case "attached":
-      return "";
-  }
 }
 
 async function copyToClipboard(text: string) {

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -18,6 +18,7 @@ import {
   isNonRetryableTerminalClose,
   parseTerminalCloseReason,
   terminalConnectionCopy,
+  terminalConnectionOverlayDelayMs,
 } from "./terminalConnectionStatus";
 import type { TerminalConnectionState } from "./terminalConnectionStatus";
 import { findFirstUrlInSelection, openableHttpUrl } from "./terminalSelection";
@@ -36,7 +37,6 @@ import {
   TERMINAL_FOREGROUND_FAST_ATTEMPTS,
   TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS,
   TERMINAL_FOREGROUND_SIGNAL_COALESCE_MS,
-  TERMINAL_RECONNECT_OVERLAY_DELAY_MS,
   terminalReconnectPolicy,
 } from "./terminalReconnectPolicy";
 import type { TerminalReconnectMode } from "./terminalReconnectPolicy";
@@ -158,6 +158,8 @@ export function TerminalView({
   const uploadConflictRef = useRef<UploadConflictState | null>(null);
   const connectionKeyRef = useRef(connectionKey);
   const terminalIdRef = useRef(pane?.terminal_id ?? null);
+  const overlayTerminalIdRef = useRef(pane?.terminal_id ?? null);
+  const delayConnectingOverlayRef = useRef(false);
   const [connectionState, setConnectionState] = useState<TerminalConnectionState>("idle");
   const [closeReason, setCloseReason] = useState<string | null>(null);
   const [rendererReady, setRendererReady] = useState<TerminalRendererReady | null>(null);
@@ -430,6 +432,11 @@ export function TerminalView({
   useEffect(() => {
     const host = hostRef.current;
     const terminalId = pane?.terminal_id ?? null;
+    const previousOverlayTerminalId = overlayTerminalIdRef.current;
+    delayConnectingOverlayRef.current = Boolean(
+      terminalId && previousOverlayTerminalId && previousOverlayTerminalId !== terminalId,
+    );
+    overlayTerminalIdRef.current = terminalId;
     rendererReadyRef.current = null;
     setRendererReady(null);
     setHasAttachedForTerminal(false);
@@ -968,11 +975,15 @@ export function TerminalView({
       setShowConnectionOverlay(false);
       return;
     }
-    if (connectionState === "connecting" && hasAttachedForTerminal) {
+    const overlayDelayMs = terminalConnectionOverlayDelayMs(
+      connectionState,
+      hasAttachedForTerminal || delayConnectingOverlayRef.current,
+    );
+    if (overlayDelayMs > 0) {
       setShowConnectionOverlay(false);
       overlayTimer = window.setTimeout(() => {
         setShowConnectionOverlay(true);
-      }, TERMINAL_RECONNECT_OVERLAY_DELAY_MS);
+      }, overlayDelayMs);
       return () => {
         if (overlayTimer !== null) {
           window.clearTimeout(overlayTimer);

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -310,7 +310,10 @@ describe("capabilities", () => {
     await expect(probeBridgeBaseUrl("192.168.1.20:4000")).resolves.toEqual({
       commands: ["pane.move"],
     });
-    expect(fetchMock).toHaveBeenCalledWith("http://192.168.1.20:4000/api/capabilities");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://192.168.1.20:4000/api/capabilities",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
 
     fetchMock.mockRestore();
   });

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -10,6 +10,7 @@ import {
 import type { ReactNode } from "react";
 import { Capacitor } from "@capacitor/core";
 import { Preferences } from "@capacitor/preferences";
+import { fetchWithTimeout } from "./fetchWithTimeout";
 import { addNativeResumeHandler } from "./native";
 
 export const SAME_ORIGIN_BRIDGE_ID = "same-origin";
@@ -945,7 +946,7 @@ function normalizeEndpointPath(path: string) {
 export async function fetchCapabilities(
   httpUrl: (path: string, query?: URLSearchParams) => string,
 ): Promise<BridgeCapabilities> {
-  const response = await fetch(httpUrl("/api/capabilities"));
+  const response = await fetchWithTimeout(httpUrl("/api/capabilities"));
   if (!response.ok) {
     throw new Error(`capabilities failed: ${response.status}`);
   }

--- a/web/src/fetchWithTimeout.test.ts
+++ b/web/src/fetchWithTimeout.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithTimeout } from "./fetchWithTimeout";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("fetchWithTimeout", () => {
+  it("aborts a fetch after the timeout", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason);
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = fetchWithTimeout("/api/snapshot", { timeoutMs: 25 });
+    const rejection = expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("respects caller abort signals", async () => {
+    vi.useFakeTimers();
+    const callerController = new AbortController();
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason);
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = fetchWithTimeout("/api/snapshot", {
+      signal: callerController.signal,
+      timeoutMs: 5000,
+    });
+    const rejection = expect(pending).rejects.toBe("cancelled by caller");
+    callerController.abort("cancelled by caller");
+
+    await rejection;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/fetchWithTimeout.ts
+++ b/web/src/fetchWithTimeout.ts
@@ -1,0 +1,35 @@
+export const BRIDGE_FETCH_TIMEOUT_MS = 5000;
+
+export type FetchWithTimeoutInit = RequestInit & {
+  timeoutMs?: number;
+};
+
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  { timeoutMs = BRIDGE_FETCH_TIMEOUT_MS, signal, ...init }: FetchWithTimeoutInit = {},
+) {
+  const controller = new AbortController();
+  const abortFromCaller = () => {
+    controller.abort(signal?.reason);
+  };
+  if (signal?.aborted) {
+    abortFromCaller();
+  } else {
+    signal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
+  const timer = globalThis.setTimeout(() => {
+    controller.abort(abortError());
+  }, timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    globalThis.clearTimeout(timer);
+    signal?.removeEventListener("abort", abortFromCaller);
+  }
+}
+
+function abortError() {
+  return typeof DOMException === "function"
+    ? new DOMException("Bridge request timed out", "AbortError")
+    : undefined;
+}

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -87,6 +87,42 @@ describe("chooseSelectedPane", () => {
     expect(chooseSelectedPane(snapshot([pane("1-1"), pane("1-2", true)]), "1-1")).toBe("1-1");
   });
 
+  it("keeps the current pane while the snapshot selection catches up", () => {
+    expect(
+      chooseSelectedPane(
+        {
+          ...snapshot([pane("1-1"), pane("1-2", true)]),
+          selected_pane_id: "1-1",
+        },
+        "1-2",
+      ),
+    ).toBe("1-2");
+  });
+
+  it("uses the snapshot selection when there is no current pane", () => {
+    expect(
+      chooseSelectedPane(
+        {
+          ...snapshot([pane("1-1"), pane("1-2", true)]),
+          selected_pane_id: "1-1",
+        },
+        null,
+      ),
+    ).toBe("1-1");
+  });
+
+  it("uses the snapshot selection when the current pane is gone", () => {
+    expect(
+      chooseSelectedPane(
+        {
+          ...snapshot([pane("1-1"), pane("1-2", true)]),
+          selected_pane_id: "1-1",
+        },
+        "missing",
+      ),
+    ).toBe("1-1");
+  });
+
   it("falls back to the focused pane", () => {
     expect(chooseSelectedPane(snapshot([pane("1-1"), pane("1-2", true)]), "missing")).toBe(
       "1-2",

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -12,14 +12,14 @@ export function chooseSelectedPane(snapshot: Snapshot | null, currentPaneId: str
   if (!snapshot || snapshot.panes.length === 0) {
     return null;
   }
+  if (currentPaneId && snapshot.panes.some((pane) => pane.pane_id === currentPaneId)) {
+    return currentPaneId;
+  }
   if (
     snapshot.selected_pane_id &&
     snapshot.panes.some((pane) => pane.pane_id === snapshot.selected_pane_id)
   ) {
     return snapshot.selected_pane_id;
-  }
-  if (currentPaneId && snapshot.panes.some((pane) => pane.pane_id === currentPaneId)) {
-    return currentPaneId;
   }
   return snapshot.panes.find((pane) => pane.focused)?.pane_id ?? snapshot.panes[0].pane_id;
 }

--- a/web/src/terminalConnectionStatus.test.ts
+++ b/web/src/terminalConnectionStatus.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  isNonRetryableTerminalClose,
+  parseTerminalCloseReason,
+  terminalConnectionCopy,
+} from "./terminalConnectionStatus";
+
+describe("terminalConnectionStatus", () => {
+  it("parses terminal close reason messages", () => {
+    expect(
+      parseTerminalCloseReason(
+        JSON.stringify({ type: "closed", reason: "terminal attach taken over" }),
+      ),
+    ).toBe("terminal attach taken over");
+    expect(
+      parseTerminalCloseReason(JSON.stringify({ type: "notice", reason: "ignored" })),
+    ).toBeNull();
+    expect(parseTerminalCloseReason("not json")).toBeNull();
+  });
+
+  it("classifies non-retryable terminal attach close reasons", () => {
+    expect(isNonRetryableTerminalClose("terminal already has an attached client")).toBe(true);
+    expect(isNonRetryableTerminalClose("terminal attach taken over")).toBe(true);
+    expect(isNonRetryableTerminalClose("terminal attach failed: terminal abc missing")).toBe(true);
+    expect(isNonRetryableTerminalClose("temporary network close")).toBe(false);
+    expect(isNonRetryableTerminalClose(null)).toBe(false);
+  });
+
+  it("maps terminal connection states to status copy", () => {
+    expect(terminalConnectionCopy("connecting", null)).toBe("Connecting");
+    expect(terminalConnectionCopy("connecting", null, true)).toBe("Reconnecting");
+    expect(terminalConnectionCopy("closed", "terminal already has an attached client")).toBe(
+      "Attached elsewhere",
+    );
+    expect(terminalConnectionCopy("closed", "terminal attach taken over")).toBe(
+      "Detached elsewhere",
+    );
+    expect(terminalConnectionCopy("error", null)).toBe("Connection failed");
+  });
+});

--- a/web/src/terminalConnectionStatus.test.ts
+++ b/web/src/terminalConnectionStatus.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  TERMINAL_CONNECTION_OVERLAY_DELAY_MS,
   isNonRetryableTerminalClose,
   parseTerminalCloseReason,
   terminalConnectionCopy,
+  terminalConnectionOverlayDelayMs,
 } from "./terminalConnectionStatus";
 
 describe("terminalConnectionStatus", () => {
@@ -36,5 +38,16 @@ describe("terminalConnectionStatus", () => {
       "Detached elsewhere",
     );
     expect(terminalConnectionCopy("error", null)).toBe("Connection failed");
+  });
+
+  it("delays only transient connecting overlays", () => {
+    expect(terminalConnectionOverlayDelayMs("connecting", true)).toBe(
+      TERMINAL_CONNECTION_OVERLAY_DELAY_MS,
+    );
+    expect(terminalConnectionOverlayDelayMs("connecting", false)).toBe(0);
+    expect(terminalConnectionOverlayDelayMs("closed", true)).toBe(0);
+    expect(terminalConnectionOverlayDelayMs("error", true)).toBe(0);
+    expect(terminalConnectionOverlayDelayMs("attached", true)).toBe(0);
+    expect(terminalConnectionOverlayDelayMs("idle", true)).toBe(0);
   });
 });

--- a/web/src/terminalConnectionStatus.ts
+++ b/web/src/terminalConnectionStatus.ts
@@ -1,0 +1,43 @@
+export type TerminalConnectionState = "idle" | "connecting" | "attached" | "closed" | "error";
+
+export function parseTerminalCloseReason(message: string) {
+  try {
+    const parsed = JSON.parse(message) as { type?: unknown; reason?: unknown };
+    return parsed.type === "closed" && typeof parsed.reason === "string" ? parsed.reason : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isNonRetryableTerminalClose(reason: string | null) {
+  return (
+    reason !== null &&
+    (reason.includes("already has an attached client") ||
+      reason.includes("terminal attach taken over") ||
+      reason.includes("terminal attach failed: terminal"))
+  );
+}
+
+export function terminalConnectionCopy(
+  state: TerminalConnectionState,
+  reason: string | null,
+  hasAttachedForTerminal = false,
+) {
+  if (reason?.includes("already has an attached client")) {
+    return "Attached elsewhere";
+  }
+  if (reason?.includes("terminal attach taken over")) {
+    return "Detached elsewhere";
+  }
+  switch (state) {
+    case "connecting":
+      return hasAttachedForTerminal ? "Reconnecting" : "Connecting";
+    case "closed":
+      return "Detached";
+    case "error":
+      return "Connection failed";
+    case "idle":
+    case "attached":
+      return "";
+  }
+}

--- a/web/src/terminalConnectionStatus.ts
+++ b/web/src/terminalConnectionStatus.ts
@@ -1,5 +1,7 @@
 export type TerminalConnectionState = "idle" | "connecting" | "attached" | "closed" | "error";
 
+export const TERMINAL_CONNECTION_OVERLAY_DELAY_MS = 500;
+
 export function parseTerminalCloseReason(message: string) {
   try {
     const parsed = JSON.parse(message) as { type?: unknown; reason?: unknown };
@@ -40,4 +42,11 @@ export function terminalConnectionCopy(
     case "attached":
       return "";
   }
+}
+
+export function terminalConnectionOverlayDelayMs(
+  state: TerminalConnectionState,
+  delayConnecting: boolean,
+) {
+  return state === "connecting" && delayConnecting ? TERMINAL_CONNECTION_OVERLAY_DELAY_MS : 0;
 }

--- a/web/src/terminalReconnectPolicy.test.ts
+++ b/web/src/terminalReconnectPolicy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  TERMINAL_CONNECT_TIMEOUT_MS,
+  TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS,
+  TERMINAL_RECONNECT_BASE_DELAY_MS,
+  TERMINAL_RECONNECT_MAX_DELAY_MS,
+  terminalReconnectPolicy,
+} from "./terminalReconnectPolicy";
+
+describe("terminalReconnectPolicy", () => {
+  it("connects immediately without advancing normal backoff attempts", () => {
+    expect(
+      terminalReconnectPolicy({
+        attempt: 0,
+        mode: "normal",
+        immediate: true,
+        foregroundFastAttemptsRemaining: 0,
+      }),
+    ).toEqual({
+      delayMs: 0,
+      connectTimeoutMs: TERMINAL_CONNECT_TIMEOUT_MS,
+      nextAttempt: 0,
+      nextForegroundFastAttemptsRemaining: 0,
+    });
+  });
+
+  it("uses capped exponential delay for normal reconnects", () => {
+    expect(
+      terminalReconnectPolicy({
+        attempt: 0,
+        mode: "normal",
+        immediate: false,
+        foregroundFastAttemptsRemaining: 0,
+      }).delayMs,
+    ).toBe(500);
+    expect(
+      terminalReconnectPolicy({
+        attempt: 4,
+        mode: "normal",
+        immediate: false,
+        foregroundFastAttemptsRemaining: 0,
+      }).delayMs,
+    ).toBe(TERMINAL_RECONNECT_MAX_DELAY_MS);
+  });
+
+  it("keeps the foreground fast-attempt transition in the pure policy", () => {
+    const first = terminalReconnectPolicy({
+      attempt: 0,
+      mode: "foreground",
+      immediate: true,
+      foregroundFastAttemptsRemaining: 2,
+    });
+    expect(first.connectTimeoutMs).toBe(TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS);
+    expect(first.nextForegroundFastAttemptsRemaining).toBe(1);
+
+    const second = terminalReconnectPolicy({
+      attempt: first.nextAttempt,
+      mode: "foreground",
+      immediate: false,
+      foregroundFastAttemptsRemaining: first.nextForegroundFastAttemptsRemaining,
+    });
+    expect(second.delayMs).toBe(TERMINAL_RECONNECT_BASE_DELAY_MS);
+    expect(second.connectTimeoutMs).toBe(TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS);
+    expect(second.nextForegroundFastAttemptsRemaining).toBe(0);
+
+    const third = terminalReconnectPolicy({
+      attempt: second.nextAttempt,
+      mode: "foreground",
+      immediate: false,
+      foregroundFastAttemptsRemaining: second.nextForegroundFastAttemptsRemaining,
+    });
+    expect(third.connectTimeoutMs).toBe(TERMINAL_CONNECT_TIMEOUT_MS);
+    expect(third.nextForegroundFastAttemptsRemaining).toBe(0);
+  });
+});

--- a/web/src/terminalReconnectPolicy.ts
+++ b/web/src/terminalReconnectPolicy.ts
@@ -1,0 +1,44 @@
+export type TerminalReconnectMode = "normal" | "foreground";
+
+export type TerminalReconnectPolicyInput = {
+  attempt: number;
+  mode: TerminalReconnectMode;
+  immediate: boolean;
+  foregroundFastAttemptsRemaining: number;
+};
+
+export type TerminalReconnectPolicy = {
+  delayMs: number;
+  connectTimeoutMs: number;
+  nextAttempt: number;
+  nextForegroundFastAttemptsRemaining: number;
+};
+
+export const TERMINAL_RECONNECT_BASE_DELAY_MS = 500;
+export const TERMINAL_RECONNECT_MAX_DELAY_MS = 5000;
+export const TERMINAL_CONNECT_TIMEOUT_MS = 3500;
+export const TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS = 1200;
+export const TERMINAL_FOREGROUND_FAST_ATTEMPTS = 2;
+export const TERMINAL_FOREGROUND_SIGNAL_COALESCE_MS = 400;
+export const TERMINAL_RECONNECT_OVERLAY_DELAY_MS = 300;
+
+export function terminalReconnectPolicy({
+  attempt,
+  mode,
+  immediate,
+  foregroundFastAttemptsRemaining,
+}: TerminalReconnectPolicyInput): TerminalReconnectPolicy {
+  const foregroundFastAttempt = mode === "foreground" && foregroundFastAttemptsRemaining > 0;
+  return {
+    delayMs: immediate
+      ? 0
+      : Math.min(TERMINAL_RECONNECT_BASE_DELAY_MS * 2 ** attempt, TERMINAL_RECONNECT_MAX_DELAY_MS),
+    connectTimeoutMs: foregroundFastAttempt
+      ? TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS
+      : TERMINAL_CONNECT_TIMEOUT_MS,
+    nextAttempt: immediate ? attempt : attempt + 1,
+    nextForegroundFastAttemptsRemaining: foregroundFastAttempt
+      ? foregroundFastAttemptsRemaining - 1
+      : foregroundFastAttemptsRemaining,
+  };
+}

--- a/web/src/terminalReconnectPolicy.ts
+++ b/web/src/terminalReconnectPolicy.ts
@@ -20,7 +20,6 @@ export const TERMINAL_CONNECT_TIMEOUT_MS = 3500;
 export const TERMINAL_FOREGROUND_CONNECT_TIMEOUT_MS = 1200;
 export const TERMINAL_FOREGROUND_FAST_ATTEMPTS = 2;
 export const TERMINAL_FOREGROUND_SIGNAL_COALESCE_MS = 400;
-export const TERMINAL_RECONNECT_OVERLAY_DELAY_MS = 300;
 
 export function terminalReconnectPolicy({
   attempt,


### PR DESCRIPTION
## Summary
- Keep the terminal renderer mounted across same-terminal reconnect/resume paths while reconnecting transport independently
- Add foreground resume/visibility reconnect coalescing, fetch timeouts, and delayed transient connecting overlays
- Prevent stale snapshot selection from briefly reverting the top tab area during terminal switches

## Verification
- npm run test:web -- terminalConnectionStatus.test.ts terminalReconnectPolicy.test.ts state.test.ts App.test.ts
- npm run lint:web
- npm run android:build:debug with ANDROID_HOME=/home/kevin/.local/android-sdk
- Local herdr-web.service restarted
- Debug APK transferred to srv downloads: herdr-web-terminal-reconnect-lifecycle-debug.apk
- Keel Claude xhigh follow-up review finished clean with no remaining findings
