### PR TITLE
Add pane notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
   by default. [PR #21](https://github.com/kcosr/herdr-web/pull/21)
 - Fixed notes editor selection and autosave edge cases so switching to panes without notes clears
   the editor, deleting the selected note no longer shows a deleted note, and stale local save
-  refreshes do not appear as external note changes.
+  refreshes do not appear as external note changes. Also fixed mobile delete-dialog back handling
+  and unresolved note recovery actions in the notes panel.
 - Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
   keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.
   [PR #19](https://github.com/kcosr/herdr-web/pull/19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   the editor, deleting the selected note no longer shows a deleted note, and stale local save
   refreshes do not appear as external note changes. Also fixed mobile delete-dialog back handling
   and unresolved note recovery actions in the notes panel.
+- Kept the new-tab button pinned at the right edge of the top tab bar while the tab list scrolls.
 - Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
   keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.
   [PR #19](https://github.com/kcosr/herdr-web/pull/19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@
 - Added bridge-owned pane notes with a sidebar Notes view, desktop/mobile notes editor, pane
   attachment recovery states, and per-bridge note synchronization. Notes are exposed through the
   same bridge request policy as terminal controls, so allowed bridge clients can read and mutate
-  saved note content.
+  saved note content. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
 - Added a Notes feature toggle plus persisted desktop notes panel sizing, notes list collapse
   state, notes panel open state, pane note tabs, and a dedicated Other notes list.
+  [PR #20](https://github.com/kcosr/herdr-web/pull/20)
+- Added a Markdown preview mode for notes that remembers Edit/Preview preference locally and keeps
+  the Markdown renderer lazy-loaded until preview is used. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
 
 ### Changed
 
@@ -23,12 +26,13 @@
 - Fixed notes editor selection and autosave edge cases so switching to panes without notes clears
   the editor, deleting the selected note no longer shows a deleted note, and stale local save
   refreshes do not appear as external note changes. Also fixed mobile delete-dialog back handling
-  and unresolved note recovery actions in the notes panel.
+  and unresolved note recovery actions in the notes panel. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
 - On mobile, kept the note editor's terminal action available for the current pane and made it
-  close the full-screen notes surface.
+  close the full-screen notes surface. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
 - Changed mobile notes back navigation so back closes the notes surface from the editor, while a
-  separate header button shows the notes list.
+  separate header button shows the notes list. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
 - Kept the new-tab button pinned at the right edge of the top tab bar while the tab list scrolls.
+  [PR #20](https://github.com/kcosr/herdr-web/pull/20)
 - Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
   keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.
   [PR #19](https://github.com/kcosr/herdr-web/pull/19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- Added bridge-owned pane notes with a sidebar Notes view, desktop/mobile notes editor, pane
+  attachment recovery states, and per-bridge note synchronization.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   and unresolved note recovery actions in the notes panel.
 - On mobile, kept the note editor's terminal action available for the current pane and made it
   close the full-screen notes surface.
+- Changed mobile notes back navigation so back closes the notes surface from the editor, while a
+  separate header button shows the notes list.
 - Kept the new-tab button pinned at the right edge of the top tab bar while the tab list scrolls.
 - Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
   keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   the editor, deleting the selected note no longer shows a deleted note, and stale local save
   refreshes do not appear as external note changes. Also fixed mobile delete-dialog back handling
   and unresolved note recovery actions in the notes panel.
+- On mobile, kept the note editor's terminal action available for the current pane and made it
+  close the full-screen notes surface.
 - Kept the new-tab button pinned at the right edge of the top tab bar while the tab list scrolls.
 - Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
   keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 ### Added
 
 - Added bridge-owned pane notes with a sidebar Notes view, desktop/mobile notes editor, pane
-  attachment recovery states, and per-bridge note synchronization.
+  attachment recovery states, and per-bridge note synchronization. Notes are exposed through the
+  same bridge request policy as terminal controls, so allowed bridge clients can read and mutate
+  saved note content.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   same bridge request policy as terminal controls, so allowed bridge clients can read and mutate
   saved note content.
 - Added a Notes feature toggle plus persisted desktop notes panel sizing, notes list collapse
-  state, pane note tabs, and a dedicated Other notes list.
+  state, notes panel open state, pane note tabs, and a dedicated Other notes list.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   attachment recovery states, and per-bridge note synchronization. Notes are exposed through the
   same bridge request policy as terminal controls, so allowed bridge clients can read and mutate
   saved note content.
+- Added a Notes feature toggle plus persisted desktop notes panel sizing, notes list collapse
+  state, pane note tabs, and a dedicated Other notes list.
 
 ### Changed
 
@@ -18,6 +20,9 @@
 - Added Mobile settings for an expanding terminal command input and Enter-as-newline
   editing, allowing long prompts to wrap and remain viewable while preserving send-on-Enter
   by default. [PR #21](https://github.com/kcosr/herdr-web/pull/21)
+- Fixed notes editor selection and autosave edge cases so switching to panes without notes clears
+  the editor, deleting the selected note no longer shows a deleted note, and stale local save
+  refreshes do not appear as external note changes.
 - Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
   keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.
   [PR #19](https://github.com/kcosr/herdr-web/pull/19)

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ The bridge exposes:
 - `GET /api/snapshot`: workspaces, tabs, panes, layouts, and shared web selection
 - `POST /api/command`: allow-listed workspace/tab/pane commands
 - `POST /api/selection`: bridge-owned selected pane for syncing browser clients
+- `GET /api/notes` and `POST /api/notes...`: bridge-owned pane notes
 - `POST /api/uploads`: save uploaded files into the configured upload directory
 - `GET /ws/activity`: bridge-owned pane activity deltas
 - `GET /ws/events`: Herdr structural events
@@ -273,6 +274,10 @@ must also be same-origin with the bridge, an explicitly allowed origin such as A
 `http://localhost`, or a loopback development proxy origin allowed for Vite. Hostname backends must
 be explicitly allowed with `--allow-host HOSTNAME`. This is a DNS-rebinding/CSRF guard, not user
 authentication.
+
+Bridge-owned notes are part of that same request policy. Any allowed bridge client can read and
+mutate saved note content, including clients connecting over a trusted LAN when the bridge is bound
+to a non-loopback interface. Do not store sensitive notes on a bridge exposed to untrusted networks.
 
 Bridge-served pages also send a Content Security Policy. By default, `connect-src` allows only the
 serving bridge origin and `data:`. Use `--allow-connect-origin ORIGIN` on the serving bridge when

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -1,3 +1,4 @@
+mod notes;
 mod session;
 mod web_bridge;
 mod workspace;

--- a/bridge/src/notes.rs
+++ b/bridge/src/notes.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, ErrorKind};
+use std::io::{self, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -609,7 +609,13 @@ impl NotesManager {
 
     fn load_or_create_notes_store(&self) -> Result<NotesStore, NotesError> {
         match fs::read(&self.notes_path) {
-            Ok(bytes) => parse_notes_store(&bytes),
+            Ok(bytes) => match parse_notes_store(&bytes) {
+                Ok(store) => Ok(store),
+                Err(err) => {
+                    copy_corrupt_once(&self.notes_path);
+                    Err(err)
+                }
+            },
             Err(err) if err.kind() == ErrorKind::NotFound => {
                 let now = now_ms_string();
                 Ok(NotesStore {
@@ -953,11 +959,22 @@ fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<(), NotesEr
     let temp_path = path.with_extension(format!("{}.tmp", std::process::id()));
     let bytes = serde_json::to_vec_pretty(value)
         .map_err(|err| NotesError::Store(format!("failed to serialize notes: {err}")))?;
-    fs::write(&temp_path, bytes)?;
+    let mut file = File::create(&temp_path)?;
     set_private_file_permissions(&temp_path)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    drop(file);
     backup_existing_file(path);
     fs::rename(&temp_path, path)?;
     set_private_file_permissions(path)?;
+    sync_parent_dir(path)?;
+    Ok(())
+}
+
+fn sync_parent_dir(path: &Path) -> Result<(), NotesError> {
+    if let Some(parent) = path.parent() {
+        File::open(parent)?.sync_all()?;
+    }
     Ok(())
 }
 
@@ -1324,6 +1341,19 @@ mod tests {
         assert_eq!(corrupt_copy_count(&dir), 0);
         manager.observe_panes(&panes).unwrap();
         manager.observe_panes(&panes).unwrap();
+        assert_eq!(corrupt_copy_count(&dir), 1);
+    }
+
+    #[test]
+    fn corrupt_notes_store_is_copied_once_for_recovery() {
+        let dir = test_dir("corrupt_notes_store_is_copied_once_for_recovery");
+        let manager = NotesManager::for_test(dir.clone(), "session:default").unwrap();
+        fs::write(&manager.notes_path, b"not json").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+
+        assert!(manager.list(NotesListQuery::default(), &panes).is_err());
+        assert!(manager.list(NotesListQuery::default(), &panes).is_err());
+
         assert_eq!(corrupt_copy_count(&dir), 1);
     }
 

--- a/bridge/src/notes.rs
+++ b/bridge/src/notes.rs
@@ -474,7 +474,7 @@ impl NotesManager {
         moved_pane: &PaneInfo,
     ) -> Result<bool, NotesError> {
         let attachment = self.capture_attachment_for_pane(moved_pane);
-        let changed = self.with_notes_store(|store, now| {
+        let changed = self.with_notes_store_if_changed(|store, now| {
             let mut changed = false;
             for note in store
                 .notes
@@ -493,7 +493,7 @@ impl NotesManager {
                     changed = true;
                 }
             }
-            Ok(changed)
+            Ok((changed, changed))
         })?;
         Ok(changed)
     }
@@ -588,6 +588,20 @@ impl NotesManager {
         let result = mutate(&mut store, now_ms_string())?;
         store.updated_at = now_ms_string();
         write_json_atomic(&self.notes_path, &store)?;
+        Ok(result)
+    }
+
+    fn with_notes_store_if_changed<F, T>(&self, mutate: F) -> Result<T, NotesError>
+    where
+        F: FnOnce(&mut NotesStore, String) -> Result<(T, bool), NotesError>,
+    {
+        let _lock = LockFile::exclusive(&self.notes_lock_path)?;
+        let mut store = self.load_or_create_notes_store()?;
+        let (result, changed) = mutate(&mut store, now_ms_string())?;
+        if changed {
+            store.updated_at = now_ms_string();
+            write_json_atomic(&self.notes_path, &store)?;
+        }
         Ok(result)
     }
 
@@ -1239,6 +1253,72 @@ mod tests {
     }
 
     #[test]
+    fn detach_delete_and_restore_preserve_recovery_state() {
+        let dir = test_dir("detach_delete_and_restore_preserve_recovery_state");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+        let note = manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Recoverable".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &panes,
+            )
+            .unwrap();
+
+        let detached = manager
+            .detach(
+                &note.note.note_id,
+                RevisionRequest {
+                    expected_revision: note.note.revision,
+                },
+                &panes,
+            )
+            .unwrap();
+        assert_eq!(detached.link_state, NoteLinkState::Detached);
+        assert!(detached.note.attachment.is_none());
+        assert_eq!(detached.note.attachment_history.len(), 1);
+
+        let deleted = manager
+            .delete(
+                &detached.note.note_id,
+                RevisionRequest {
+                    expected_revision: detached.note.revision,
+                },
+                &panes,
+            )
+            .unwrap();
+        assert!(deleted.note.deleted_at.is_some());
+        assert!(manager
+            .list(NotesListQuery::default(), &panes)
+            .unwrap()
+            .notes
+            .is_empty());
+
+        let restored = manager
+            .restore(
+                &deleted.note.note_id,
+                RevisionRequest {
+                    expected_revision: deleted.note.revision,
+                },
+                &panes,
+            )
+            .unwrap();
+        assert!(restored.note.deleted_at.is_none());
+        assert_eq!(restored.link_state, NoteLinkState::Detached);
+        assert_eq!(
+            manager
+                .list(NotesListQuery::default(), &panes)
+                .unwrap()
+                .notes
+                .len(),
+            1
+        );
+    }
+
+    #[test]
     fn move_updates_attachment_and_stays_linked() {
         let dir = test_dir("move_updates_attachment_and_stays_linked");
         let manager = NotesManager::for_test(dir, "session:default").unwrap();
@@ -1263,6 +1343,31 @@ mod tests {
             listed.notes[0].note.attachment.as_ref().unwrap().pane_id,
             "p2"
         );
+    }
+
+    #[test]
+    fn no_op_pane_move_does_not_rewrite_notes_store() {
+        let dir = test_dir("no_op_pane_move_does_not_rewrite_notes_store");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+        manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Plan".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &panes,
+            )
+            .unwrap();
+        let before = fs::read_to_string(&manager.notes_path).unwrap();
+
+        let changed = manager
+            .update_for_pane_move("missing-pane", &pane("p2", "t2", "w2", "tab2", 2))
+            .unwrap();
+
+        assert!(!changed);
+        assert_eq!(fs::read_to_string(&manager.notes_path).unwrap(), before);
     }
 
     #[test]

--- a/bridge/src/notes.rs
+++ b/bridge/src/notes.rs
@@ -1,0 +1,1376 @@
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use herdr_compat::api::schema::PaneInfo;
+use serde::{Deserialize, Serialize};
+
+const NOTES_STORE_VERSION: u32 = 1;
+const OBSERVATION_STORE_VERSION: u32 = 1;
+const MAX_TITLE_CHARS: usize = 200;
+const MAX_BODY_BYTES: usize = 256 * 1024;
+const MAX_ATTACHMENT_HISTORY: usize = 20;
+const MAX_OBSERVATIONS_PER_SESSION: usize = 5_000;
+const MISSING_OBSERVATION_RETENTION_MS: u128 = 30 * 24 * 60 * 60 * 1000;
+
+#[derive(Clone)]
+pub struct NotesManager {
+    notes_path: PathBuf,
+    notes_lock_path: PathBuf,
+    observations_path: PathBuf,
+    observations_lock_path: PathBuf,
+    session_key: String,
+}
+
+#[derive(Debug)]
+pub enum NotesError {
+    BadRequest(String),
+    Conflict(String),
+    Io(io::Error),
+    Store(String),
+}
+
+impl std::fmt::Display for NotesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadRequest(message) => write!(f, "{message}"),
+            Self::Conflict(message) => write!(f, "{message}"),
+            Self::Io(err) => write!(f, "{err}"),
+            Self::Store(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl From<io::Error> for NotesError {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotesListResponse {
+    pub store_id: String,
+    pub session_key: String,
+    pub notes: Vec<NoteResponse>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct NotesListQuery {
+    #[serde(default)]
+    pub include_archived: bool,
+    #[serde(default)]
+    pub include_deleted: bool,
+    #[serde(default)]
+    pub include_other_sessions: bool,
+    pub pane_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateNoteRequest {
+    pub title: Option<String>,
+    pub body: Option<String>,
+    pub pane_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UpdateNoteRequest {
+    pub title: Option<String>,
+    pub body: Option<String>,
+    pub expected_revision: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AttachNoteRequest {
+    pub pane_id: String,
+    pub expected_revision: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RevisionRequest {
+    pub expected_revision: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NotesStore {
+    version: u32,
+    store_id: String,
+    next_note_number: u64,
+    created_at: String,
+    updated_at: String,
+    notes: Vec<NoteRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ObservationStore {
+    version: u32,
+    next_generation_number: u64,
+    observations: Vec<PaneObservation>,
+}
+
+struct LoadedObservationStore {
+    store: ObservationStore,
+    recovered: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NoteRecord {
+    pub note_id: String,
+    pub title: String,
+    pub body: String,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+    pub session_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attachment: Option<NoteAttachment>,
+    #[serde(default)]
+    pub attachment_history: Vec<NoteAttachment>,
+    pub revision: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NoteAttachment {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub pane_id: String,
+    pub workspace_id: String,
+    pub tab_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_revision: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<String>,
+    pub captured_at: String,
+    pub context: NotePaneContext,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NotePaneContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreground_cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NoteResponse {
+    #[serde(flatten)]
+    pub note: NoteRecord,
+    pub link_state: NoteLinkState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_pane: Option<PaneInfo>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NoteLinkState {
+    Linked,
+    Unresolved,
+    Detached,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PaneObservation {
+    session_key: String,
+    pane_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    terminal_id: Option<String>,
+    workspace_id: String,
+    tab_id: String,
+    observed_generation: String,
+    generation_confidence: GenerationConfidence,
+    first_seen_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    missing_since: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum GenerationConfidence {
+    Known,
+    RecoveredUnknown,
+}
+
+impl NotesManager {
+    pub fn new() -> io::Result<Self> {
+        let notes_dir = default_notes_dir();
+        ensure_private_dir(&notes_dir)?;
+        Ok(Self {
+            notes_path: notes_dir.join("notes.json"),
+            notes_lock_path: notes_dir.join("notes.lock"),
+            observations_path: notes_dir.join("pane-observations.json"),
+            observations_lock_path: notes_dir.join("pane-observations.lock"),
+            session_key: session_key(),
+        })
+    }
+
+    #[cfg(test)]
+    fn for_test(dir: PathBuf, session_key: &str) -> io::Result<Self> {
+        ensure_private_dir(&dir)?;
+        Ok(Self {
+            notes_path: dir.join("notes.json"),
+            notes_lock_path: dir.join("notes.lock"),
+            observations_path: dir.join("pane-observations.json"),
+            observations_lock_path: dir.join("pane-observations.lock"),
+            session_key: session_key.to_string(),
+        })
+    }
+
+    pub fn list(
+        &self,
+        query: NotesListQuery,
+        panes: &[PaneInfo],
+    ) -> Result<NotesListResponse, NotesError> {
+        let _lock = LockFile::exclusive(&self.notes_lock_path)?;
+        let store = self.load_or_create_notes_store()?;
+        let observations = self.load_observation_store_best_effort().observations;
+        let pane_filter = query
+            .pane_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|pane_id| !pane_id.is_empty());
+        let pane_filter_exists =
+            pane_filter.is_none_or(|pane_id| panes.iter().any(|pane| pane.pane_id == pane_id));
+        let notes = if !pane_filter_exists {
+            Vec::new()
+        } else {
+            store
+                .notes
+                .into_iter()
+                .filter(|note| query.include_other_sessions || note.session_key == self.session_key)
+                .filter(|note| query.include_archived || note.archived_at.is_none())
+                .filter(|note| query.include_deleted || note.deleted_at.is_none())
+                .filter(|note| {
+                    pane_filter.is_none_or(|pane_id| {
+                        note.session_key == self.session_key
+                            && note
+                                .attachment
+                                .as_ref()
+                                .is_some_and(|attachment| attachment.pane_id == pane_id)
+                    })
+                })
+                .map(|note| note_response(note, panes, &observations, &self.session_key))
+                .collect()
+        };
+        Ok(NotesListResponse {
+            store_id: store.store_id,
+            session_key: self.session_key.clone(),
+            notes,
+        })
+    }
+
+    pub fn create(
+        &self,
+        request: CreateNoteRequest,
+        panes: &[PaneInfo],
+    ) -> Result<NoteResponse, NotesError> {
+        let attachment = match request
+            .pane_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|pane| !pane.is_empty())
+        {
+            Some(pane_id) => Some(self.capture_attachment_for_pane_id(pane_id, panes)?),
+            None => None,
+        };
+        let title = normalize_title(request.title.as_deref(), request.body.as_deref())?;
+        let body = normalize_body(request.body.as_deref())?;
+        self.with_notes_store(|store, now| {
+            let note_id = format!("note_{}", store.next_note_number);
+            store.next_note_number += 1;
+            let note = NoteRecord {
+                note_id,
+                title,
+                body,
+                created_at: now.clone(),
+                updated_at: now,
+                archived_at: None,
+                deleted_at: None,
+                session_key: self.session_key.clone(),
+                attachment,
+                attachment_history: Vec::new(),
+                revision: 1,
+            };
+            store.notes.push(note.clone());
+            Ok(note)
+        })
+        .map(|note| {
+            let observations = self.load_observation_store_best_effort().observations;
+            note_response(note, panes, &observations, &self.session_key)
+        })
+    }
+
+    pub fn update(
+        &self,
+        note_id: &str,
+        request: UpdateNoteRequest,
+        panes: &[PaneInfo],
+    ) -> Result<NoteResponse, NotesError> {
+        let title = match request.title {
+            Some(title) => Some(normalize_title(Some(&title), None)?),
+            None => None,
+        };
+        let body = match request.body {
+            Some(body) => Some(normalize_body(Some(&body))?),
+            None => None,
+        };
+        self.with_note_mutation(note_id, request.expected_revision, |note, now| {
+            if let Some(title) = title {
+                note.title = title;
+            }
+            if let Some(body) = body {
+                note.body = body;
+            }
+            note.updated_at = now;
+            note.revision += 1;
+        })
+        .map(|note| {
+            let observations = self.load_observation_store_best_effort().observations;
+            note_response(note, panes, &observations, &self.session_key)
+        })
+    }
+
+    pub fn attach(
+        &self,
+        note_id: &str,
+        request: AttachNoteRequest,
+        panes: &[PaneInfo],
+    ) -> Result<NoteResponse, NotesError> {
+        let attachment = self.capture_attachment_for_pane_id(request.pane_id.trim(), panes)?;
+        self.with_note_mutation(note_id, request.expected_revision, |note, now| {
+            push_attachment_history(note, now.clone());
+            note.attachment = Some(attachment);
+            note.updated_at = now;
+            note.revision += 1;
+        })
+        .map(|note| {
+            let observations = self.load_observation_store_best_effort().observations;
+            note_response(note, panes, &observations, &self.session_key)
+        })
+    }
+
+    pub fn detach(
+        &self,
+        note_id: &str,
+        request: RevisionRequest,
+        panes: &[PaneInfo],
+    ) -> Result<NoteResponse, NotesError> {
+        self.with_note_mutation(note_id, request.expected_revision, |note, now| {
+            push_attachment_history(note, now.clone());
+            note.attachment = None;
+            note.updated_at = now;
+            note.revision += 1;
+        })
+        .map(|note| {
+            let observations = self.load_observation_store_best_effort().observations;
+            note_response(note, panes, &observations, &self.session_key)
+        })
+    }
+
+    pub fn archive(
+        &self,
+        note_id: &str,
+        request: RevisionRequest,
+        panes: &[PaneInfo],
+    ) -> Result<NoteResponse, NotesError> {
+        self.with_note_mutation(note_id, request.expected_revision, |note, now| {
+            note.archived_at = Some(now.clone());
+            note.updated_at = now;
+            note.revision += 1;
+        })
+        .map(|note| {
+            let observations = self.load_observation_store_best_effort().observations;
+            note_response(note, panes, &observations, &self.session_key)
+        })
+    }
+
+    pub fn restore(
+        &self,
+        note_id: &str,
+        request: RevisionRequest,
+        panes: &[PaneInfo],
+    ) -> Result<NoteResponse, NotesError> {
+        self.with_note_mutation(note_id, request.expected_revision, |note, now| {
+            note.archived_at = None;
+            note.deleted_at = None;
+            note.updated_at = now;
+            note.revision += 1;
+        })
+        .map(|note| {
+            let observations = self.load_observation_store_best_effort().observations;
+            note_response(note, panes, &observations, &self.session_key)
+        })
+    }
+
+    pub fn delete(
+        &self,
+        note_id: &str,
+        request: RevisionRequest,
+        panes: &[PaneInfo],
+    ) -> Result<NoteResponse, NotesError> {
+        self.with_note_mutation(note_id, request.expected_revision, |note, now| {
+            note.deleted_at = Some(now.clone());
+            note.updated_at = now;
+            note.revision += 1;
+        })
+        .map(|note| {
+            let observations = self.load_observation_store_best_effort().observations;
+            note_response(note, panes, &observations, &self.session_key)
+        })
+    }
+
+    pub fn observe_panes(&self, panes: &[PaneInfo]) -> Result<bool, NotesError> {
+        let observed_ids: HashSet<&str> = panes.iter().map(|pane| pane.pane_id.as_str()).collect();
+        self.with_observation_store(|store, now, recovered| {
+            let mut changed = false;
+            let new_confidence = if recovered {
+                GenerationConfidence::RecoveredUnknown
+            } else {
+                GenerationConfidence::Known
+            };
+            for pane in panes {
+                changed |= ensure_observation_for_pane(
+                    store,
+                    &self.session_key,
+                    pane,
+                    &now,
+                    new_confidence,
+                );
+            }
+            for observation in store
+                .observations
+                .iter_mut()
+                .filter(|item| item.session_key == self.session_key)
+            {
+                if !observed_ids.contains(observation.pane_id.as_str())
+                    && observation.missing_since.is_none()
+                {
+                    observation.missing_since = Some(now.clone());
+                    changed = true;
+                }
+            }
+            changed |= prune_observations(store, &now);
+            Ok(changed)
+        })
+    }
+
+    pub fn update_for_pane_move(
+        &self,
+        previous_pane_id: &str,
+        moved_pane: &PaneInfo,
+    ) -> Result<bool, NotesError> {
+        let attachment = self.capture_attachment_for_pane(moved_pane);
+        let changed = self.with_notes_store(|store, now| {
+            let mut changed = false;
+            for note in store
+                .notes
+                .iter_mut()
+                .filter(|note| note.session_key == self.session_key)
+            {
+                let matches = note
+                    .attachment
+                    .as_ref()
+                    .is_some_and(|attachment| attachment.pane_id == previous_pane_id);
+                if matches {
+                    push_attachment_history(note, now.clone());
+                    note.attachment = Some(attachment.clone());
+                    note.updated_at = now.clone();
+                    note.revision += 1;
+                    changed = true;
+                }
+            }
+            Ok(changed)
+        })?;
+        Ok(changed)
+    }
+
+    fn capture_attachment_for_pane_id(
+        &self,
+        pane_id: &str,
+        panes: &[PaneInfo],
+    ) -> Result<NoteAttachment, NotesError> {
+        if pane_id.is_empty() {
+            return Err(NotesError::BadRequest("pane_id is required".to_string()));
+        }
+        let pane = panes
+            .iter()
+            .find(|pane| pane.pane_id == pane_id)
+            .ok_or_else(|| NotesError::BadRequest(format!("pane not found: {pane_id}")))?;
+        Ok(self.capture_attachment_for_pane(pane))
+    }
+
+    fn capture_attachment_for_pane(&self, pane: &PaneInfo) -> NoteAttachment {
+        let observed_generation = self
+            .with_observation_store(|store, now, recovered| {
+                ensure_observation_for_pane(
+                    store,
+                    &self.session_key,
+                    pane,
+                    &now,
+                    if recovered {
+                        GenerationConfidence::RecoveredUnknown
+                    } else {
+                        GenerationConfidence::Known
+                    },
+                );
+                Ok(observation_generation_for_pane(
+                    store,
+                    &self.session_key,
+                    &pane.pane_id,
+                ))
+            })
+            .ok()
+            .flatten();
+        NoteAttachment {
+            kind: "pane".to_string(),
+            pane_id: pane.pane_id.clone(),
+            workspace_id: pane.workspace_id.clone(),
+            tab_id: pane.tab_id.clone(),
+            terminal_id: Some(pane.terminal_id.clone()),
+            pane_revision: Some(pane.revision),
+            observed_generation,
+            captured_at: now_ms_string(),
+            context: NotePaneContext {
+                pane_label: pane.label.clone(),
+                pane_title: pane.title.clone(),
+                agent: pane.agent.clone(),
+                display_agent: pane.display_agent.clone(),
+                cwd: pane.cwd.clone(),
+                foreground_cwd: pane.foreground_cwd.clone(),
+            },
+        }
+    }
+
+    fn with_note_mutation<F>(
+        &self,
+        note_id: &str,
+        expected_revision: u64,
+        mutate: F,
+    ) -> Result<NoteRecord, NotesError>
+    where
+        F: FnOnce(&mut NoteRecord, String),
+    {
+        let note_id = normalized_note_id(note_id)?;
+        self.with_notes_store(|store, now| {
+            let note = store
+                .notes
+                .iter_mut()
+                .find(|note| note.note_id == note_id)
+                .ok_or_else(|| NotesError::BadRequest(format!("note not found: {note_id}")))?;
+            if note.revision != expected_revision {
+                return Err(NotesError::Conflict("note has changed".to_string()));
+            }
+            mutate(note, now);
+            Ok(note.clone())
+        })
+    }
+
+    fn with_notes_store<F, T>(&self, mutate: F) -> Result<T, NotesError>
+    where
+        F: FnOnce(&mut NotesStore, String) -> Result<T, NotesError>,
+    {
+        let _lock = LockFile::exclusive(&self.notes_lock_path)?;
+        let mut store = self.load_or_create_notes_store()?;
+        let result = mutate(&mut store, now_ms_string())?;
+        store.updated_at = now_ms_string();
+        write_json_atomic(&self.notes_path, &store)?;
+        Ok(result)
+    }
+
+    fn with_observation_store<F, T>(&self, mutate: F) -> Result<T, NotesError>
+    where
+        F: FnOnce(&mut ObservationStore, String, bool) -> Result<T, NotesError>,
+    {
+        let _lock = LockFile::exclusive(&self.observations_lock_path)?;
+        let loaded = self.load_observation_store_for_update();
+        let mut store = loaded.store;
+        let before = serde_json::to_vec(&store).unwrap_or_default();
+        let result = mutate(&mut store, now_ms_string(), loaded.recovered)?;
+        let changed = result_changed(&before, &store);
+        if changed || loaded.recovered {
+            write_json_atomic(&self.observations_path, &store)?;
+        }
+        Ok(result)
+    }
+
+    fn load_or_create_notes_store(&self) -> Result<NotesStore, NotesError> {
+        match fs::read(&self.notes_path) {
+            Ok(bytes) => parse_notes_store(&bytes),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let now = now_ms_string();
+                Ok(NotesStore {
+                    version: NOTES_STORE_VERSION,
+                    store_id: format!("store_{}_{}", now, std::process::id()),
+                    next_note_number: 1,
+                    created_at: now.clone(),
+                    updated_at: now,
+                    notes: Vec::new(),
+                })
+            }
+            Err(err) => Err(NotesError::Io(err)),
+        }
+    }
+
+    fn load_observation_store_best_effort(&self) -> ObservationStore {
+        match fs::read(&self.observations_path) {
+            Ok(bytes) => {
+                parse_observation_store(&bytes).unwrap_or_else(|_| default_observation_store())
+            }
+            Err(_) => default_observation_store(),
+        }
+    }
+
+    fn load_observation_store_for_update(&self) -> LoadedObservationStore {
+        match fs::read(&self.observations_path) {
+            Ok(bytes) => match parse_observation_store(&bytes) {
+                Ok(store) => LoadedObservationStore {
+                    store,
+                    recovered: false,
+                },
+                Err(_) => {
+                    copy_corrupt_once(&self.observations_path);
+                    LoadedObservationStore {
+                        store: default_observation_store(),
+                        recovered: true,
+                    }
+                }
+            },
+            Err(err) if err.kind() == ErrorKind::NotFound => LoadedObservationStore {
+                store: default_observation_store(),
+                recovered: self.notes_path.exists(),
+            },
+            Err(_) => LoadedObservationStore {
+                store: default_observation_store(),
+                recovered: true,
+            },
+        }
+    }
+}
+
+fn result_changed<T: Serialize>(before: &[u8], value: &T) -> bool {
+    serde_json::to_vec(value).map_or(true, |after| before != after)
+}
+
+fn parse_notes_store(bytes: &[u8]) -> Result<NotesStore, NotesError> {
+    let store: NotesStore = serde_json::from_slice(bytes)
+        .map_err(|err| NotesError::Store(format!("notes store is unreadable: {err}")))?;
+    if store.version != NOTES_STORE_VERSION {
+        return Err(NotesError::Store(format!(
+            "unsupported notes store version: {}",
+            store.version
+        )));
+    }
+    Ok(store)
+}
+
+fn parse_observation_store(bytes: &[u8]) -> Result<ObservationStore, NotesError> {
+    let store: ObservationStore = serde_json::from_slice(bytes)
+        .map_err(|err| NotesError::Store(format!("observation store is unreadable: {err}")))?;
+    if store.version != OBSERVATION_STORE_VERSION {
+        return Err(NotesError::Store(format!(
+            "unsupported observation store version: {}",
+            store.version
+        )));
+    }
+    Ok(store)
+}
+
+fn default_observation_store() -> ObservationStore {
+    ObservationStore {
+        version: OBSERVATION_STORE_VERSION,
+        next_generation_number: 1,
+        observations: Vec::new(),
+    }
+}
+
+fn ensure_observation_for_pane(
+    store: &mut ObservationStore,
+    session_key: &str,
+    pane: &PaneInfo,
+    now: &str,
+    confidence_for_new: GenerationConfidence,
+) -> bool {
+    let index = store
+        .observations
+        .iter()
+        .position(|item| item.session_key == session_key && item.pane_id == pane.pane_id);
+    match index {
+        Some(index) => {
+            let conflict = {
+                let existing = &store.observations[index];
+                existing.terminal_id.as_deref() != Some(pane.terminal_id.as_str())
+                    || existing.workspace_id != pane.workspace_id
+                    || existing.tab_id != pane.tab_id
+                    || existing.missing_since.is_some()
+            };
+            if conflict {
+                let generation = next_generation(store);
+                let existing = &mut store.observations[index];
+                existing.terminal_id = Some(pane.terminal_id.clone());
+                existing.workspace_id = pane.workspace_id.clone();
+                existing.tab_id = pane.tab_id.clone();
+                existing.observed_generation = generation;
+                existing.generation_confidence = GenerationConfidence::Known;
+                existing.first_seen_at = now.to_string();
+                existing.missing_since = None;
+                true
+            } else {
+                false
+            }
+        }
+        None => {
+            let generation = next_generation(store);
+            store.observations.push(PaneObservation {
+                session_key: session_key.to_string(),
+                pane_id: pane.pane_id.clone(),
+                terminal_id: Some(pane.terminal_id.clone()),
+                workspace_id: pane.workspace_id.clone(),
+                tab_id: pane.tab_id.clone(),
+                observed_generation: generation,
+                generation_confidence: confidence_for_new,
+                first_seen_at: now.to_string(),
+                missing_since: None,
+            });
+            true
+        }
+    }
+}
+
+fn observation_generation_for_pane(
+    store: &ObservationStore,
+    session_key: &str,
+    pane_id: &str,
+) -> Option<String> {
+    store
+        .observations
+        .iter()
+        .find(|item| item.session_key == session_key && item.pane_id == pane_id)
+        .map(|item| item.observed_generation.clone())
+}
+
+fn next_generation(store: &mut ObservationStore) -> String {
+    let generation = format!("gen_{}", store.next_generation_number);
+    store.next_generation_number += 1;
+    generation
+}
+
+fn prune_observations(store: &mut ObservationStore, now: &str) -> bool {
+    let now_ms = now.parse::<u128>().unwrap_or(0);
+    let before = store.observations.len();
+    store.observations.retain(|item| {
+        let Some(missing_since) = item.missing_since.as_deref() else {
+            return true;
+        };
+        let missing_ms = missing_since.parse::<u128>().unwrap_or(now_ms);
+        now_ms.saturating_sub(missing_ms) <= MISSING_OBSERVATION_RETENTION_MS
+    });
+    let sessions: HashSet<String> = store
+        .observations
+        .iter()
+        .map(|item| item.session_key.clone())
+        .collect();
+    for session in sessions {
+        let session_count = store
+            .observations
+            .iter()
+            .filter(|item| item.session_key == session)
+            .count();
+        if session_count <= MAX_OBSERVATIONS_PER_SESSION {
+            continue;
+        }
+        let mut missing_indexes: Vec<(usize, u128)> = store
+            .observations
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| item.session_key == session && item.missing_since.is_some())
+            .map(|(index, item)| {
+                (
+                    index,
+                    item.missing_since
+                        .as_deref()
+                        .and_then(|value| value.parse().ok())
+                        .unwrap_or(0),
+                )
+            })
+            .collect();
+        missing_indexes.sort_by_key(|(_, missing)| *missing);
+        let remove_count = session_count.saturating_sub(MAX_OBSERVATIONS_PER_SESSION);
+        let remove_indexes: HashSet<usize> = missing_indexes
+            .into_iter()
+            .take(remove_count)
+            .map(|(index, _)| index)
+            .collect();
+        store
+            .observations
+            .retain_with_index(|index, _| !remove_indexes.contains(&index));
+    }
+    before != store.observations.len()
+}
+
+trait RetainWithIndex<T> {
+    fn retain_with_index<F>(&mut self, f: F)
+    where
+        F: FnMut(usize, &T) -> bool;
+}
+
+impl<T> RetainWithIndex<T> for Vec<T> {
+    fn retain_with_index<F>(&mut self, mut f: F)
+    where
+        F: FnMut(usize, &T) -> bool,
+    {
+        let mut index = 0;
+        self.retain(|item| {
+            let keep = f(index, item);
+            index += 1;
+            keep
+        });
+    }
+}
+
+fn note_response(
+    note: NoteRecord,
+    panes: &[PaneInfo],
+    observations: &[PaneObservation],
+    session_key: &str,
+) -> NoteResponse {
+    let (link_state, resolved_pane) = resolve_note_link(&note, panes, observations, session_key);
+    NoteResponse {
+        note,
+        link_state,
+        resolved_pane,
+    }
+}
+
+fn resolve_note_link(
+    note: &NoteRecord,
+    panes: &[PaneInfo],
+    observations: &[PaneObservation],
+    session_key: &str,
+) -> (NoteLinkState, Option<PaneInfo>) {
+    let Some(attachment) = &note.attachment else {
+        return (NoteLinkState::Detached, None);
+    };
+    if note.session_key != session_key {
+        return (NoteLinkState::Unresolved, None);
+    }
+    let Some(pane) = panes.iter().find(|pane| pane.pane_id == attachment.pane_id) else {
+        return (NoteLinkState::Unresolved, None);
+    };
+    let identity_conflicts = attachment
+        .terminal_id
+        .as_deref()
+        .is_some_and(|terminal_id| terminal_id != pane.terminal_id)
+        || attachment.workspace_id != pane.workspace_id
+        || attachment.tab_id != pane.tab_id;
+    if identity_conflicts {
+        return (NoteLinkState::Unresolved, None);
+    }
+    if attachment
+        .pane_revision
+        .is_some_and(|revision| pane.revision < revision)
+    {
+        return (NoteLinkState::Unresolved, None);
+    }
+    if let Some(captured_generation) = attachment.observed_generation.as_deref() {
+        let observation = observations.iter().find(|item| {
+            item.session_key == note.session_key && item.pane_id == attachment.pane_id
+        });
+        if let Some(observation) = observation {
+            if observation.generation_confidence == GenerationConfidence::Known
+                && observation.observed_generation != captured_generation
+            {
+                return (NoteLinkState::Unresolved, None);
+            }
+        }
+    }
+    (NoteLinkState::Linked, Some(pane.clone()))
+}
+
+fn normalize_title(title: Option<&str>, body: Option<&str>) -> Result<String, NotesError> {
+    let fallback = body
+        .and_then(|body| body.lines().find(|line| !line.trim().is_empty()))
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .unwrap_or("Untitled note");
+    let title = title
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .unwrap_or(fallback);
+    if title.chars().count() > MAX_TITLE_CHARS {
+        return Err(NotesError::BadRequest(format!(
+            "title must be at most {MAX_TITLE_CHARS} characters"
+        )));
+    }
+    Ok(title.to_string())
+}
+
+fn normalize_body(body: Option<&str>) -> Result<String, NotesError> {
+    let body = body.unwrap_or("").to_string();
+    if body.len() > MAX_BODY_BYTES {
+        return Err(NotesError::BadRequest("body exceeds 256 KiB".to_string()));
+    }
+    Ok(body)
+}
+
+fn normalized_note_id(note_id: &str) -> Result<String, NotesError> {
+    let note_id = note_id.trim();
+    if note_id.is_empty() {
+        return Err(NotesError::BadRequest("note_id is required".to_string()));
+    }
+    Ok(note_id.to_string())
+}
+
+fn push_attachment_history(note: &mut NoteRecord, now: String) {
+    if let Some(attachment) = note.attachment.clone() {
+        let mut attachment = attachment;
+        attachment.captured_at = now;
+        note.attachment_history.push(attachment);
+        if note.attachment_history.len() > MAX_ATTACHMENT_HISTORY {
+            let extra = note.attachment_history.len() - MAX_ATTACHMENT_HISTORY;
+            note.attachment_history.drain(0..extra);
+        }
+    }
+}
+
+fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<(), NotesError> {
+    if let Some(parent) = path.parent() {
+        ensure_private_dir(parent)?;
+    }
+    let temp_path = path.with_extension(format!("{}.tmp", std::process::id()));
+    let bytes = serde_json::to_vec_pretty(value)
+        .map_err(|err| NotesError::Store(format!("failed to serialize notes: {err}")))?;
+    fs::write(&temp_path, bytes)?;
+    set_private_file_permissions(&temp_path)?;
+    backup_existing_file(path);
+    fs::rename(&temp_path, path)?;
+    set_private_file_permissions(path)?;
+    Ok(())
+}
+
+fn backup_existing_file(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+    let backup_path = path.with_extension("bak");
+    if fs::copy(path, &backup_path).is_ok() {
+        let _ = set_private_file_permissions(&backup_path);
+    }
+}
+
+fn copy_corrupt_once(path: &Path) {
+    if corrupt_copy_exists(path) {
+        return;
+    }
+    let Ok(bytes) = fs::read(path) else {
+        return;
+    };
+    let corrupt_path = path.with_extension(format!("{}.corrupt", now_ms_string()));
+    if fs::write(&corrupt_path, bytes).is_ok() {
+        let _ = set_private_file_permissions(&corrupt_path);
+    }
+}
+
+fn corrupt_copy_exists(path: &Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    let Ok(entries) = fs::read_dir(parent) else {
+        return false;
+    };
+    let prefix = format!("{stem}.");
+    entries.flatten().any(|entry| {
+        entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".corrupt"))
+    })
+}
+
+fn default_notes_dir() -> PathBuf {
+    if let Some(path) = non_empty_env_path("HERDR_WEB_NOTES_DIR") {
+        return path;
+    }
+    if let Some(data_home) = non_empty_env_path("XDG_DATA_HOME") {
+        return data_home.join("herdr-web").join("notes");
+    }
+    if let Some(home) = non_empty_env_path("HOME") {
+        return home
+            .join(".local")
+            .join("share")
+            .join("herdr-web")
+            .join("notes");
+    }
+    PathBuf::from("herdr-web-notes")
+}
+
+fn non_empty_env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn session_key() -> String {
+    if let Some(name) = crate::session::active_name() {
+        return format!("session:{name}");
+    }
+    if let Ok(path) = std::env::var(herdr_compat::api::SOCKET_PATH_ENV_VAR) {
+        if !path.is_empty() && !crate::session::explicit_session_requested() {
+            let canonical = fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(path));
+            return format!(
+                "socket:{:016x}",
+                stable_hash(canonical.to_string_lossy().as_ref())
+            );
+        }
+    }
+    "session:default".to_string()
+}
+
+fn stable_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn now_ms_string() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .to_string()
+}
+
+fn ensure_private_dir(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    set_private_dir_permissions(path)
+}
+
+#[cfg(unix)]
+fn set_private_dir_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn set_private_dir_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+fn set_private_file_permissions(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+struct LockFile {
+    file: File,
+}
+
+impl LockFile {
+    fn exclusive(path: &Path) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            ensure_private_dir(parent)?;
+        }
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(path)?;
+        set_private_file_permissions(path)?;
+        lock_file(&file)?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for LockFile {
+    fn drop(&mut self) {
+        let _ = unlock_file(&self.file);
+    }
+}
+
+#[cfg(unix)]
+fn lock_file(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn unlock_file(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+fn lock_file(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn unlock_file(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use herdr_compat::api::schema::AgentStatus;
+
+    #[test]
+    fn creates_and_lists_linked_note() {
+        let dir = test_dir("creates_and_lists_linked_note");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+
+        let note = manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Plan".to_string()),
+                    body: Some("hello".to_string()),
+                    pane_id: Some("p1".to_string()),
+                },
+                &panes,
+            )
+            .unwrap();
+
+        assert_eq!(note.link_state, NoteLinkState::Linked);
+        let listed = manager.list(NotesListQuery::default(), &panes).unwrap();
+        assert_eq!(listed.notes.len(), 1);
+        assert_eq!(listed.notes[0].note.note_id, note.note.note_id);
+    }
+
+    #[test]
+    fn unresolved_note_remains_listed_when_pane_missing() {
+        let dir = test_dir("unresolved_note_remains_listed_when_pane_missing");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+        manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Plan".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &panes,
+            )
+            .unwrap();
+
+        let listed = manager.list(NotesListQuery::default(), &[]).unwrap();
+        assert_eq!(listed.notes.len(), 1);
+        assert_eq!(listed.notes[0].link_state, NoteLinkState::Unresolved);
+    }
+
+    #[test]
+    fn stale_revision_is_conflict() {
+        let dir = test_dir("stale_revision_is_conflict");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+        let note = manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Plan".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &panes,
+            )
+            .unwrap();
+
+        let err = manager
+            .update(
+                &note.note.note_id,
+                UpdateNoteRequest {
+                    title: Some("Later".to_string()),
+                    body: None,
+                    expected_revision: note.note.revision + 1,
+                },
+                &panes,
+            )
+            .unwrap_err();
+        assert!(matches!(err, NotesError::Conflict(_)));
+    }
+
+    #[test]
+    fn move_updates_attachment_and_stays_linked() {
+        let dir = test_dir("move_updates_attachment_and_stays_linked");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let old = pane("p1", "t1", "w1", "tab1", 1);
+        let note = manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Move me".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &[old],
+            )
+            .unwrap();
+        let moved = pane("p2", "t1", "w2", "tab2", 2);
+        manager.update_for_pane_move("p1", &moved).unwrap();
+
+        let listed = manager.list(NotesListQuery::default(), &[moved]).unwrap();
+        assert_eq!(listed.notes[0].note.note_id, note.note.note_id);
+        assert_eq!(listed.notes[0].link_state, NoteLinkState::Linked);
+        assert_eq!(
+            listed.notes[0].note.attachment.as_ref().unwrap().pane_id,
+            "p2"
+        );
+    }
+
+    #[test]
+    fn corrupt_observations_do_not_block_notes() {
+        let dir = test_dir("corrupt_observations_do_not_block_notes");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+        let note = manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Plan".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &panes,
+            )
+            .unwrap();
+        fs::write(&manager.observations_path, b"not json").unwrap();
+
+        let listed = manager.list(NotesListQuery::default(), &panes).unwrap();
+        assert_eq!(listed.notes[0].note.note_id, note.note.note_id);
+        assert_eq!(listed.notes[0].link_state, NoteLinkState::Linked);
+    }
+
+    #[test]
+    fn note_mutations_keep_backup_copy() {
+        let dir = test_dir("note_mutations_keep_backup_copy");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+        let note = manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Plan".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &panes,
+            )
+            .unwrap();
+
+        manager
+            .update(
+                &note.note.note_id,
+                UpdateNoteRequest {
+                    title: Some("Updated".to_string()),
+                    body: None,
+                    expected_revision: note.note.revision,
+                },
+                &panes,
+            )
+            .unwrap();
+
+        assert!(manager.notes_path.with_extension("bak").exists());
+    }
+
+    #[test]
+    fn corrupt_observation_reads_do_not_create_repeated_copies() {
+        let dir = test_dir("corrupt_observation_reads_do_not_create_repeated_copies");
+        let manager = NotesManager::for_test(dir.clone(), "session:default").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+        manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Plan".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &panes,
+            )
+            .unwrap();
+        fs::write(&manager.observations_path, b"not json").unwrap();
+
+        manager.list(NotesListQuery::default(), &panes).unwrap();
+        manager.list(NotesListQuery::default(), &panes).unwrap();
+
+        assert_eq!(corrupt_copy_count(&dir), 0);
+        manager.observe_panes(&panes).unwrap();
+        manager.observe_panes(&panes).unwrap();
+        assert_eq!(corrupt_copy_count(&dir), 1);
+    }
+
+    fn pane(
+        id: &str,
+        terminal_id: &str,
+        workspace_id: &str,
+        tab_id: &str,
+        revision: u64,
+    ) -> PaneInfo {
+        PaneInfo {
+            pane_id: id.to_string(),
+            terminal_id: terminal_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            tab_id: tab_id.to_string(),
+            focused: false,
+            cwd: None,
+            foreground_cwd: None,
+            label: None,
+            agent: None,
+            title: None,
+            display_agent: None,
+            agent_status: AgentStatus::Unknown,
+            custom_status: None,
+            state_labels: Default::default(),
+            agent_session: None,
+            revision,
+        }
+    }
+
+    fn test_dir(name: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("herdr-web-notes-test-{name}-{}", now_ms_string()));
+        let _ = fs::remove_dir_all(&dir);
+        dir
+    }
+
+    fn corrupt_copy_count(dir: &Path) -> usize {
+        fs::read_dir(dir)
+            .unwrap()
+            .flatten()
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.ends_with(".corrupt"))
+            })
+            .count()
+    }
+}

--- a/bridge/src/notes.rs
+++ b/bridge/src/notes.rs
@@ -1371,6 +1371,80 @@ mod tests {
     }
 
     #[test]
+    fn observation_pruning_bounds_missing_panes_per_session() {
+        let dir = test_dir("observation_pruning_bounds_missing_panes_per_session");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let panes = (0..=MAX_OBSERVATIONS_PER_SESSION)
+            .map(|index| pane(&format!("p{index}"), &format!("t{index}"), "w1", "tab1", 1))
+            .collect::<Vec<_>>();
+
+        manager.observe_panes(&panes).unwrap();
+        manager.observe_panes(&[]).unwrap();
+
+        let observations = manager.load_observation_store_best_effort().observations;
+        let session_observations = observations
+            .iter()
+            .filter(|item| item.session_key == "session:default")
+            .collect::<Vec<_>>();
+        assert_eq!(session_observations.len(), MAX_OBSERVATIONS_PER_SESSION);
+        assert!(!session_observations.iter().any(|item| item.pane_id == "p0"));
+        assert!(session_observations
+            .iter()
+            .all(|item| item.missing_since.is_some()));
+    }
+
+    #[test]
+    fn persisted_observation_keeps_note_linked_after_restart() {
+        let dir = test_dir("persisted_observation_keeps_note_linked_after_restart");
+        let manager = NotesManager::for_test(dir.clone(), "session:default").unwrap();
+        let panes = vec![pane("p1", "t1", "w1", "tab1", 1)];
+        let note = manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Restart".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &panes,
+            )
+            .unwrap();
+
+        let restarted = NotesManager::for_test(dir, "session:default").unwrap();
+        let listed = restarted.list(NotesListQuery::default(), &panes).unwrap();
+
+        assert_eq!(listed.notes[0].note.note_id, note.note.note_id);
+        assert_eq!(listed.notes[0].link_state, NoteLinkState::Linked);
+    }
+
+    #[test]
+    fn move_to_stale_observed_pane_refreshes_generation_and_stays_linked() {
+        let dir = test_dir("move_to_stale_observed_pane_refreshes_generation_and_stays_linked");
+        let manager = NotesManager::for_test(dir, "session:default").unwrap();
+        let source = pane("p1", "t1", "w1", "tab1", 1);
+        let stale_target = pane("p2", "old-terminal", "w1", "tab1", 1);
+        manager
+            .observe_panes(&[source.clone(), stale_target])
+            .unwrap();
+        let note = manager
+            .create(
+                CreateNoteRequest {
+                    title: Some("Move".to_string()),
+                    body: None,
+                    pane_id: Some("p1".to_string()),
+                },
+                &[source],
+            )
+            .unwrap();
+        let target = pane("p2", "new-terminal", "w2", "tab2", 2);
+
+        assert!(manager.update_for_pane_move("p1", &target).unwrap());
+        let listed = manager.list(NotesListQuery::default(), &[target]).unwrap();
+
+        assert_eq!(listed.notes[0].note.note_id, note.note.note_id);
+        assert_eq!(listed.notes[0].link_state, NoteLinkState::Linked);
+    }
+
+    #[test]
     fn corrupt_observations_do_not_block_notes() {
         let dir = test_dir("corrupt_observations_do_not_block_notes");
         let manager = NotesManager::for_test(dir, "session:default").unwrap();

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -1553,9 +1553,14 @@ async fn command_handler(
         .map_err(|err| BridgeError::Protocol(err.to_string()))??;
     if let ResponseResult::PaneMove { move_result } = &response.result {
         if move_result.changed {
-            match state
-                .notes
-                .update_for_pane_move(&move_result.previous_pane_id, &move_result.pane)
+            let notes = state.notes.clone();
+            let previous_pane_id = move_result.previous_pane_id.clone();
+            let moved_pane = (*move_result.pane).clone();
+            match tokio::task::spawn_blocking(move || {
+                notes.update_for_pane_move(&previous_pane_id, &moved_pane)
+            })
+            .await
+            .map_err(|err| BridgeError::Protocol(err.to_string()))?
             {
                 Ok(true) => broadcast_notes_changed(&state, None, None),
                 Ok(false) => {}
@@ -1794,7 +1799,12 @@ async fn snapshot_handler(
         }
     };
     let panes = current_panes(&state.api)?;
-    match state.notes.observe_panes(&panes) {
+    let notes = state.notes.clone();
+    let note_panes = panes.clone();
+    match tokio::task::spawn_blocking(move || notes.observe_panes(&note_panes))
+        .await
+        .map_err(|err| BridgeError::Protocol(err.to_string()))?
+    {
         Ok(true) => broadcast_notes_changed(&state, None, None),
         Ok(false) => {}
         Err(err) => warn!(error = %err, "failed to update pane note observations"),
@@ -1854,8 +1864,13 @@ async fn notes_list_handler(
     headers: HeaderMap,
 ) -> Result<Json<NotesListResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let panes = current_panes(&state.api)?;
-    Ok(Json(state.notes.list(query, &panes)?))
+    Ok(Json(
+        run_notes_task(state, move |state| {
+            let panes = current_panes(&state.api)?;
+            Ok(state.notes.list(query, &panes)?)
+        })
+        .await?,
+    ))
 }
 
 async fn notes_create_handler(
@@ -1864,8 +1879,11 @@ async fn notes_create_handler(
     Json(body): Json<CreateNoteRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let panes = current_panes(&state.api)?;
-    let note = state.notes.create(body, &panes)?;
+    let note = run_notes_task(state.clone(), move |state| {
+        let panes = current_panes(&state.api)?;
+        Ok(state.notes.create(body, &panes)?)
+    })
+    .await?;
     broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
     Ok(Json(note))
 }
@@ -1877,8 +1895,11 @@ async fn notes_update_handler(
     Json(body): Json<UpdateNoteRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let panes = current_panes(&state.api)?;
-    let note = state.notes.update(&note_id, body, &panes)?;
+    let note = run_notes_task(state.clone(), move |state| {
+        let panes = current_panes(&state.api)?;
+        Ok(state.notes.update(&note_id, body, &panes)?)
+    })
+    .await?;
     broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
     Ok(Json(note))
 }
@@ -1890,8 +1911,11 @@ async fn notes_attach_handler(
     Json(body): Json<AttachNoteRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let panes = current_panes(&state.api)?;
-    let note = state.notes.attach(&note_id, body, &panes)?;
+    let note = run_notes_task(state.clone(), move |state| {
+        let panes = current_panes(&state.api)?;
+        Ok(state.notes.attach(&note_id, body, &panes)?)
+    })
+    .await?;
     broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
     Ok(Json(note))
 }
@@ -1903,8 +1927,11 @@ async fn notes_detach_handler(
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let panes = current_panes(&state.api)?;
-    let note = state.notes.detach(&note_id, body, &panes)?;
+    let note = run_notes_task(state.clone(), move |state| {
+        let panes = current_panes(&state.api)?;
+        Ok(state.notes.detach(&note_id, body, &panes)?)
+    })
+    .await?;
     broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
     Ok(Json(note))
 }
@@ -1916,8 +1943,11 @@ async fn notes_archive_handler(
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let panes = current_panes(&state.api)?;
-    let note = state.notes.archive(&note_id, body, &panes)?;
+    let note = run_notes_task(state.clone(), move |state| {
+        let panes = current_panes(&state.api)?;
+        Ok(state.notes.archive(&note_id, body, &panes)?)
+    })
+    .await?;
     broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
     Ok(Json(note))
 }
@@ -1929,8 +1959,11 @@ async fn notes_restore_handler(
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let panes = current_panes(&state.api)?;
-    let note = state.notes.restore(&note_id, body, &panes)?;
+    let note = run_notes_task(state.clone(), move |state| {
+        let panes = current_panes(&state.api)?;
+        Ok(state.notes.restore(&note_id, body, &panes)?)
+    })
+    .await?;
     broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
     Ok(Json(note))
 }
@@ -1942,10 +1975,23 @@ async fn notes_delete_handler(
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let panes = current_panes(&state.api)?;
-    let note = state.notes.delete(&note_id, body, &panes)?;
+    let note = run_notes_task(state.clone(), move |state| {
+        let panes = current_panes(&state.api)?;
+        Ok(state.notes.delete(&note_id, body, &panes)?)
+    })
+    .await?;
     broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
     Ok(Json(note))
+}
+
+async fn run_notes_task<T, F>(state: BridgeState, task: F) -> Result<T, BridgeError>
+where
+    T: Send + 'static,
+    F: FnOnce(BridgeState) -> Result<T, BridgeError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(move || task(state))
+        .await
+        .map_err(|err| BridgeError::Protocol(err.to_string()))?
 }
 
 fn broadcast_notes_changed(state: &BridgeState, note_id: Option<&str>, revision: Option<u64>) {

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use axum::body::Bytes;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::{DefaultBodyLimit, Query, State};
+use axum::extract::{DefaultBodyLimit, Path as AxumPath, Query, State};
 use axum::http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
     ACCESS_CONTROL_MAX_AGE, ACCESS_CONTROL_REQUEST_HEADERS, HOST, ORIGIN, VARY,
@@ -43,6 +43,11 @@ use herdr_compat::protocol::{
     PROTOCOL_VERSION,
 };
 
+use crate::notes::{
+    AttachNoteRequest, CreateNoteRequest, NoteResponse, NotesError, NotesListQuery,
+    NotesListResponse, NotesManager, RevisionRequest, UpdateNoteRequest,
+};
+
 const DEFAULT_HOST: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 8787;
 const DEFAULT_COLS: u16 = 80;
@@ -50,6 +55,7 @@ const DEFAULT_ROWS: u16 = 24;
 const DEFAULT_STATIC_DIR: &str = "web/dist";
 const MIN_TERMINAL_ATTACH_PROTOCOL: u32 = 13;
 const MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
+const MAX_NOTES_REQUEST_BYTES: usize = 512 * 1024;
 const MAX_TERMINAL_INPUT_CHUNK_BYTES: usize = 768 * 1024;
 const DEFAULT_TERMINAL_OUTPUT_COALESCE_MS: u64 = 16;
 const MAX_TERMINAL_OUTPUT_COALESCE_MS: u64 = 256;
@@ -80,6 +86,7 @@ struct BridgeState {
     request_policy: RequestPolicy,
     terminal_sessions: Arc<Mutex<HashMap<String, SharedTerminalSession>>>,
     selected_pane_id: Arc<Mutex<Option<String>>>,
+    notes: Arc<NotesManager>,
     ui_event_tx: tokio::sync::broadcast::Sender<String>,
     activity_tx: tokio::sync::broadcast::Sender<ActivityMessage>,
     upload_dir: PathBuf,
@@ -120,6 +127,12 @@ struct SnapshotTabInfo {
 #[derive(Debug, Serialize)]
 struct Capabilities {
     commands: &'static [&'static str],
+    notes: NotesCapability,
+}
+
+#[derive(Debug, Serialize)]
+struct NotesCapability {
+    version: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -507,6 +520,7 @@ enum BridgeError {
     Api(ApiClientError),
     Io(io::Error),
     BadRequest(String),
+    Conflict(String),
     Forbidden(String),
     Protocol(String),
 }
@@ -526,6 +540,7 @@ impl fmt::Display for BridgeError {
             Self::Api(err) => write!(f, "{err}"),
             Self::Io(err) => write!(f, "{err}"),
             Self::BadRequest(message) => write!(f, "{message}"),
+            Self::Conflict(message) => write!(f, "{message}"),
             Self::Forbidden(message) => write!(f, "{message}"),
             Self::Protocol(message) => write!(f, "{message}"),
         }
@@ -536,6 +551,7 @@ impl IntoResponse for BridgeError {
     fn into_response(self) -> Response {
         let status = match self {
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::Conflict(_) => StatusCode::CONFLICT,
             Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::Api(_) | Self::Io(_) | Self::Protocol(_) => StatusCode::BAD_GATEWAY,
         };
@@ -555,6 +571,17 @@ impl From<ApiClientError> for BridgeError {
 impl From<io::Error> for BridgeError {
     fn from(err: io::Error) -> Self {
         Self::Io(err)
+    }
+}
+
+impl From<NotesError> for BridgeError {
+    fn from(err: NotesError) -> Self {
+        match err {
+            NotesError::BadRequest(message) => Self::BadRequest(message),
+            NotesError::Conflict(message) => Self::Conflict(message),
+            NotesError::Io(err) => Self::Io(err),
+            NotesError::Store(message) => Self::Protocol(message),
+        }
     }
 }
 
@@ -750,6 +777,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         );
     }
     ensure_upload_dir(&options.upload_dir)?;
+    let notes = Arc::new(NotesManager::new()?);
     let request_policy = RequestPolicy {
         bind_host: options.host.clone(),
         bind_port: options.port,
@@ -769,12 +797,46 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         request_policy: request_policy.clone(),
         terminal_sessions: Arc::new(Mutex::new(HashMap::new())),
         selected_pane_id: Arc::new(Mutex::new(None)),
+        notes,
         ui_event_tx: tokio::sync::broadcast::channel(256).0,
         activity_tx: tokio::sync::broadcast::channel(512).0,
         upload_dir: options.upload_dir.clone(),
     };
     spawn_agent_activity_watcher(state.clone());
+    let notes_routes = Router::new()
+        .route(
+            "/api/notes",
+            get(notes_list_handler)
+                .post(notes_create_handler)
+                .options(preflight_handler),
+        )
+        .route(
+            "/api/notes/{note_id}/update",
+            post(notes_update_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/notes/{note_id}/attach",
+            post(notes_attach_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/notes/{note_id}/detach",
+            post(notes_detach_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/notes/{note_id}/archive",
+            post(notes_archive_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/notes/{note_id}/restore",
+            post(notes_restore_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/notes/{note_id}/delete",
+            post(notes_delete_handler).options(preflight_handler),
+        )
+        .layer(DefaultBodyLimit::max(MAX_NOTES_REQUEST_BYTES));
     let app = Router::new()
+        .merge(notes_routes)
         .route(
             "/api/snapshot",
             get(snapshot_handler).options(preflight_handler),
@@ -1489,6 +1551,18 @@ async fn command_handler(
     let response = tokio::task::spawn_blocking(move || api.request(request))
         .await
         .map_err(|err| BridgeError::Protocol(err.to_string()))??;
+    if let ResponseResult::PaneMove { move_result } = &response.result {
+        if move_result.changed {
+            match state
+                .notes
+                .update_for_pane_move(&move_result.previous_pane_id, &move_result.pane)
+            {
+                Ok(true) => broadcast_notes_changed(&state, None, None),
+                Ok(false) => {}
+                Err(err) => warn!(error = %err, "failed to update note attachment after pane move"),
+            }
+        }
+    }
     let value = serde_json::to_value(response.result)
         .map_err(|err| BridgeError::Protocol(err.to_string()))?;
     if should_prune_terminal_sessions {
@@ -1720,6 +1794,11 @@ async fn snapshot_handler(
         }
     };
     let panes = current_panes(&state.api)?;
+    match state.notes.observe_panes(&panes) {
+        Ok(true) => broadcast_notes_changed(&state, None, None),
+        Ok(false) => {}
+        Err(err) => warn!(error = %err, "failed to update pane note observations"),
+    }
     let layouts = collect_tab_layouts(&state.api, &tabs, &panes);
     let selected_pane_id = shared_selected_pane(&state, &panes)?;
     let workspaces = workspaces
@@ -1765,7 +1844,121 @@ async fn capabilities_handler(
     ensure_allowed_request(&headers, &state.request_policy)?;
     Ok(Json(Capabilities {
         commands: ALLOWED_COMMANDS,
+        notes: NotesCapability { version: 1 },
     }))
+}
+
+async fn notes_list_handler(
+    State(state): State<BridgeState>,
+    Query(query): Query<NotesListQuery>,
+    headers: HeaderMap,
+) -> Result<Json<NotesListResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let panes = current_panes(&state.api)?;
+    Ok(Json(state.notes.list(query, &panes)?))
+}
+
+async fn notes_create_handler(
+    State(state): State<BridgeState>,
+    headers: HeaderMap,
+    Json(body): Json<CreateNoteRequest>,
+) -> Result<Json<NoteResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let panes = current_panes(&state.api)?;
+    let note = state.notes.create(body, &panes)?;
+    broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
+    Ok(Json(note))
+}
+
+async fn notes_update_handler(
+    State(state): State<BridgeState>,
+    AxumPath(note_id): AxumPath<String>,
+    headers: HeaderMap,
+    Json(body): Json<UpdateNoteRequest>,
+) -> Result<Json<NoteResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let panes = current_panes(&state.api)?;
+    let note = state.notes.update(&note_id, body, &panes)?;
+    broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
+    Ok(Json(note))
+}
+
+async fn notes_attach_handler(
+    State(state): State<BridgeState>,
+    AxumPath(note_id): AxumPath<String>,
+    headers: HeaderMap,
+    Json(body): Json<AttachNoteRequest>,
+) -> Result<Json<NoteResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let panes = current_panes(&state.api)?;
+    let note = state.notes.attach(&note_id, body, &panes)?;
+    broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
+    Ok(Json(note))
+}
+
+async fn notes_detach_handler(
+    State(state): State<BridgeState>,
+    AxumPath(note_id): AxumPath<String>,
+    headers: HeaderMap,
+    Json(body): Json<RevisionRequest>,
+) -> Result<Json<NoteResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let panes = current_panes(&state.api)?;
+    let note = state.notes.detach(&note_id, body, &panes)?;
+    broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
+    Ok(Json(note))
+}
+
+async fn notes_archive_handler(
+    State(state): State<BridgeState>,
+    AxumPath(note_id): AxumPath<String>,
+    headers: HeaderMap,
+    Json(body): Json<RevisionRequest>,
+) -> Result<Json<NoteResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let panes = current_panes(&state.api)?;
+    let note = state.notes.archive(&note_id, body, &panes)?;
+    broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
+    Ok(Json(note))
+}
+
+async fn notes_restore_handler(
+    State(state): State<BridgeState>,
+    AxumPath(note_id): AxumPath<String>,
+    headers: HeaderMap,
+    Json(body): Json<RevisionRequest>,
+) -> Result<Json<NoteResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let panes = current_panes(&state.api)?;
+    let note = state.notes.restore(&note_id, body, &panes)?;
+    broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
+    Ok(Json(note))
+}
+
+async fn notes_delete_handler(
+    State(state): State<BridgeState>,
+    AxumPath(note_id): AxumPath<String>,
+    headers: HeaderMap,
+    Json(body): Json<RevisionRequest>,
+) -> Result<Json<NoteResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let panes = current_panes(&state.api)?;
+    let note = state.notes.delete(&note_id, body, &panes)?;
+    broadcast_notes_changed(&state, Some(&note.note.note_id), Some(note.note.revision));
+    Ok(Json(note))
+}
+
+fn broadcast_notes_changed(state: &BridgeState, note_id: Option<&str>, revision: Option<u64>) {
+    let mut payload = serde_json::json!({
+        "type": "herdr_web.notes_changed",
+    });
+    if let Some(note_id) = note_id {
+        payload["note_id"] = serde_json::json!(note_id);
+    }
+    if let Some(revision) = revision {
+        payload["revision"] = serde_json::json!(revision);
+    }
+    let _ = state.ui_event_tx.send(payload.to_string());
 }
 
 fn current_panes(api: &ApiClient) -> Result<Vec<PaneInfo>, BridgeError> {

--- a/docs/release.md
+++ b/docs/release.md
@@ -99,6 +99,7 @@ Open `http://127.0.0.1:8787` and verify:
 - New tabs can launch Shell, Codex, Claude, and pi.
 - Split right/down can launch Shell, Codex, Claude, and pi.
 - Upload button, paste upload, and drop upload place shell-quoted file paths in the terminal.
+- Pane notes can be created, edited, reloaded, and recovered from the Notes view.
 - Binding to `HOST=0.0.0.0` is only used on a trusted network.
 
 ## Cut

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,7 +19,9 @@
         "ghostty-web": "0.4.0",
         "lucide-react": "^0.562.0",
         "react": "^19.2.3",
-        "react-dom": "^19.2.3"
+        "react-dom": "^19.2.3",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -1557,6 +1559,14 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1568,14 +1578,42 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
       "version": "25.9.3",
@@ -1591,7 +1629,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1606,6 +1643,11 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.0",
@@ -1927,6 +1969,11 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
@@ -2133,6 +2180,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2235,6 +2291,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2261,6 +2326,42 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2278,6 +2379,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2323,7 +2433,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -2343,7 +2452,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2364,11 +2472,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2377,6 +2505,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2627,6 +2767,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2655,6 +2804,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2801,6 +2955,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -2827,6 +3019,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -2863,6 +3064,42 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2882,6 +3119,26 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3310,6 +3567,15 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3339,11 +3605,821 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3361,7 +4437,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3472,6 +4547,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -3568,6 +4666,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3597,6 +4704,94 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -3717,6 +4912,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3731,6 +4935,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3741,6 +4958,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/supports-color": {
@@ -3851,6 +5084,24 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -3933,6 +5184,87 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3971,6 +5303,32 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -4281,6 +5639,15 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,85 +29,59 @@
         "@vitejs/plugin-react": "^6.0.2",
         "eslint": "^9.39.2",
         "eslint-plugin-react-hooks": "^7.0.1",
+        "jsdom": "^29.1.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.50.0",
         "vite": "^8.0.16",
         "vitest": "^4.0.15"
       }
     },
-    "node_modules/@acemir/cssom": {
-      "version": "0.9.31",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@csstools/css-calc": "^3.0.0",
-        "@csstools/css-color-parser": "^4.0.1",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.5"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.6"
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -357,6 +331,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@capacitor/app": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
@@ -404,9 +390,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -426,9 +409,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -438,9 +418,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.4.tgz",
-      "integrity": "sha512-yI8kNhHiOrLb8Rlulsk07DeQz0PwyT69FX9dkz5rAp7p9RUwFKEXnZpBGzURiLHgi66YqIWxOHn1nij8Lrg27Q==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+      "integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
       "dev": true,
       "funding": [
         {
@@ -452,9 +432,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
         "@csstools/css-calc": "^3.2.1"
@@ -482,9 +459,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -507,9 +481,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0",
-      "optional": true,
-      "peer": true,
       "peerDependencies": {
         "css-tree": "^3.2.1"
       },
@@ -534,9 +505,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1154,8 +1122,6 @@
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -2120,18 +2086,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -2203,9 +2157,6 @@
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -2360,45 +2311,12 @@
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/cssstyle": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -2409,31 +2327,16 @@
       "license": "MIT"
     },
     "node_modules/data-urls": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
-      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^15.1.0"
+        "whatwg-url": "^16.0.0"
       },
       "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -2459,9 +2362,7 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2491,8 +2392,6 @@
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2923,45 +2822,11 @@
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/ignore": {
@@ -3023,10 +2888,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3064,37 +2926,35 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
-      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@acemir/cssom": "^0.9.28",
-        "@asamuzakjp/dom-selector": "^6.7.6",
-        "@exodus/bytes": "^1.6.0",
-        "cssstyle": "^5.3.4",
-        "data-urls": "^6.0.0",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.0",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^15.1.0",
-        "ws": "^8.18.3",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -3103,6 +2963,15 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3474,10 +3343,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3612,8 +3478,6 @@
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "entities": "^8.0.0"
       },
@@ -3740,9 +3604,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3795,8 +3656,6 @@
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -3901,9 +3760,7 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3955,8 +3812,6 @@
       "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tldts-core": "^7.4.2"
       },
@@ -3969,9 +3824,7 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
       "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
@@ -3979,8 +3832,6 @@
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -3993,9 +3844,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -4067,6 +3915,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4289,8 +4146,6 @@
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -4303,39 +4158,31 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
-      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
+        "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.0"
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -4379,38 +4226,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4420,9 +4241,7 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^9.39.2",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "jsdom": "^29.1.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.50.0",
     "vite": "^8.0.16",

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,9 @@
     "ghostty-web": "0.4.0",
     "lucide-react": "^0.562.0",
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildVisibleAgentPaneEntries,
   buildVisibleScopedNotes,
+  noteDraftStorageKey,
   buildVisibleScopedWorkspaces,
   buildVisibleTabEntries,
   nextVisibleAgentPaneEntry,
@@ -360,6 +361,31 @@ describe("App multi-bridge helpers", () => {
         false,
       ).map((entry) => `${entry.bridgeId}:${entry.note.note_id}`),
     ).toEqual(["bridge-a:a"]);
+  });
+
+  it("scopes note drafts by bridge connection, store, session, and note id", () => {
+    const bridgeViews = [
+      bridgeView(
+        "bridge-a",
+        bridgeSnapshot("workspace-a", "tab-a", pane("pane-a", "workspace-a", "tab-a")),
+      ),
+    ];
+    const [first] = buildVisibleScopedNotes(
+      bridgeViews,
+      notesState("bridge-a", "store-1", [note("n1", "workspace-a", "linked")]),
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+      false,
+      false,
+    );
+    const changedSession = { ...first, sessionKey: "session:other" };
+
+    expect(noteDraftStorageKey(first)).not.toBe(noteDraftStorageKey(changedSession));
+    expect(noteDraftStorageKey(first)).toContain("store-1");
+    expect(noteDraftStorageKey(first)).toContain("session%3Adefault");
   });
 });
 

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -335,7 +335,7 @@ describe("App multi-bridge helpers", () => {
     ).toEqual(["deleted", "archived", "unresolved-other-space", "active-linked"]);
   });
 
-  it("dedupes all-host notes when two bridge profiles point at the same store", () => {
+  it("dedupes all-host notes by note identity when two bridge profiles point at the same store", () => {
     const bridgeViews = [
       bridgeView(
         "bridge-a",
@@ -346,13 +346,31 @@ describe("App multi-bridge helpers", () => {
         bridgeSnapshot("workspace-a", "tab-a", pane("pane-a", "workspace-a", "tab-a")),
       ),
     ];
+    const sharedFromOtherSession = {
+      ...note("shared", "workspace-a", "linked"),
+      session_key: "session:bridge-b",
+    };
+    const sharedFromOwningSession = {
+      ...sharedFromOtherSession,
+      resolved_pane: pane("workspace-a-pane", "workspace-a", "tab-a"),
+    };
 
     expect(
       buildVisibleScopedNotes(
         bridgeViews,
         {
-          ...notesState("bridge-a", "shared-store", [note("a", "workspace-a", "linked")]),
-          ...notesState("bridge-b", "shared-store", [note("b", "workspace-a", "linked")]),
+          ...notesState(
+            "bridge-a",
+            "shared-store",
+            [note("a", "workspace-a", "linked"), sharedFromOtherSession],
+            "session:bridge-a",
+          ),
+          ...notesState(
+            "bridge-b",
+            "shared-store",
+            [note("b", "workspace-a", "linked"), sharedFromOwningSession],
+            "session:bridge-b",
+          ),
         },
         "bridge-a",
         "all",
@@ -361,8 +379,12 @@ describe("App multi-bridge helpers", () => {
         {},
         false,
         false,
-      ).map((entry) => `${entry.bridgeId}:${entry.note.note_id}`),
-    ).toEqual(["bridge-a:a"]);
+      ).map((entry) => `${entry.bridgeId}:${entry.note.session_key}:${entry.note.note_id}`),
+    ).toEqual([
+      "bridge-a:session:default:a",
+      "bridge-b:session:default:b",
+      "bridge-b:session:bridge-b:shared",
+    ]);
   });
 
   it("scopes note drafts by bridge connection, store, session, and note id", () => {
@@ -388,6 +410,36 @@ describe("App multi-bridge helpers", () => {
     expect(noteDraftStorageKey(first)).not.toBe(noteDraftStorageKey(changedSession));
     expect(noteDraftStorageKey(first)).toContain("store-1");
     expect(noteDraftStorageKey(first)).toContain("session%3Adefault");
+  });
+
+  it("scopes note drafts by the note owner session for other-session notes", () => {
+    const bridgeViews = [
+      bridgeView(
+        "bridge-a",
+        bridgeSnapshot("workspace-a", "tab-a", pane("pane-a", "workspace-a", "tab-a")),
+      ),
+    ];
+    const [first] = buildVisibleScopedNotes(
+      bridgeViews,
+      notesState(
+        "bridge-a",
+        "store-1",
+        [{ ...note("n1", "workspace-a", "linked"), session_key: "session:note-owner" }],
+        "session:bridge-response",
+      ),
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+      false,
+      false,
+    );
+
+    expect(first.sessionKey).toBe("session:note-owner");
+    expect(first.bridgeSessionKey).toBe("session:bridge-response");
+    expect(noteDraftStorageKey(first)).toContain("session%3Anote-owner");
+    expect(noteDraftStorageKey(first)).not.toContain("session%3Abridge-response");
   });
 
   it("blocks note autosave when the server revision advances under a dirty draft", () => {
@@ -580,13 +632,18 @@ function bridgeSnapshot(workspaceId: string, tabId: string, paneInfo: PaneInfo):
   };
 }
 
-function notesState(bridgeId: string, storeId: string, notes: PaneNote[]) {
+function notesState(
+  bridgeId: string,
+  storeId: string,
+  notes: PaneNote[],
+  sessionKey = "session:default",
+) {
   return {
     [bridgeId]: {
       connectionKey: bridgeId,
       response: {
         store_id: storeId,
-        session_key: "session:default",
+        session_key: sessionKey,
         notes,
       },
       loadState: "ready" as const,

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -8,6 +8,7 @@ import {
   nextVisibleAgentPaneEntry,
   nextVisibleTabEntry,
   resolveInitialSelectedBridgeId,
+  shouldBlockDirtyNoteAutosave,
   shouldCollapseHostScope,
   sortScopedAgentPanes,
   stableBridgeRefreshOffsetMs,
@@ -386,6 +387,42 @@ describe("App multi-bridge helpers", () => {
     expect(noteDraftStorageKey(first)).not.toBe(noteDraftStorageKey(changedSession));
     expect(noteDraftStorageKey(first)).toContain("store-1");
     expect(noteDraftStorageKey(first)).toContain("session%3Adefault");
+  });
+
+  it("blocks note autosave when the server revision advances under a dirty draft", () => {
+    expect(
+      shouldBlockDirtyNoteAutosave({
+        dirty: true,
+        title: "Local title",
+        body: "Local draft",
+        baseRevision: 1,
+        serverTitle: "Remote title",
+        serverBody: "Remote edit",
+        serverRevision: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockDirtyNoteAutosave({
+        dirty: true,
+        title: "Remote title",
+        body: "Remote edit",
+        baseRevision: 1,
+        serverTitle: "Remote title",
+        serverBody: "Remote edit",
+        serverRevision: 2,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockDirtyNoteAutosave({
+        dirty: true,
+        title: "Local title",
+        body: "Local draft",
+        baseRevision: 1,
+        serverTitle: "Original title",
+        serverBody: "Original body",
+        serverRevision: 1,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildVisibleAgentPaneEntries,
+  buildVisibleScopedNotes,
   buildVisibleScopedWorkspaces,
   buildVisibleTabEntries,
   nextVisibleAgentPaneEntry,
@@ -17,6 +18,7 @@ import {
   isConnectionResultCurrent,
 } from "./connectionState";
 import type { AgentStatus, PaneInfo, Snapshot, TabInfo, WorkspaceInfo } from "./types";
+import type { PaneNote } from "./notes";
 
 describe("App connection guards", () => {
   it("hides snapshots from stale backend connections", () => {
@@ -286,6 +288,79 @@ describe("App multi-bridge helpers", () => {
     expect(nextVisibleTabEntry(entries, 0, -1).tab.tab_id).toBe("tab-b");
     expect(nextVisibleTabEntry(entries, 1, 1).tab.tab_id).toBe("tab-a");
   });
+
+  it("keeps unresolved notes visible in space scope and filters archived/deleted notes explicitly", () => {
+    const bridgeViews = [
+      bridgeView(
+        "bridge-a",
+        bridgeSnapshot("workspace-a", "tab-a", pane("pane-a", "workspace-a", "tab-a")),
+      ),
+    ];
+    const notes = [
+      note("active-linked", "workspace-a", "linked"),
+      note("unresolved-other-space", "workspace-b", "unresolved"),
+      { ...note("archived", "workspace-a", "linked"), archived_at: "500" },
+      { ...note("deleted", "workspace-a", "linked"), deleted_at: "600" },
+    ];
+
+    expect(
+      buildVisibleScopedNotes(
+        bridgeViews,
+        notesState("bridge-a", "store-1", notes),
+        "bridge-a",
+        "selected",
+        "space",
+        bridgeViews[0].snapshot?.workspaces[0] ?? null,
+        { "bridge-a": "workspace-a" },
+        false,
+        false,
+      ).map((entry) => entry.note.note_id),
+    ).toEqual(["unresolved-other-space", "active-linked"]);
+
+    expect(
+      buildVisibleScopedNotes(
+        bridgeViews,
+        notesState("bridge-a", "store-1", notes),
+        "bridge-a",
+        "selected",
+        "space",
+        bridgeViews[0].snapshot?.workspaces[0] ?? null,
+        { "bridge-a": "workspace-a" },
+        true,
+        true,
+      ).map((entry) => entry.note.note_id),
+    ).toEqual(["deleted", "archived", "unresolved-other-space", "active-linked"]);
+  });
+
+  it("dedupes all-host notes when two bridge profiles point at the same store", () => {
+    const bridgeViews = [
+      bridgeView(
+        "bridge-a",
+        bridgeSnapshot("workspace-a", "tab-a", pane("pane-a", "workspace-a", "tab-a")),
+      ),
+      bridgeView(
+        "bridge-b",
+        bridgeSnapshot("workspace-a", "tab-a", pane("pane-a", "workspace-a", "tab-a")),
+      ),
+    ];
+
+    expect(
+      buildVisibleScopedNotes(
+        bridgeViews,
+        {
+          ...notesState("bridge-a", "shared-store", [note("a", "workspace-a", "linked")]),
+          ...notesState("bridge-b", "shared-store", [note("b", "workspace-a", "linked")]),
+        },
+        "bridge-a",
+        "all",
+        "all",
+        null,
+        {},
+        false,
+        false,
+      ).map((entry) => `${entry.bridgeId}:${entry.note.note_id}`),
+    ).toEqual(["bridge-a:a"]);
+  });
 });
 
 function entry(
@@ -390,5 +465,59 @@ function bridgeSnapshot(workspaceId: string, tabId: string, paneInfo: PaneInfo):
     tabs: [tabInfo],
     panes: [paneInfo],
     layouts: [],
+  };
+}
+
+function notesState(bridgeId: string, storeId: string, notes: PaneNote[]) {
+  return {
+    [bridgeId]: {
+      connectionKey: bridgeId,
+      response: {
+        store_id: storeId,
+        session_key: "session:default",
+        notes,
+      },
+      loadState: "ready" as const,
+      error: null,
+    },
+  };
+}
+
+function note(
+  noteId: string,
+  workspaceId: string,
+  linkState: PaneNote["link_state"],
+): PaneNote {
+  const paneId = `${workspaceId}-pane`;
+  return {
+    note_id: noteId,
+    title: noteId,
+    body: "",
+    created_at: "100",
+    updated_at:
+      noteId === "deleted"
+        ? "600"
+        : noteId === "archived"
+          ? "500"
+          : noteId === "unresolved-other-space"
+            ? "300"
+            : "200",
+    session_key: "session:default",
+    attachment: {
+      type: "pane",
+      pane_id: paneId,
+      workspace_id: workspaceId,
+      tab_id: "tab-a",
+      terminal_id: `${paneId}-terminal`,
+      captured_at: "100",
+      context: {},
+    },
+    attachment_history: [],
+    revision: 1,
+    link_state: linkState,
+    resolved_pane:
+      linkState === "linked"
+        ? pane(paneId, workspaceId, "tab-a")
+        : undefined,
   };
 }

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -423,6 +423,17 @@ describe("App multi-bridge helpers", () => {
         serverRevision: 1,
       }),
     ).toBe(false);
+    expect(
+      shouldBlockDirtyNoteAutosave({
+        dirty: true,
+        title: "Continued title",
+        body: "Continued typing",
+        baseRevision: 2,
+        serverTitle: "Saved title",
+        serverBody: "Saved body",
+        serverRevision: 2,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -5,6 +5,7 @@ import {
   noteDraftStorageKey,
   buildVisibleScopedWorkspaces,
   buildVisibleTabEntries,
+  isInFlightNoteSaveVisible,
   nextVisibleAgentPaneEntry,
   nextVisibleTabEntry,
   resolveInitialSelectedBridgeId,
@@ -432,6 +433,43 @@ describe("App multi-bridge helpers", () => {
         serverTitle: "Saved title",
         serverBody: "Saved body",
         serverRevision: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("recognizes the user's in-flight note save when a refetch exposes it", () => {
+    const inFlight = {
+      noteIdentity: "note-key",
+      expectedRevision: 5,
+      title: "Saved title",
+      body: "Saved body",
+    };
+
+    expect(
+      isInFlightNoteSaveVisible({
+        inFlight,
+        noteIdentity: "note-key",
+        serverTitle: "Saved title",
+        serverBody: "Saved body",
+        serverRevision: 6,
+      }),
+    ).toBe(true);
+    expect(
+      isInFlightNoteSaveVisible({
+        inFlight,
+        noteIdentity: "note-key",
+        serverTitle: "Remote title",
+        serverBody: "Saved body",
+        serverRevision: 6,
+      }),
+    ).toBe(false);
+    expect(
+      isInFlightNoteSaveVisible({
+        inFlight,
+        noteIdentity: "note-key",
+        serverTitle: "Saved title",
+        serverBody: "Saved body",
+        serverRevision: 5,
       }),
     ).toBe(false);
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1578,12 +1578,13 @@ export function App() {
       throw new Error("Bridge is not ready");
     }
     try {
-      await updateNote(runtime.httpUrl, entry.note.note_id, {
+      const savedNote = await updateNote(runtime.httpUrl, entry.note.note_id, {
         title,
         body,
         expectedRevision,
       });
       await refreshBridgeNotes(runtime, false);
+      return savedNote.revision;
     } catch (caught) {
       setError(
         isNotesConflictError(caught)
@@ -4605,7 +4606,7 @@ function NotesSurface({
     title: string,
     body: string,
     expectedRevision: number,
-  ) => Promise<void>;
+  ) => Promise<number>;
   onAttachToCurrentPane: (entry: ScopedNoteEntry) => void;
   onDetach: (entry: ScopedNoteEntry) => void;
   onArchive: (entry: ScopedNoteEntry) => void;
@@ -4786,7 +4787,7 @@ function NoteEditor({
     title: string,
     body: string,
     expectedRevision: number,
-  ) => Promise<void>;
+  ) => Promise<number>;
   onAttachToCurrentPane: (entry: ScopedNoteEntry) => void;
   onDetach: (entry: ScopedNoteEntry) => void;
   onArchive: (entry: ScopedNoteEntry) => void;
@@ -4919,8 +4920,9 @@ function NoteEditor({
     const timer = window.setTimeout(() => {
       setSaveState("saving");
       void onSave(entry, title, body, expectedRevision)
-        .then(() => {
+        .then((savedRevision) => {
           if (!cancelled) {
+            setBaseRevision(savedRevision);
             setSaveState("saved");
           }
         })
@@ -4966,9 +4968,9 @@ function NoteEditor({
     saveBlockedRef.current = false;
     setSaveState("saving");
     void onSave(entry, title, body, entry.note.revision)
-      .then(() => {
+      .then((savedRevision) => {
         clearNoteDraft(entry);
-        setBaseRevision(entry.note.revision);
+        setBaseRevision(savedRevision);
         setSaveState("saved");
       })
       .catch((caught) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,12 +1,19 @@
 import {
   ChevronLeft,
+  Archive,
+  Link2,
   MoreVertical,
   PanelLeft,
   Plus,
   RefreshCw,
+  RotateCcw,
   Settings,
   SplitSquareHorizontal,
   SplitSquareVertical,
+  StickyNote,
+  Trash2,
+  Unlink,
+  X,
 } from "lucide-react";
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, Dispatch, MutableRefObject, SetStateAction } from "react";
@@ -53,6 +60,20 @@ import type {
   MobileTouchSelectionEndpointTimeoutMs,
 } from "./mobileTerminalPrefs";
 import { addNativeBackHandler, addNativeKeyboardHideHandler, isNativeAndroid } from "./native";
+import {
+  archiveNote,
+  attachNote,
+  compareNotes,
+  createNote,
+  deleteNote,
+  detachNote,
+  fetchNotes,
+  notesForPane,
+  restoreNote,
+  supportsNotes,
+  updateNote,
+} from "./notes";
+import type { NotesListResponse, PaneNote } from "./notes";
 import { ActionMenu, ConfirmDialog, RenameDialog, useLongPress } from "./overlays";
 import type { MenuItem } from "./overlays";
 import { createSnapshotRefreshController } from "./refreshCoordinator";
@@ -101,7 +122,7 @@ import type {
 type LoadState = "loading" | "ready" | "error";
 type Scope = "space" | "all";
 type HostScope = "selected" | "all";
-type SidebarView = "agents" | "tabs";
+type SidebarView = "agents" | "tabs" | "notes";
 type AgentSort = "attention" | "status" | "workspace";
 type AgentGroup = "none" | "host" | "workspace" | "hostWorkspace";
 type MenuKind = "space" | "tab" | "pane";
@@ -109,6 +130,11 @@ type ScopedPaneRef = {
   bridgeId: BridgeId;
   paneId: string;
 };
+type ScopedNoteRef = {
+  bridgeId: BridgeId;
+  noteId: string;
+};
+type MobileNotesScreen = "list" | "editor";
 type ScopedWorkspaceRef = {
   bridgeId: BridgeId;
   workspaceId: string;
@@ -125,6 +151,12 @@ type BridgeConnectionState = {
   connectionKey: string;
   snapshot: Snapshot | null;
   loadState: LoadState;
+};
+type BridgeNotesState = {
+  connectionKey: string;
+  response: NotesListResponse | null;
+  loadState: LoadState;
+  error: string | null;
 };
 type BridgeConnectionRef = {
   connectionKey: string;
@@ -158,6 +190,16 @@ type ScopedTabWorkspace = ScopedWorkspace & {
 export type ScopedTabEntry = ScopedWorkspace & {
   tab: TabInfo;
   panes: PaneInfo[];
+};
+export type ScopedNoteEntry = {
+  bridgeId: BridgeId;
+  bridgeIndex: number;
+  bridgeLabel: string;
+  bridgeColor: string;
+  note: PaneNote;
+  snapshot: Snapshot | null;
+  workspace?: WorkspaceInfo;
+  pane?: PaneInfo;
 };
 type ScopedAgentGroup = {
   key: string;
@@ -294,7 +336,9 @@ function parseDisplayPrefsValue(
         : fallback.hostScope,
     scope: parsed.scope === "all" || parsed.scope === "space" ? parsed.scope : fallback.scope,
     sidebarView:
-      parsed.sidebarView === "agents" || parsed.sidebarView === "tabs"
+      parsed.sidebarView === "agents" ||
+      parsed.sidebarView === "tabs" ||
+      parsed.sidebarView === "notes"
         ? parsed.sidebarView
         : fallback.sidebarView,
     agentSort:
@@ -383,7 +427,9 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
           : fallback.hostScope,
       scope: parsed.scope === "all" || parsed.scope === "space" ? parsed.scope : fallback.scope,
       sidebarView:
-        parsed.sidebarView === "agents" || parsed.sidebarView === "tabs"
+        parsed.sidebarView === "agents" ||
+        parsed.sidebarView === "tabs" ||
+        parsed.sidebarView === "notes"
           ? parsed.sidebarView
           : fallback.sidebarView,
       agentSort:
@@ -551,9 +597,15 @@ export function App() {
   const legacySelectionPrefs = useMemo(readLegacyDisplaySelectionPrefs, []);
   const [displayPrefsLoaded, setDisplayPrefsLoaded] = useState(() => !isNativeApp());
   const [connectionStates, setConnectionStates] = useState<Record<string, BridgeConnectionState>>({});
+  const [notesStates, setNotesStates] = useState<Record<string, BridgeNotesState>>({});
   const [selectedBridgeId, setSelectedBridgeId] = useState<BridgeId | null>(
     initialPrefs.selectedBridgeId,
   );
+  const [selectedNoteRef, setSelectedNoteRef] = useState<ScopedNoteRef | null>(null);
+  const [notesPanelOpen, setNotesPanelOpen] = useState(false);
+  const [mobileNotesScreen, setMobileNotesScreen] = useState<MobileNotesScreen>("list");
+  const [notesIncludeArchived, setNotesIncludeArchived] = useState(false);
+  const [notesIncludeDeleted, setNotesIncludeDeleted] = useState(false);
   const [selectedPaneRefState, setSelectedPaneRefState] = useState<ScopedPaneRef | null>(
     initialPrefs.selectedPane,
   );
@@ -681,6 +733,14 @@ export function App() {
 
   useEffect(() => {
     return addNativeBackHandler(() => {
+      if (notesPanelOpen) {
+        if (isCompactLayout && mobileNotesScreen === "editor") {
+          setMobileNotesScreen("list");
+          return true;
+        }
+        setNotesPanelOpen(false);
+        return true;
+      }
       if (backendSettingsOpen) {
         setBackendSettingsOpen(false);
         return true;
@@ -699,7 +759,15 @@ export function App() {
       }
       return false;
     });
-  }, [backendSettingsOpen, dialog, launchTarget, menu]);
+  }, [
+    backendSettingsOpen,
+    dialog,
+    isCompactLayout,
+    launchTarget,
+    menu,
+    mobileNotesScreen,
+    notesPanelOpen,
+  ]);
 
   const bridgeViews = useMemo<BridgeConnectionView[]>(
     () =>
@@ -1111,6 +1179,18 @@ export function App() {
       }
       return changed ? next : current;
     });
+    setNotesStates((current) => {
+      let changed = false;
+      const next: Record<string, BridgeNotesState> = {};
+      for (const [bridgeId, state] of Object.entries(current)) {
+        if (activeBridgeIds.has(bridgeId)) {
+          next[bridgeId] = state;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
   }, [bridge.enabledRuntimes]);
 
   useEffect(() => {
@@ -1157,6 +1237,15 @@ export function App() {
     () => snapshot?.panes.find((pane) => pane.pane_id === resolvedPaneId) ?? null,
     [snapshot, resolvedPaneId],
   );
+  const selectedNotesState =
+    selectedRuntime && notesStates[selectedRuntime.id]?.connectionKey === selectedRuntime.connectionKey
+      ? notesStates[selectedRuntime.id]
+      : null;
+  const selectedBridgeNotes = selectedNotesState?.response?.notes ?? [];
+  const selectedPaneNotes = useMemo(
+    () => notesForPane(selectedBridgeNotes, selectedPane?.pane_id),
+    [selectedBridgeNotes, selectedPane?.pane_id],
+  );
   const selectedPaneMenuPress = useLongPress((x, y) => {
     if (selectedPane && selectedRuntime) {
       setMenu({
@@ -1194,6 +1283,54 @@ export function App() {
       null
     );
   }, [snapshot, activeWorkspaceId, selectedPane]);
+  const visibleNotes = useMemo(
+    () =>
+      buildVisibleScopedNotes(
+        bridgeViews,
+        notesStates,
+        selectedRuntime?.id ?? null,
+        hostScope,
+        scope,
+        activeSpace,
+        activeWorkspacesByBridgeId,
+        notesIncludeArchived,
+        notesIncludeDeleted,
+      ),
+    [
+      activeSpace,
+      activeWorkspacesByBridgeId,
+      bridgeViews,
+      hostScope,
+      notesStates,
+      notesIncludeArchived,
+      notesIncludeDeleted,
+      scope,
+      selectedRuntime?.id,
+    ],
+  );
+  const allScopedNotes = useMemo(
+    () =>
+      buildVisibleScopedNotes(
+        bridgeViews,
+        notesStates,
+        null,
+        "all",
+        "all",
+        null,
+        {},
+        true,
+        true,
+        false,
+      ),
+    [bridgeViews, notesStates],
+  );
+  const selectedScopedNote = useMemo(
+    () =>
+      selectedNoteRef
+        ? findScopedNote(allScopedNotes, selectedNoteRef, false)
+        : (visibleNotes[0] ?? null),
+    [allScopedNotes, selectedNoteRef, visibleNotes],
+  );
 
   // The active tab's split layout, normalized to fractions of the tab area so we
   // can reproduce the herdr split geometry in the browser. Null when the tab has
@@ -1354,6 +1491,177 @@ export function App() {
   const focusPane = (bridgeId: BridgeId, pane: PaneInfo) => {
     openPane(bridgeId, pane);
     requestTerminalFocus();
+  };
+
+  const selectNote = (bridgeId: BridgeId, noteId: string) => {
+    setSelectedNoteRef({ bridgeId, noteId });
+    if (isCompactLayout) {
+      setMobileNotesScreen("editor");
+    }
+    setNotesPanelOpen(true);
+  };
+
+  const openNotesPanel = () => {
+    setMobileNotesScreen("list");
+    if (!selectedNoteRef && selectedRuntime && selectedPaneNotes.length > 0) {
+      setSelectedNoteRef({
+        bridgeId: selectedRuntime.id,
+        noteId: selectedPaneNotes[0].note_id,
+      });
+    }
+    setNotesPanelOpen(true);
+  };
+
+  const createNoteForCurrentPane = async () => {
+    if (!selectedRuntime || !selectedPane || !supportsNotes(selectedRuntime.capabilities)) {
+      setError("Notes are not available for this bridge");
+      return;
+    }
+    try {
+      const note = await createNote(selectedRuntime.httpUrl, {
+        title: "Untitled note",
+        body: "",
+        paneId: selectedPane.pane_id,
+      });
+      setSelectedNoteRef({ bridgeId: selectedRuntime.id, noteId: note.note_id });
+      if (isCompactLayout) {
+        setMobileNotesScreen("editor");
+      }
+      setNotesPanelOpen(true);
+      await refreshBridgeNotes(selectedRuntime, false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not create note");
+    }
+  };
+
+  const createDetachedBridgeNote = async (bridgeId = selectedRuntime?.id ?? null) => {
+    const runtime = bridgeId ? bridge.getRuntime(bridgeId) : null;
+    if (!runtime || !supportsNotes(runtime.capabilities)) {
+      setError("Notes are not available for this bridge");
+      return;
+    }
+    try {
+      const note = await createNote(runtime.httpUrl, {
+        title: "Untitled note",
+        body: "",
+      });
+      setSelectedNoteRef({ bridgeId: runtime.id, noteId: note.note_id });
+      if (isCompactLayout) {
+        setMobileNotesScreen("editor");
+      }
+      setNotesPanelOpen(true);
+      await refreshBridgeNotes(runtime, false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not create note");
+    }
+  };
+
+  const saveScopedNote = async (entry: ScopedNoteEntry, title: string, body: string) => {
+    const runtime = bridge.getRuntime(entry.bridgeId);
+    if (!runtime) {
+      setError("Bridge is not ready");
+      throw new Error("Bridge is not ready");
+    }
+    try {
+      await updateNote(runtime.httpUrl, entry.note.note_id, {
+        title,
+        body,
+        expectedRevision: entry.note.revision,
+      });
+      await refreshBridgeNotes(runtime, false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not save note");
+      await refreshBridgeNotes(runtime, false);
+      throw caught;
+    }
+  };
+
+  const attachScopedNoteToCurrentPane = async (entry: ScopedNoteEntry) => {
+    if (!selectedRuntime || !selectedPane || selectedRuntime.id !== entry.bridgeId) {
+      setError("Select a pane on the same bridge first");
+      return;
+    }
+    try {
+      await attachNote(selectedRuntime.httpUrl, entry.note.note_id, {
+        paneId: selectedPane.pane_id,
+        expectedRevision: entry.note.revision,
+      });
+      await refreshBridgeNotes(selectedRuntime, false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not attach note");
+    }
+  };
+
+  const detachScopedNote = async (entry: ScopedNoteEntry) => {
+    const runtime = bridge.getRuntime(entry.bridgeId);
+    if (!runtime) {
+      setError("Bridge is not ready");
+      return;
+    }
+    try {
+      await detachNote(runtime.httpUrl, entry.note.note_id, {
+        expectedRevision: entry.note.revision,
+      });
+      await refreshBridgeNotes(runtime, false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not detach note");
+    }
+  };
+
+  const archiveScopedNote = async (entry: ScopedNoteEntry) => {
+    const runtime = bridge.getRuntime(entry.bridgeId);
+    if (!runtime) {
+      setError("Bridge is not ready");
+      return;
+    }
+    try {
+      await archiveNote(runtime.httpUrl, entry.note.note_id, {
+        expectedRevision: entry.note.revision,
+      });
+      await refreshBridgeNotes(runtime, false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not archive note");
+    }
+  };
+
+  const restoreScopedNote = async (entry: ScopedNoteEntry) => {
+    const runtime = bridge.getRuntime(entry.bridgeId);
+    if (!runtime) {
+      setError("Bridge is not ready");
+      return;
+    }
+    try {
+      await restoreNote(runtime.httpUrl, entry.note.note_id, {
+        expectedRevision: entry.note.revision,
+      });
+      await refreshBridgeNotes(runtime, false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not restore note");
+    }
+  };
+
+  const deleteScopedNote = async (entry: ScopedNoteEntry) => {
+    const runtime = bridge.getRuntime(entry.bridgeId);
+    if (!runtime) {
+      setError("Bridge is not ready");
+      return;
+    }
+    try {
+      await deleteNote(runtime.httpUrl, entry.note.note_id, {
+        expectedRevision: entry.note.revision,
+      });
+      await refreshBridgeNotes(runtime, false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not delete note");
+    }
+  };
+
+  const viewScopedNotePane = (entry: ScopedNoteEntry) => {
+    if (!entry.pane) {
+      setError("That note is not linked to an open pane");
+      return;
+    }
+    openPane(entry.bridgeId, entry.pane);
   };
 
   useEffect(() => {
@@ -1645,6 +1953,88 @@ export function App() {
     }
   }
 
+  async function refreshBridgeNotes(runtime: BridgeRuntime, setLoading: boolean) {
+    const requestConnectionKey = runtime.connectionKey;
+    if (!runtime.canConnect || runtime.capabilityState !== "ready" || !supportsNotes(runtime.capabilities)) {
+      setNotesStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response: null,
+          loadState: "ready",
+          error: null,
+        },
+      }));
+      return null;
+    }
+    if (setLoading) {
+      setNotesStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response:
+            current[runtime.id]?.connectionKey === requestConnectionKey
+              ? current[runtime.id]?.response ?? null
+              : null,
+          loadState: "loading",
+          error: null,
+        },
+      }));
+    }
+    try {
+      const response = await fetchNotes(runtime.httpUrl, {
+        includeArchived: true,
+        includeDeleted: true,
+        includeOtherSessions: true,
+      });
+      setNotesStates((current) => {
+        if (bridge.getRuntime(runtime.id)?.connectionKey !== requestConnectionKey) {
+          return current;
+        }
+        return {
+          ...current,
+          [runtime.id]: {
+            connectionKey: requestConnectionKey,
+            response,
+            loadState: "ready",
+            error: null,
+          },
+        };
+      });
+      return response;
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : "Notes unavailable";
+      setNotesStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response:
+            current[runtime.id]?.connectionKey === requestConnectionKey
+              ? current[runtime.id]?.response ?? null
+              : null,
+          loadState: "error",
+          error: message,
+        },
+      }));
+      return null;
+    }
+  }
+
+  const refreshNotesForBridge = (bridgeId: BridgeId) => {
+    const runtime = bridge.getRuntime(bridgeId);
+    if (runtime) {
+      void refreshBridgeNotes(runtime, false);
+    }
+  };
+
+  useEffect(() => {
+    for (const runtime of bridge.enabledRuntimes) {
+      if (runtime.capabilityState === "ready" && supportsNotes(runtime.capabilities)) {
+        void refreshBridgeNotes(runtime, true);
+      }
+    }
+  }, [bridge.enabledRuntimes]);
+
   async function exec(
     runtime: BridgeRuntime | null,
     action: () => Promise<{ [key: string]: unknown }>,
@@ -1860,6 +2250,7 @@ export function App() {
           connectionRefs={connectionRefs}
           setConnectionStates={setConnectionStates}
           onPaneSelection={rememberPaneSelection}
+          onNotesChanged={refreshNotesForBridge}
         />
       ))}
       <aside className="sidebar" aria-label="Switcher">
@@ -1876,6 +2267,9 @@ export function App() {
           capabilityState={selectedRuntime?.capabilityState ?? "idle"}
           scope={scope}
           sidebarView={sidebarView}
+          notesStates={notesStates}
+          visibleNotes={visibleNotes}
+          selectedNote={selectedScopedNote}
           agentSort={agentSort}
           agentGroup={agentGroup}
           activeSpace={activeSpace}
@@ -1884,6 +2278,8 @@ export function App() {
           onHostScope={setHostScope}
           onScope={setScope}
           onSidebarView={setSidebarView}
+          onSelectNote={selectNote}
+          onCreateNote={() => void createDetachedBridgeNote()}
           onAgentSort={setAgentSort}
           onAgentGroup={setAgentGroup}
           onSelectBridge={setSelectedBridgeId}
@@ -2057,6 +2453,21 @@ export function App() {
           ) : null}
           {selectedPane ? (
             <button
+              className="icon-btn notes-button"
+              type="button"
+              aria-label="Notes"
+              title="Notes"
+              data-active={notesPanelOpen ? "true" : "false"}
+              onClick={openNotesPanel}
+            >
+              <StickyNote size={18} />
+              {selectedPaneNotes.length > 0 ? (
+                <span className="notes-count mono">{selectedPaneNotes.length}</span>
+              ) : null}
+            </button>
+          ) : null}
+          {selectedPane ? (
+            <button
               className="icon-btn"
               type="button"
               aria-label="Refit terminal"
@@ -2125,6 +2536,58 @@ export function App() {
           <div className="terminal-stage" aria-hidden="true" />
         )}
       </section>
+
+      {notesPanelOpen ? (
+        <NotesSurface
+          compact={isCompactLayout}
+          mobileScreen={mobileNotesScreen}
+          selectedEntry={selectedScopedNote}
+          selectedPane={selectedPane}
+          selectedPaneNotes={selectedRuntime ? selectedPaneNotes.map((note) => ({
+            bridgeId: selectedRuntime.id,
+            bridgeIndex: Math.max(
+              0,
+              bridgeViews.findIndex((view) => view.runtime.id === selectedRuntime.id),
+            ),
+            bridgeLabel: selectedRuntime.label,
+            bridgeColor: selectedRuntime.color,
+            note,
+            snapshot,
+            workspace: snapshot?.workspaces.find(
+              (workspace) => workspace.workspace_id === note.attachment?.workspace_id,
+            ),
+            pane: note.resolved_pane,
+          })) : []}
+          visibleNotes={visibleNotes}
+          notesLoadState={selectedNotesState?.loadState ?? "ready"}
+          notesError={selectedNotesState?.error ?? null}
+          includeArchived={notesIncludeArchived}
+          includeDeleted={notesIncludeDeleted}
+          currentBridgeSupportsNotes={Boolean(
+            selectedRuntime && supportsNotes(selectedRuntime.capabilities),
+          )}
+          canAttachToCurrentPane={Boolean(
+            selectedRuntime &&
+              selectedPane &&
+              selectedScopedNote &&
+              selectedScopedNote.bridgeId === selectedRuntime.id,
+          )}
+          onClose={() => setNotesPanelOpen(false)}
+          onMobileBackToList={() => setMobileNotesScreen("list")}
+          onSelectNote={selectNote}
+          onCreatePaneNote={() => void createNoteForCurrentPane()}
+          onCreateDetachedNote={() => void createDetachedBridgeNote()}
+          onIncludeArchived={setNotesIncludeArchived}
+          onIncludeDeleted={setNotesIncludeDeleted}
+          onSaveNote={saveScopedNote}
+          onAttachToCurrentPane={(entry) => void attachScopedNoteToCurrentPane(entry)}
+          onDetach={(entry) => void detachScopedNote(entry)}
+          onArchive={(entry) => void archiveScopedNote(entry)}
+          onRestore={(entry) => void restoreScopedNote(entry)}
+          onDelete={(entry) => void deleteScopedNote(entry)}
+          onViewPane={viewScopedNotePane}
+        />
+      ) : null}
 
       {menu && activeMenuItems.length > 0 ? (
         <ActionMenu
@@ -2243,11 +2706,13 @@ function BridgeConnectionController({
   connectionRefs,
   setConnectionStates,
   onPaneSelection,
+  onNotesChanged,
 }: {
   runtime: BridgeRuntime;
   connectionRefs: MutableRefObject<Record<string, BridgeConnectionRef>>;
   setConnectionStates: Dispatch<SetStateAction<Record<string, BridgeConnectionState>>>;
   onPaneSelection: (bridgeId: BridgeId, paneId: string, workspaceId?: string) => void;
+  onNotesChanged: (bridgeId: BridgeId) => void;
 }) {
   const httpUrlRef = useRef(runtime.httpUrl);
   const wsUrlRef = useRef(runtime.wsUrl);
@@ -2406,6 +2871,12 @@ function BridgeConnectionController({
           (item) => item.pane_id === paneId,
         );
         onPaneSelection(runtime.id, paneId, pane?.workspace_id);
+        refresh();
+        return;
+      }
+      if (isNotesChangedEvent(event)) {
+        onNotesChanged(runtime.id);
+        return;
       }
       refresh();
     });
@@ -2424,6 +2895,7 @@ function BridgeConnectionController({
     };
   }, [
     connectionRefs,
+    onNotesChanged,
     onPaneSelection,
     runtime.canConnect,
     runtime.connectionKey,
@@ -2651,6 +3123,145 @@ export function buildVisibleTabEntries(
     );
   }
   return spaceGroups.flatMap(flattenGroup);
+}
+
+export function buildVisibleScopedNotes(
+  bridgeViews: BridgeConnectionView[],
+  notesStates: Record<string, BridgeNotesState>,
+  selectedBridgeId: BridgeId | null,
+  hostScope: HostScope,
+  scope: Scope,
+  activeSpace: WorkspaceInfo | null,
+  activeWorkspacesByBridgeId: Record<string, string>,
+  includeArchived: boolean,
+  includeDeleted: boolean,
+  dedupeStores = true,
+): ScopedNoteEntry[] {
+  const hostBridgeViews = visibleHostBridgeViews(bridgeViews, selectedBridgeId, hostScope);
+  const seenStores = new Set<string>();
+  const entries = hostBridgeViews.flatMap((view) => {
+    const notesState = notesStates[view.runtime.id];
+    if (!notesState || notesState.connectionKey !== view.runtime.connectionKey) {
+      return [];
+    }
+    if (dedupeStores && hostScope === "all" && notesState.response) {
+      const storeKey = `${notesState.response.store_id}:${notesState.response.session_key}`;
+      if (seenStores.has(storeKey)) {
+        return [];
+      }
+      seenStores.add(storeKey);
+    }
+    const snapshot = view.snapshot;
+    const bridgeIndex = Math.max(
+      0,
+      bridgeViews.findIndex((candidate) => candidate.runtime.id === view.runtime.id),
+    );
+    const activeWorkspace =
+      scope === "space"
+        ? activeWorkspaceForBridgeView(
+            view,
+            selectedBridgeId,
+            activeSpace,
+            activeWorkspacesByBridgeId,
+          )
+        : null;
+    return (notesState.response?.notes ?? [])
+      .filter((note) => noteVisibleByLifecycle(note, includeArchived, includeDeleted))
+      .filter((note) => noteVisibleInScope(note, activeWorkspace))
+      .map((note) => {
+        const pane = note.resolved_pane;
+        const workspaceId = pane?.workspace_id ?? note.attachment?.workspace_id;
+        return {
+          bridgeId: view.runtime.id,
+          bridgeIndex,
+          bridgeLabel: view.runtime.label,
+          bridgeColor: view.runtime.color,
+          note,
+          snapshot,
+          workspace: workspaceId
+            ? snapshot?.workspaces.find((workspace) => workspace.workspace_id === workspaceId)
+            : undefined,
+          pane,
+        };
+      });
+  });
+  return entries.sort((a, b) => {
+    const bridge = a.bridgeIndex - b.bridgeIndex;
+    if (bridge !== 0) {
+      return bridge;
+    }
+    return compareNotes(a.note, b.note);
+  });
+}
+
+function noteVisibleByLifecycle(
+  note: PaneNote,
+  includeArchived: boolean,
+  includeDeleted: boolean,
+) {
+  if (note.deleted_at) {
+    return includeDeleted;
+  }
+  if (note.archived_at) {
+    return includeArchived;
+  }
+  return true;
+}
+
+function noteVisibleInScope(note: PaneNote, activeWorkspace: WorkspaceInfo | null) {
+  if (!activeWorkspace) {
+    return true;
+  }
+  if (note.link_state !== "linked") {
+    return true;
+  }
+  const workspaceId = note.resolved_pane?.workspace_id ?? note.attachment?.workspace_id;
+  return !workspaceId || workspaceId === activeWorkspace.workspace_id;
+}
+
+function findScopedNote(
+  entries: ScopedNoteEntry[],
+  ref: ScopedNoteRef | null,
+  fallback = true,
+) {
+  if (!ref) {
+    return fallback ? (entries[0] ?? null) : null;
+  }
+  const found = entries.find(
+    (entry) => entry.bridgeId === ref.bridgeId && entry.note.note_id === ref.noteId,
+  );
+  return found ?? (fallback ? (entries[0] ?? null) : null);
+}
+
+function noteStateLabel(note: PaneNote) {
+  if (note.deleted_at) {
+    return { label: "deleted", status: "blocked" as AgentStatus };
+  }
+  if (note.archived_at) {
+    return { label: "archived", status: "idle" as AgentStatus };
+  }
+  if (note.link_state === "linked") {
+    return { label: "linked", status: "done" as AgentStatus };
+  }
+  if (note.link_state === "unresolved") {
+    return { label: "unresolved", status: "working" as AgentStatus };
+  }
+  return { label: "detached", status: "unknown" as AgentStatus };
+}
+
+function noteSubtitle(entry: ScopedNoteEntry, showBridge: boolean) {
+  const context = entry.note.attachment?.context;
+  const paneLabel =
+    entry.pane ? paneTitle(entry.pane) : context?.pane_label || context?.pane_title;
+  const cwd = basename(context?.foreground_cwd || context?.cwd);
+  return [
+    showBridge ? entry.bridgeLabel : null,
+    entry.workspace?.label,
+    paneLabel,
+    cwd,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 export function nextVisibleAgentPaneEntry(
@@ -2954,6 +3565,9 @@ function Switcher({
   capabilityState,
   scope,
   sidebarView,
+  notesStates,
+  visibleNotes,
+  selectedNote,
   agentSort,
   agentGroup,
   activeSpace,
@@ -2962,6 +3576,8 @@ function Switcher({
   onHostScope,
   onScope,
   onSidebarView,
+  onSelectNote,
+  onCreateNote,
   onAgentSort,
   onAgentGroup,
   onSelectBridge,
@@ -2988,6 +3604,9 @@ function Switcher({
   capabilityState: "idle" | "probing" | "ready" | "error";
   scope: Scope;
   sidebarView: SidebarView;
+  notesStates: Record<string, BridgeNotesState>;
+  visibleNotes: ScopedNoteEntry[];
+  selectedNote: ScopedNoteEntry | null;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
   activeSpace: WorkspaceInfo | null;
@@ -2996,6 +3615,8 @@ function Switcher({
   onHostScope: (scope: HostScope) => void;
   onScope: (scope: Scope) => void;
   onSidebarView: (view: SidebarView) => void;
+  onSelectNote: (bridgeId: BridgeId, noteId: string) => void;
+  onCreateNote: () => void;
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
   onSelectBridge: (bridgeId: BridgeId) => void;
@@ -3061,10 +3682,20 @@ function Switcher({
           (view) => !view.snapshot && (!view.runtime.canConnect || view.loadState === "error"),
         )
       : [];
+  const notesSupported = hostBridgeViews.some((view) => supportsNotes(view.runtime.capabilities));
+  const notesLoading = hostBridgeViews.some(
+    (view) => notesStates[view.runtime.id]?.loadState === "loading",
+  );
+  const notesError = hostBridgeViews
+    .map((view) => notesStates[view.runtime.id]?.error)
+    .find((message): message is string => Boolean(message));
+  const hasNotesList =
+    sidebarView === "notes" && (notesSupported || visibleNotes.length > 0 || notesLoading || notesError);
   const hasListSnapshot =
-    hostScope === "all"
+    hasNotesList ||
+    (hostScope === "all"
       ? hostBridgeViews.some((view) => view.snapshot) || disconnectedBridgeViews.length > 0
-      : Boolean(snapshot);
+      : Boolean(snapshot));
 
   const agentPanes = useMemo<ScopedAgentPane[]>(() => {
     return buildVisibleAgentPaneEntries(
@@ -3093,14 +3724,16 @@ function Switcher({
   );
   const showGroupedHostContext = hostScope === "all";
   const showGroupControl =
-    sidebarView === "agents" || hostScope === "all" || scope === "all" || agentGroup !== "none";
-  const showOptionsControl = sidebarView === "agents" || showGroupControl;
+    sidebarView !== "notes" &&
+    (sidebarView === "agents" || hostScope === "all" || scope === "all" || agentGroup !== "none");
+  const showOptionsControl = sidebarView !== "notes" && (sidebarView === "agents" || showGroupControl);
   const canCreateTabFromHeader = Boolean(
     sidebarView === "tabs" &&
       scope === "space" &&
       activeSpace &&
       selectedBridgeId,
   );
+  const canCreateNoteFromHeader = sidebarView === "notes" && notesSupported;
 
   useEffect(() => {
     if (optionsMenu && !showOptionsControl) {
@@ -3267,6 +3900,37 @@ function Switcher({
       );
     });
   };
+  const renderNoteRows = () => {
+    if (!notesSupported) {
+      return (
+        <div className="empty">
+          <strong>Notes unavailable</strong>
+          <span>Update the selected bridge to use pane notes.</span>
+        </div>
+      );
+    }
+    if (visibleNotes.length === 0) {
+      return (
+        <div className="empty">
+          <strong>{notesLoading ? "Loading notes" : "No notes"}</strong>
+          <span>{notesError || (notesLoading ? "" : "Create a note from the terminal header.")}</span>
+        </div>
+      );
+    }
+    return visibleNotes.map((entry, index) => (
+      <NoteRow
+        key={`${entry.bridgeId}:${entry.note.note_id}`}
+        entry={entry}
+        index={index}
+        active={
+          selectedNote?.bridgeId === entry.bridgeId &&
+          selectedNote.note.note_id === entry.note.note_id
+        }
+        showBridge={hostScope === "all"}
+        onSelect={() => onSelectNote(entry.bridgeId, entry.note.note_id)}
+      />
+    ));
+  };
 
   return (
     <>
@@ -3356,6 +4020,14 @@ function Switcher({
           onClick={() => onSidebarView("tabs")}
         >
           Tabs
+        </button>
+        <button
+          type="button"
+          data-on={sidebarView === "notes"}
+          aria-pressed={sidebarView === "notes"}
+          onClick={() => onSidebarView("notes")}
+        >
+          Notes
         </button>
       </div>
       <div className="sidebar-scope" role="group" aria-label="Sidebar scope">
@@ -3498,7 +4170,8 @@ function Switcher({
             ) : null}
 
             {/* PANES ----------------------------------------------------- */}
-            {(hostScope === "all" ? hasListSnapshot : snapshot && snapshot.workspaces.length > 0) ? (
+            {sidebarView === "notes" ||
+            (hostScope === "all" ? hasListSnapshot : snapshot && snapshot.workspaces.length > 0) ? (
             <section className="sec">
               <div className="sec-head">
                 <span className="sec-label">
@@ -3506,6 +4179,10 @@ function Switcher({
                     ? scope === "all"
                       ? "all agents"
                       : "space agents"
+                    : sidebarView === "notes"
+                      ? scope === "all"
+                        ? "all notes"
+                        : "space notes"
                     : scope === "all"
                       ? "all tabs"
                       : hostScope === "all"
@@ -3528,6 +4205,17 @@ function Switcher({
                     <Plus size={14} />
                   </button>
                 ) : null}
+                {canCreateNoteFromHeader ? (
+                  <button
+                    className="sec-add"
+                    type="button"
+                    aria-label="New note"
+                    title="New note"
+                    onClick={onCreateNote}
+                  >
+                    <Plus size={14} />
+                  </button>
+                ) : null}
                 {showOptionsControl ? (
                   <button
                     className="sec-add"
@@ -3546,7 +4234,9 @@ function Switcher({
                 ) : null}
               </div>
 
-              {sidebarView === "agents" ? (
+              {sidebarView === "notes" ? (
+                renderNoteRows()
+              ) : sidebarView === "agents" ? (
                 agentPanes.length === 0 && disconnectedBridgeViews.length === 0 ? (
                   <div className="empty">
                     <strong>No detected agents</strong>
@@ -3731,6 +4421,405 @@ function SidebarOptionsMenu({
   );
 }
 
+function NotesSurface({
+  compact,
+  mobileScreen,
+  selectedEntry,
+  selectedPane,
+  selectedPaneNotes,
+  visibleNotes,
+  notesLoadState,
+  notesError,
+  includeArchived,
+  includeDeleted,
+  currentBridgeSupportsNotes,
+  canAttachToCurrentPane,
+  onClose,
+  onMobileBackToList,
+  onSelectNote,
+  onCreatePaneNote,
+  onCreateDetachedNote,
+  onIncludeArchived,
+  onIncludeDeleted,
+  onSaveNote,
+  onAttachToCurrentPane,
+  onDetach,
+  onArchive,
+  onRestore,
+  onDelete,
+  onViewPane,
+}: {
+  compact: boolean;
+  mobileScreen: MobileNotesScreen;
+  selectedEntry: ScopedNoteEntry | null;
+  selectedPane: PaneInfo | null;
+  selectedPaneNotes: ScopedNoteEntry[];
+  visibleNotes: ScopedNoteEntry[];
+  notesLoadState: LoadState;
+  notesError: string | null;
+  includeArchived: boolean;
+  includeDeleted: boolean;
+  currentBridgeSupportsNotes: boolean;
+  canAttachToCurrentPane: boolean;
+  onClose: () => void;
+  onMobileBackToList: () => void;
+  onSelectNote: (bridgeId: BridgeId, noteId: string) => void;
+  onCreatePaneNote: () => void;
+  onCreateDetachedNote: () => void;
+  onIncludeArchived: (include: boolean) => void;
+  onIncludeDeleted: (include: boolean) => void;
+  onSaveNote: (entry: ScopedNoteEntry, title: string, body: string) => Promise<void>;
+  onAttachToCurrentPane: (entry: ScopedNoteEntry) => void;
+  onDetach: (entry: ScopedNoteEntry) => void;
+  onArchive: (entry: ScopedNoteEntry) => void;
+  onRestore: (entry: ScopedNoteEntry) => void;
+  onDelete: (entry: ScopedNoteEntry) => void;
+  onViewPane: (entry: ScopedNoteEntry) => void;
+}) {
+  return (
+    <aside
+      className="notes-surface"
+      data-compact={compact ? "true" : "false"}
+      data-mobile-screen={mobileScreen}
+      role="dialog"
+      aria-label="Notes"
+    >
+      <header className="notes-head">
+        {compact && mobileScreen === "editor" ? (
+          <button
+            className="icon-btn"
+            type="button"
+            aria-label="Back to notes"
+            title="Back"
+            onClick={onMobileBackToList}
+          >
+            <ChevronLeft size={20} />
+          </button>
+        ) : null}
+        <div>
+          <span className="notes-title">Notes</span>
+          <span className="notes-sub mono">
+            {selectedPane ? paneTitle(selectedPane) : "All notes"}
+          </span>
+        </div>
+        <button className="icon-btn" type="button" aria-label="Close notes" title="Close" onClick={onClose}>
+          <X size={18} />
+        </button>
+      </header>
+      <div className="notes-shell">
+        <div className="notes-list-pane">
+          <section className="notes-section">
+            <div className="notes-section-head">
+              <span>Pane</span>
+              <button
+                className="icon-btn"
+                type="button"
+                aria-label="New pane note"
+                title="New pane note"
+                disabled={!selectedPane || !currentBridgeSupportsNotes}
+                onClick={onCreatePaneNote}
+              >
+                <Plus size={15} />
+              </button>
+            </div>
+            {selectedPaneNotes.length === 0 ? (
+              <div className="notes-empty">No notes attached to this pane</div>
+            ) : (
+              selectedPaneNotes.map((entry) => (
+                <NotesListItem
+                  key={`${entry.bridgeId}:${entry.note.note_id}`}
+                  entry={entry}
+                  active={
+                    selectedEntry?.bridgeId === entry.bridgeId &&
+                    selectedEntry.note.note_id === entry.note.note_id
+                  }
+                  onSelect={() => onSelectNote(entry.bridgeId, entry.note.note_id)}
+                />
+              ))
+            )}
+          </section>
+          <section className="notes-section">
+            <div className="notes-section-head">
+              <span>All</span>
+              <label className="notes-filter">
+                <input
+                  type="checkbox"
+                  checked={includeArchived}
+                  onChange={(event) => onIncludeArchived(event.currentTarget.checked)}
+                />
+                Archived
+              </label>
+              <label className="notes-filter">
+                <input
+                  type="checkbox"
+                  checked={includeDeleted}
+                  onChange={(event) => onIncludeDeleted(event.currentTarget.checked)}
+                />
+                Deleted
+              </label>
+              <button
+                className="icon-btn"
+                type="button"
+                aria-label="New detached note"
+                title="New detached note"
+                disabled={!currentBridgeSupportsNotes}
+                onClick={onCreateDetachedNote}
+              >
+                <Plus size={15} />
+              </button>
+            </div>
+            {notesLoadState === "loading" && visibleNotes.length === 0 ? (
+              <div className="notes-empty">Loading notes</div>
+            ) : notesError && visibleNotes.length === 0 ? (
+              <div className="notes-empty">{notesError}</div>
+            ) : visibleNotes.length === 0 ? (
+              <div className="notes-empty">No notes yet</div>
+            ) : (
+              visibleNotes.map((entry) => (
+                <NotesListItem
+                  key={`${entry.bridgeId}:${entry.note.note_id}`}
+                  entry={entry}
+                  active={
+                    selectedEntry?.bridgeId === entry.bridgeId &&
+                    selectedEntry.note.note_id === entry.note.note_id
+                  }
+                  onSelect={() => onSelectNote(entry.bridgeId, entry.note.note_id)}
+                />
+              ))
+            )}
+          </section>
+        </div>
+        <NoteEditor
+          entry={selectedEntry}
+          canAttachToCurrentPane={canAttachToCurrentPane}
+          onSave={onSaveNote}
+          onAttachToCurrentPane={onAttachToCurrentPane}
+          onDetach={onDetach}
+          onArchive={onArchive}
+          onRestore={onRestore}
+          onDelete={onDelete}
+          onViewPane={onViewPane}
+        />
+      </div>
+    </aside>
+  );
+}
+
+function NotesListItem({
+  entry,
+  active,
+  onSelect,
+}: {
+  entry: ScopedNoteEntry;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const state = noteStateLabel(entry.note);
+  return (
+    <button className="notes-list-item" type="button" data-active={active} onClick={onSelect}>
+      <span
+        className="bridge-chip-dot"
+        style={{ "--bridge-color": entry.bridgeColor } as CSSProperties}
+        aria-hidden="true"
+      />
+      <span className="notes-list-item-body">
+        <span className="notes-list-item-title">{entry.note.title || "Untitled note"}</span>
+        <span className="notes-list-item-sub mono">{noteSubtitle(entry, true)}</span>
+      </span>
+      <span className="notes-list-item-state">{state.label}</span>
+    </button>
+  );
+}
+
+function NoteEditor({
+  entry,
+  canAttachToCurrentPane,
+  onSave,
+  onAttachToCurrentPane,
+  onDetach,
+  onArchive,
+  onRestore,
+  onDelete,
+  onViewPane,
+}: {
+  entry: ScopedNoteEntry | null;
+  canAttachToCurrentPane: boolean;
+  onSave: (entry: ScopedNoteEntry, title: string, body: string) => Promise<void>;
+  onAttachToCurrentPane: (entry: ScopedNoteEntry) => void;
+  onDetach: (entry: ScopedNoteEntry) => void;
+  onArchive: (entry: ScopedNoteEntry) => void;
+  onRestore: (entry: ScopedNoteEntry) => void;
+  onDelete: (entry: ScopedNoteEntry) => void;
+  onViewPane: (entry: ScopedNoteEntry) => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [dirty, setDirty] = useState(false);
+  const [saveState, setSaveState] = useState<"idle" | "pending" | "saving" | "saved" | "error">("idle");
+  const loadedNoteIdentityRef = useRef("");
+  const saveBlockedRef = useRef(false);
+  const noteIdentity = entry ? `${entry.bridgeId}:${entry.note.note_id}` : "";
+  const noteKey = entry ? `${entry.bridgeId}:${entry.note.note_id}:${entry.note.revision}` : "";
+
+  useEffect(() => {
+    if (!entry) {
+      loadedNoteIdentityRef.current = "";
+      setTitle("");
+      setBody("");
+      setDirty(false);
+      setSaveState("idle");
+      saveBlockedRef.current = false;
+      return;
+    }
+    const noteChanged = loadedNoteIdentityRef.current !== noteIdentity;
+    if (!noteChanged && dirty && title === entry.note.title && body === entry.note.body) {
+      setDirty(false);
+      setSaveState("saved");
+      saveBlockedRef.current = false;
+      return;
+    }
+    if (noteChanged || !dirty) {
+      loadedNoteIdentityRef.current = noteIdentity;
+      setTitle(entry.note.title);
+      setBody(entry.note.body);
+      setDirty(false);
+      setSaveState("idle");
+      saveBlockedRef.current = false;
+    }
+  }, [body, dirty, entry, noteIdentity, noteKey, title]);
+
+  useEffect(() => {
+    if (!entry || !dirty) {
+      return;
+    }
+    if (title === entry.note.title && body === entry.note.body) {
+      return;
+    }
+    if (saveBlockedRef.current) {
+      return;
+    }
+    setSaveState("pending");
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      setSaveState("saving");
+      void onSave(entry, title, body)
+        .then(() => {
+          if (!cancelled) {
+            setSaveState("saved");
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            saveBlockedRef.current = true;
+            setSaveState("error");
+          }
+        });
+    }, 700);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [body, dirty, entry, onSave, title]);
+
+  if (!entry) {
+    return (
+      <div className="note-editor note-editor-empty">
+        <StickyNote size={24} />
+        <span>Select or create a note</span>
+      </div>
+    );
+  }
+
+  const note = entry.note;
+  const deleted = Boolean(note.deleted_at);
+  const archived = Boolean(note.archived_at);
+  return (
+    <div className="note-editor">
+      <div className="note-editor-toolbar">
+        <span className="note-editor-status mono">
+          {saveState === "pending"
+            ? "pending"
+            : saveState === "saving"
+              ? "saving"
+              : saveState === "saved"
+                ? "saved"
+                : saveState === "error"
+                  ? "save failed"
+                : noteStateLabel(note).label}
+        </span>
+        {note.link_state === "linked" ? (
+          <button className="icon-btn" type="button" aria-label="View pane" title="View pane" onClick={() => onViewPane(entry)}>
+            <Link2 size={16} />
+          </button>
+        ) : null}
+        {note.attachment ? (
+          <button className="icon-btn" type="button" aria-label="Detach note" title="Detach" onClick={() => onDetach(entry)}>
+            <Unlink size={16} />
+          </button>
+        ) : null}
+        <button
+          className="icon-btn"
+          type="button"
+          aria-label="Attach to current pane"
+          title="Attach to current pane"
+          disabled={!canAttachToCurrentPane}
+          onClick={() => onAttachToCurrentPane(entry)}
+        >
+          <Link2 size={16} />
+        </button>
+        {archived || deleted ? (
+          <button className="icon-btn" type="button" aria-label="Restore note" title="Restore" onClick={() => onRestore(entry)}>
+            <RotateCcw size={16} />
+          </button>
+        ) : (
+          <button className="icon-btn" type="button" aria-label="Archive note" title="Archive" onClick={() => onArchive(entry)}>
+            <Archive size={16} />
+          </button>
+        )}
+        {!deleted ? (
+          <button
+            className="icon-btn danger"
+            type="button"
+            aria-label="Delete note"
+            title="Delete"
+            onClick={() => {
+              if (window.confirm("Delete this note?")) {
+                onDelete(entry);
+              }
+            }}
+          >
+            <Trash2 size={16} />
+          </button>
+        ) : null}
+      </div>
+      <input
+        className="note-title-input"
+        value={title}
+        onChange={(event) => {
+          setTitle(event.currentTarget.value);
+          setDirty(true);
+          saveBlockedRef.current = false;
+          setSaveState("pending");
+        }}
+        placeholder="Untitled note"
+        disabled={deleted}
+      />
+      <textarea
+        className="note-body-input"
+        value={body}
+        onChange={(event) => {
+          setBody(event.currentTarget.value);
+          setDirty(true);
+          saveBlockedRef.current = false;
+          setSaveState("pending");
+        }}
+        placeholder="Write a note"
+        disabled={deleted}
+      />
+    </div>
+  );
+}
+
 function GroupHeader({
   label,
   bridgeColor,
@@ -3900,6 +4989,45 @@ function AgentRow({
           {statusLabel(pane.agent_status)}
         </span>
       ) : null}
+    </button>
+  );
+}
+
+function NoteRow({
+  entry,
+  active,
+  showBridge,
+  index,
+  onSelect,
+}: {
+  entry: ScopedNoteEntry;
+  active: boolean;
+  showBridge: boolean;
+  index: number;
+  onSelect: () => void;
+}) {
+  const state = noteStateLabel(entry.note);
+  return (
+    <button
+      className="pane-row note-row"
+      type="button"
+      data-active={active}
+      data-link={entry.note.link_state}
+      style={{ animationDelay: `${Math.min(index, 14) * 22}ms` }}
+      onClick={onSelect}
+    >
+      <span
+        className="bridge-chip-dot"
+        style={{ "--bridge-color": entry.bridgeColor } as CSSProperties}
+        aria-hidden="true"
+      />
+      <span className="pane-body">
+        <span className="pane-name">{entry.note.title || "Untitled note"}</span>
+        <span className="pane-meta mono">{noteSubtitle(entry, showBridge)}</span>
+      </span>
+      <span className="pane-word" data-status={state.status}>
+        {state.label}
+      </span>
     </button>
   );
 }
@@ -4293,6 +5421,18 @@ function selectionPaneId(event: MessageEvent) {
       : null;
   } catch {
     return null;
+  }
+}
+
+function isNotesChangedEvent(event: MessageEvent) {
+  if (typeof event.data !== "string") {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(event.data) as { type?: unknown };
+    return parsed.type === "herdr_web.notes_changed";
+  } catch {
+    return false;
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3755,16 +3755,6 @@ function noteStateLabel(note: PaneNote) {
   return { label: "detached", status: "unknown" as AgentStatus };
 }
 
-function noteLifecycleStatusLabel(note: PaneNote) {
-  if (note.deleted_at) {
-    return "deleted";
-  }
-  if (note.archived_at) {
-    return "archived";
-  }
-  return "";
-}
-
 function NoteStateIcon({
   note,
   label,
@@ -5447,6 +5437,7 @@ export function NoteEditor({
   const [saveState, setSaveState] = useState<
     "idle" | "pending" | "saving" | "saved" | "error" | "conflict"
   >("idle");
+  const [showSavedStatus, setShowSavedStatus] = useState(false);
   const [editorMode, setEditorModeState] = useState<NoteEditorMode>(() => readNoteEditorMode());
   const loadedNoteIdentityRef = useRef("");
   const saveBlockedRef = useRef(false);
@@ -5686,6 +5677,16 @@ export function NoteEditor({
     title,
   ]);
 
+  useEffect(() => {
+    if (saveState !== "saved") {
+      setShowSavedStatus(false);
+      return;
+    }
+    setShowSavedStatus(true);
+    const timer = window.setTimeout(() => setShowSavedStatus(false), 1400);
+    return () => window.clearTimeout(timer);
+  }, [saveState]);
+
   if (!entry) {
     return (
       <div className="note-editor note-editor-empty">
@@ -5703,6 +5704,18 @@ export function NoteEditor({
     entry.pane && (!attachedToCurrentPane || showCurrentPaneViewAction),
   );
   const canAttachCurrentPane = canAttachToCurrentPane && !attachedToCurrentPane;
+  const saveStatusLabel =
+    saveState === "pending"
+      ? "pending"
+      : saveState === "saving"
+        ? "saving"
+        : saveState === "saved" && showSavedStatus
+          ? "saved"
+          : saveState === "error"
+            ? "save failed"
+            : saveState === "conflict"
+              ? "conflict"
+              : null;
   const markEdited = () => {
     const expectedRevision = baseRevision ?? entry.note.revision;
     if (baseRevision === null) {
@@ -5743,19 +5756,6 @@ export function NoteEditor({
     <div className="note-editor">
       <div className="note-editor-toolbar">
         <div className="note-editor-toolbar-left">
-          <span className="note-editor-status mono">
-            {saveState === "pending"
-              ? "pending"
-              : saveState === "saving"
-                ? "saving"
-                : saveState === "saved"
-                  ? "saved"
-                  : saveState === "error"
-                    ? "save failed"
-                    : saveState === "conflict"
-                      ? "conflict"
-                  : noteLifecycleStatusLabel(note)}
-          </span>
           <div className="note-editor-mode segmented-control" role="group" aria-label="Note editor mode">
             <button
               type="button"
@@ -5858,6 +5858,11 @@ export function NoteEditor({
           disabled={deleted}
         />
       )}
+      {saveStatusLabel ? (
+        <span className="note-editor-save-status mono" data-state={saveState}>
+          {saveStatusLabel}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4053,28 +4053,30 @@ function TabBar({
       ? selectedPane.tab_id
       : activeSpace.active_tab_id;
   return (
-    <div className="tabbar" role="tablist" aria-label="Tabs">
-      {tabs.map((tab) => {
-        const label = displayTabLabel(tab, snapshot.panes);
-        return (
-          <button
-            key={tab.tab_id}
-            type="button"
-            className="tabbar-tab"
-            role="tab"
-            aria-selected={tab.tab_id === activeTabId}
-            data-active={tab.tab_id === activeTabId}
-            onClick={() => onSelectTab(tab.tab_id)}
-            onContextMenu={(event) => {
-              event.preventDefault();
-              onMenu("tab", tab.tab_id, label, event.clientX, event.clientY, canClearTabName(tab));
-            }}
-          >
-            <span className="dot" data-status={tab.agent_status} />
-            <span className="tabbar-name">{label}</span>
-          </button>
-        );
-      })}
+    <div className="tabbar">
+      <div className="tabbar-scroll" role="tablist" aria-label="Tabs">
+        {tabs.map((tab) => {
+          const label = displayTabLabel(tab, snapshot.panes);
+          return (
+            <button
+              key={tab.tab_id}
+              type="button"
+              className="tabbar-tab"
+              role="tab"
+              aria-selected={tab.tab_id === activeTabId}
+              data-active={tab.tab_id === activeTabId}
+              onClick={() => onSelectTab(tab.tab_id)}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                onMenu("tab", tab.tab_id, label, event.clientX, event.clientY, canClearTabName(tab));
+              }}
+            >
+              <span className="dot" data-status={tab.agent_status} />
+              <span className="tabbar-name">{label}</span>
+            </button>
+          );
+        })}
+      </div>
       <button
         className="tabbar-add"
         type="button"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4797,7 +4797,7 @@ function NotesListItem({
   );
 }
 
-function NoteEditor({
+export function NoteEditor({
   entry,
   canAttachToCurrentPane,
   onSave,
@@ -4827,6 +4827,7 @@ function NoteEditor({
   const [body, setBody] = useState("");
   const [dirty, setDirty] = useState(false);
   const [baseRevision, setBaseRevision] = useState<number | null>(null);
+  const [editorNoteIdentity, setEditorNoteIdentity] = useState("");
   const [saveRetryCycle, setSaveRetryCycle] = useState(0);
   const [saveState, setSaveState] = useState<
     "idle" | "pending" | "saving" | "saved" | "error" | "conflict"
@@ -4840,6 +4841,7 @@ function NoteEditor({
   useEffect(() => {
     if (!entry) {
       loadedNoteIdentityRef.current = "";
+      setEditorNoteIdentity("");
       setTitle("");
       setBody("");
       setDirty(false);
@@ -4896,6 +4898,7 @@ function NoteEditor({
     if (noteChanged) {
       const draft = readNoteDraft(entry);
       loadedNoteIdentityRef.current = noteIdentity;
+      setEditorNoteIdentity(noteIdentity);
       if (draft && (draft.title !== entry.note.title || draft.body !== entry.note.body)) {
         const hasConflict = draft.baseRevision !== entry.note.revision;
         setTitle(draft.title);
@@ -4938,6 +4941,9 @@ function NoteEditor({
 
   useEffect(() => {
     if (!entry || !dirty) {
+      return;
+    }
+    if (editorNoteIdentity !== noteIdentity) {
       return;
     }
     if (title === entry.note.title && body === entry.note.body) {
@@ -5024,7 +5030,17 @@ function NoteEditor({
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, [baseRevision, body, dirty, entry, noteIdentity, onSave, saveRetryCycle, title]);
+  }, [
+    baseRevision,
+    body,
+    dirty,
+    editorNoteIdentity,
+    entry,
+    noteIdentity,
+    onSave,
+    saveRetryCycle,
+    title,
+  ]);
 
   if (!entry) {
     return (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1939,6 +1939,10 @@ export function App() {
       return;
     }
     openPane(entry.bridgeId, entry.pane);
+    if (isCompactLayout) {
+      setMobileNotesScreen("list");
+      setNotesPanelOpen(false);
+    }
   };
 
   useEffect(() => {
@@ -5232,6 +5236,7 @@ function NotesSurface({
           currentBridgeId={selectedBridgeId}
           currentPaneId={selectedPane?.pane_id ?? null}
           canAttachToCurrentPane={canAttachToCurrentPane}
+          showCurrentPaneViewAction={compact}
           onSave={onSaveNote}
           onAttachToCurrentPane={onAttachToCurrentPane}
           onDetach={onDetach}
@@ -5276,6 +5281,7 @@ export function NoteEditor({
   currentBridgeId,
   currentPaneId,
   canAttachToCurrentPane,
+  showCurrentPaneViewAction = false,
   onSave,
   onAttachToCurrentPane,
   onDetach,
@@ -5288,6 +5294,7 @@ export function NoteEditor({
   currentBridgeId: BridgeId | null;
   currentPaneId: string | null;
   canAttachToCurrentPane: boolean;
+  showCurrentPaneViewAction?: boolean;
   onSave: (
     entry: ScopedNoteEntry,
     title: string,
@@ -5533,7 +5540,9 @@ export function NoteEditor({
   const deleted = Boolean(note.deleted_at);
   const archived = Boolean(note.archived_at);
   const attachedToCurrentPane = scopedNoteLinkedToPane(entry, currentBridgeId, currentPaneId);
-  const canViewLinkedPane = Boolean(entry.pane && !attachedToCurrentPane);
+  const canViewLinkedPane = Boolean(
+    entry.pane && (!attachedToCurrentPane || showCurrentPaneViewAction),
+  );
   const canAttachCurrentPane = canAttachToCurrentPane && !attachedToCurrentPane;
   const markEdited = () => {
     const expectedRevision = baseRevision ?? entry.note.revision;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -851,10 +851,6 @@ export function App() {
         return true;
       }
       if (notesPanelOpen) {
-        if (isCompactLayout && mobileNotesScreen === "editor") {
-          setMobileNotesScreen("list");
-          return true;
-        }
         setNotesPanelOpen(false);
         return true;
       }
@@ -880,10 +876,8 @@ export function App() {
     backendSettingsOpen,
     deletingNote,
     dialog,
-    isCompactLayout,
     launchTarget,
     menu,
-    mobileNotesScreen,
     noteDeleteTarget,
     notesPanelOpen,
   ]);
@@ -1728,13 +1722,20 @@ export function App() {
     if (!notesEnabled) {
       return;
     }
-    setMobileNotesScreen("list");
-    if (!selectedNoteRef && selectedRuntime && selectedPaneNotes.length > 0) {
+    const selectedNoteIsCurrentPaneNote =
+      selectedScopedNote &&
+      selectedRuntime &&
+      selectedScopedNote.bridgeId === selectedRuntime.id &&
+      selectedPaneNotes.some((note) => note.note_id === selectedScopedNote.note.note_id);
+    const firstPaneNote = selectedPaneNotes[0] ?? null;
+    const noteToOpen = selectedNoteIsCurrentPaneNote ? selectedScopedNote.note : firstPaneNote;
+    if (selectedRuntime && noteToOpen) {
       setSelectedNoteRef({
         bridgeId: selectedRuntime.id,
-        noteId: selectedPaneNotes[0].note_id,
+        noteId: noteToOpen.note_id,
       });
     }
+    setMobileNotesScreen(isCompactLayout && noteToOpen ? "editor" : "list");
     setNotesPanelOpen(true);
   };
 
@@ -2895,7 +2896,7 @@ export function App() {
               selectedScopedNote.bridgeId === selectedRuntime.id,
           )}
           onClose={() => setNotesPanelOpen(false)}
-          onMobileBackToList={() => setMobileNotesScreen("list")}
+          onShowNotesList={() => setMobileNotesScreen("list")}
           onSelectNote={selectNote}
           onCreatePaneNote={() => void createNoteForCurrentPane()}
           onCreateDetachedNote={() => void createDetachedBridgeNote()}
@@ -4987,7 +4988,7 @@ function NotesSurface({
   currentBridgeSupportsNotes,
   canAttachToCurrentPane,
   onClose,
-  onMobileBackToList,
+  onShowNotesList,
   onSelectNote,
   onCreatePaneNote,
   onCreateDetachedNote,
@@ -5023,7 +5024,7 @@ function NotesSurface({
   currentBridgeSupportsNotes: boolean;
   canAttachToCurrentPane: boolean;
   onClose: () => void;
-  onMobileBackToList: () => void;
+  onShowNotesList: () => void;
   onSelectNote: (bridgeId: BridgeId, noteId: string) => void;
   onCreatePaneNote: () => void;
   onCreateDetachedNote: () => void;
@@ -5104,11 +5105,11 @@ function NotesSurface({
           <button
             className="icon-btn"
             type="button"
-            aria-label="Back to notes"
-            title="Back"
-            onClick={onMobileBackToList}
+            aria-label="Show notes list"
+            title="Show notes list"
+            onClick={onShowNotesList}
           >
-            <ChevronLeft size={20} />
+            <PanelLeft size={18} />
           </button>
         ) : null}
         <div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2800,12 +2800,10 @@ export function App() {
               aria-label="Notes"
               title="Notes"
               data-active={notesPanelOpen ? "true" : "false"}
+              data-has-notes={selectedPaneNotes.length > 0 ? "true" : "false"}
               onClick={openNotesPanel}
             >
               <StickyNote size={18} />
-              {selectedPaneNotes.length > 0 ? (
-                <span className="notes-count mono">{selectedPaneNotes.length}</span>
-              ) : null}
             </button>
           ) : null}
           {selectedPane ? (
@@ -3725,6 +3723,43 @@ function noteStateLabel(note: PaneNote) {
     return { label: "unresolved", status: "working" as AgentStatus };
   }
   return { label: "detached", status: "unknown" as AgentStatus };
+}
+
+function noteLifecycleStatusLabel(note: PaneNote) {
+  if (note.deleted_at) {
+    return "deleted";
+  }
+  if (note.archived_at) {
+    return "archived";
+  }
+  return "";
+}
+
+function NoteStateIcon({
+  note,
+  label,
+  status,
+}: {
+  note: PaneNote;
+  label: string;
+  status: AgentStatus;
+}) {
+  const icon = note.deleted_at ? (
+    <Trash2 size={14} />
+  ) : note.archived_at ? (
+    <Archive size={14} />
+  ) : note.link_state === "linked" ? (
+    <SquareTerminal size={14} />
+  ) : note.link_state === "unresolved" ? (
+    <Link2 size={14} />
+  ) : (
+    <Unlink size={14} />
+  );
+  return (
+    <span className="note-state-icon" data-status={status} aria-label={label}>
+      {icon}
+    </span>
+  );
 }
 
 function noteSubtitle(entry: ScopedNoteEntry, showBridge: boolean) {
@@ -5318,7 +5353,7 @@ function NotesListItem({
         <span className="notes-list-item-title">{entry.note.title || "Untitled note"}</span>
         <span className="notes-list-item-sub mono">{noteSubtitle(entry, true)}</span>
       </span>
-      <span className="notes-list-item-state">{state.label}</span>
+      <NoteStateIcon note={entry.note} label={state.label} status={state.status} />
     </button>
   );
 }
@@ -5664,7 +5699,7 @@ export function NoteEditor({
                   ? "save failed"
                   : saveState === "conflict"
                     ? "conflict"
-                : noteStateLabel(note).label}
+                : noteLifecycleStatusLabel(note)}
         </span>
         {canViewLinkedPane ? (
           <button className="icon-btn" type="button" aria-label="View pane" title="View pane" onClick={() => onViewPane(entry)}>
@@ -5948,9 +5983,7 @@ function NoteRow({
         <span className="pane-name">{entry.note.title || "Untitled note"}</span>
         <span className="pane-meta mono">{noteSubtitle(entry, showBridge)}</span>
       </span>
-      <span className="pane-word" data-status={state.status}>
-        {state.label}
-      </span>
+      <NoteStateIcon note={entry.note} label={state.label} status={state.status} />
     </button>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,6 +68,7 @@ import {
   deleteNote,
   detachNote,
   fetchNotes,
+  isNotesConflictError,
   notesForPane,
   restoreNote,
   supportsNotes,
@@ -193,6 +194,9 @@ export type ScopedTabEntry = ScopedWorkspace & {
 };
 export type ScopedNoteEntry = {
   bridgeId: BridgeId;
+  connectionKey: string;
+  storeId: string;
+  sessionKey: string;
   bridgeIndex: number;
   bridgeLabel: string;
   bridgeColor: string;
@@ -208,6 +212,12 @@ type ScopedAgentGroup = {
   bridgeColor?: string;
   status?: AgentStatus;
   panes: ScopedAgentPane[];
+};
+type NoteDraft = {
+  title: string;
+  body: string;
+  revision: number;
+  updatedAt: number;
 };
 type MenuState = {
   kind: MenuKind;
@@ -1570,7 +1580,13 @@ export function App() {
       });
       await refreshBridgeNotes(runtime, false);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "Could not save note");
+      setError(
+        isNotesConflictError(caught)
+          ? "Note changed in another client"
+          : caught instanceof Error
+            ? caught.message
+            : "Could not save note",
+      );
       await refreshBridgeNotes(runtime, false);
       throw caught;
     }
@@ -1650,6 +1666,7 @@ export function App() {
       await deleteNote(runtime.httpUrl, entry.note.note_id, {
         expectedRevision: entry.note.revision,
       });
+      clearNoteDraft(entry);
       await refreshBridgeNotes(runtime, false);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Could not delete note");
@@ -2034,6 +2051,21 @@ export function App() {
       }
     }
   }, [bridge.enabledRuntimes]);
+
+  useEffect(() => {
+    if (!notesPanelOpen && sidebarView !== "notes") {
+      return;
+    }
+    const refresh = () => {
+      for (const runtime of bridge.enabledRuntimes) {
+        if (runtime.capabilityState === "ready" && supportsNotes(runtime.capabilities)) {
+          void refreshBridgeNotes(runtime, false);
+        }
+      }
+    };
+    const timer = window.setInterval(refresh, NOTES_REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [bridge.enabledRuntimes, notesPanelOpen, sidebarView]);
 
   async function exec(
     runtime: BridgeRuntime | null,
@@ -2545,6 +2577,9 @@ export function App() {
           selectedPane={selectedPane}
           selectedPaneNotes={selectedRuntime ? selectedPaneNotes.map((note) => ({
             bridgeId: selectedRuntime.id,
+            connectionKey: selectedRuntime.connectionKey,
+            storeId: selectedNotesState?.response?.store_id ?? "unknown-store",
+            sessionKey: selectedNotesState?.response?.session_key ?? note.session_key,
             bridgeIndex: Math.max(
               0,
               bridgeViews.findIndex((view) => view.runtime.id === selectedRuntime.id),
@@ -2678,6 +2713,8 @@ export function App() {
 }
 
 const SNAPSHOT_REFRESH_INTERVAL_MS = 10000;
+const NOTES_REFRESH_INTERVAL_MS = 15000;
+const NOTE_DRAFT_STORAGE_PREFIX = "herdr-web:note-draft:v1:";
 
 export function resolveInitialSelectedBridgeId(
   currentBridgeId: BridgeId | null,
@@ -3173,6 +3210,9 @@ export function buildVisibleScopedNotes(
         const workspaceId = pane?.workspace_id ?? note.attachment?.workspace_id;
         return {
           bridgeId: view.runtime.id,
+          connectionKey: view.runtime.connectionKey,
+          storeId: notesState.response?.store_id ?? "unknown-store",
+          sessionKey: notesState.response?.session_key ?? note.session_key,
           bridgeIndex,
           bridgeLabel: view.runtime.label,
           bridgeColor: view.runtime.color,
@@ -3262,6 +3302,61 @@ function noteSubtitle(entry: ScopedNoteEntry, showBridge: boolean) {
   ]
     .filter(Boolean)
     .join(" · ");
+}
+
+export function noteDraftStorageKey(entry: ScopedNoteEntry) {
+  return `${NOTE_DRAFT_STORAGE_PREFIX}${[
+    entry.bridgeId,
+    entry.connectionKey,
+    entry.storeId,
+    entry.sessionKey,
+    entry.note.note_id,
+  ]
+    .map((part) => encodeURIComponent(part))
+    .join(":")}`;
+}
+
+function readNoteDraft(entry: ScopedNoteEntry): NoteDraft | null {
+  try {
+    const raw = globalThis.localStorage?.getItem(noteDraftStorageKey(entry));
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<NoteDraft>;
+    if (typeof parsed.title !== "string" || typeof parsed.body !== "string") {
+      return null;
+    }
+    return {
+      title: parsed.title,
+      body: parsed.body,
+      revision: typeof parsed.revision === "number" ? parsed.revision : entry.note.revision,
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeNoteDraft(entry: ScopedNoteEntry, title: string, body: string) {
+  try {
+    const draft: NoteDraft = {
+      title,
+      body,
+      revision: entry.note.revision,
+      updatedAt: Date.now(),
+    };
+    globalThis.localStorage?.setItem(noteDraftStorageKey(entry), JSON.stringify(draft));
+  } catch {
+    // Draft persistence is best-effort; the bridge remains the durable source.
+  }
+}
+
+function clearNoteDraft(entry: ScopedNoteEntry) {
+  try {
+    globalThis.localStorage?.removeItem(noteDraftStorageKey(entry));
+  } catch {
+    // Ignore storage failures.
+  }
 }
 
 export function nextVisibleAgentPaneEntry(
@@ -4655,10 +4750,12 @@ function NoteEditor({
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [dirty, setDirty] = useState(false);
-  const [saveState, setSaveState] = useState<"idle" | "pending" | "saving" | "saved" | "error">("idle");
+  const [saveState, setSaveState] = useState<
+    "idle" | "pending" | "saving" | "saved" | "error" | "conflict"
+  >("idle");
   const loadedNoteIdentityRef = useRef("");
   const saveBlockedRef = useRef(false);
-  const noteIdentity = entry ? `${entry.bridgeId}:${entry.note.note_id}` : "";
+  const noteIdentity = entry ? noteDraftStorageKey(entry) : "";
   const noteKey = entry ? `${entry.bridgeId}:${entry.note.note_id}:${entry.note.revision}` : "";
 
   useEffect(() => {
@@ -4676,17 +4773,38 @@ function NoteEditor({
       setDirty(false);
       setSaveState("saved");
       saveBlockedRef.current = false;
+      clearNoteDraft(entry);
       return;
     }
     if (noteChanged || !dirty) {
+      const draft = readNoteDraft(entry);
       loadedNoteIdentityRef.current = noteIdentity;
-      setTitle(entry.note.title);
-      setBody(entry.note.body);
-      setDirty(false);
-      setSaveState("idle");
+      if (draft && (draft.title !== entry.note.title || draft.body !== entry.note.body)) {
+        setTitle(draft.title);
+        setBody(draft.body);
+        setDirty(true);
+        setSaveState("pending");
+      } else {
+        setTitle(entry.note.title);
+        setBody(entry.note.body);
+        setDirty(false);
+        setSaveState("idle");
+        clearNoteDraft(entry);
+      }
       saveBlockedRef.current = false;
     }
   }, [body, dirty, entry, noteIdentity, noteKey, title]);
+
+  useEffect(() => {
+    if (!entry) {
+      return;
+    }
+    if (dirty && (title !== entry.note.title || body !== entry.note.body)) {
+      writeNoteDraft(entry, title, body);
+    } else {
+      clearNoteDraft(entry);
+    }
+  }, [body, dirty, entry, title]);
 
   useEffect(() => {
     if (!entry || !dirty) {
@@ -4708,10 +4826,10 @@ function NoteEditor({
             setSaveState("saved");
           }
         })
-        .catch(() => {
+        .catch((caught) => {
           if (!cancelled) {
             saveBlockedRef.current = true;
-            setSaveState("error");
+            setSaveState(isNotesConflictError(caught) ? "conflict" : "error");
           }
         });
     }, 700);
@@ -4733,6 +4851,36 @@ function NoteEditor({
   const note = entry.note;
   const deleted = Boolean(note.deleted_at);
   const archived = Boolean(note.archived_at);
+  const markEdited = () => {
+    setDirty(true);
+    if (saveState === "conflict") {
+      writeNoteDraft(entry, title, body);
+      return;
+    }
+    saveBlockedRef.current = false;
+    setSaveState("pending");
+  };
+  const overwriteConflict = () => {
+    saveBlockedRef.current = false;
+    setSaveState("saving");
+    void onSave(entry, title, body)
+      .then(() => {
+        clearNoteDraft(entry);
+        setSaveState("saved");
+      })
+      .catch((caught) => {
+        saveBlockedRef.current = true;
+        setSaveState(isNotesConflictError(caught) ? "conflict" : "error");
+      });
+  };
+  const useServerVersion = () => {
+    setTitle(entry.note.title);
+    setBody(entry.note.body);
+    setDirty(false);
+    saveBlockedRef.current = false;
+    setSaveState("idle");
+    clearNoteDraft(entry);
+  };
   return (
     <div className="note-editor">
       <div className="note-editor-toolbar">
@@ -4745,6 +4893,8 @@ function NoteEditor({
                 ? "saved"
                 : saveState === "error"
                   ? "save failed"
+                  : saveState === "conflict"
+                    ? "conflict"
                 : noteStateLabel(note).label}
         </span>
         {note.link_state === "linked" ? (
@@ -4792,14 +4942,23 @@ function NoteEditor({
           </button>
         ) : null}
       </div>
+      {saveState === "conflict" ? (
+        <div className="note-conflict" role="alert">
+          <span>This note changed elsewhere.</span>
+          <button type="button" onClick={overwriteConflict}>
+            Overwrite
+          </button>
+          <button type="button" onClick={useServerVersion}>
+            Use server
+          </button>
+        </div>
+      ) : null}
       <input
         className="note-title-input"
         value={title}
         onChange={(event) => {
           setTitle(event.currentTarget.value);
-          setDirty(true);
-          saveBlockedRef.current = false;
-          setSaveState("pending");
+          markEdited();
         }}
         placeholder="Untitled note"
         disabled={deleted}
@@ -4809,9 +4968,7 @@ function NoteEditor({
         value={body}
         onChange={(event) => {
           setBody(event.currentTarget.value);
-          setDirty(true);
-          saveBlockedRef.current = false;
-          setSaveState("pending");
+          markEdited();
         }}
         placeholder="Write a note"
         disabled={deleted}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -148,7 +148,7 @@ export type BridgeConnectionView = {
   snapshot: Snapshot | null;
   loadState: LoadState;
 };
-type BridgeConnectionState = {
+export type BridgeConnectionState = {
   connectionKey: string;
   snapshot: Snapshot | null;
   loadState: LoadState;
@@ -159,7 +159,7 @@ type BridgeNotesState = {
   loadState: LoadState;
   error: string | null;
 };
-type BridgeConnectionRef = {
+export type BridgeConnectionRef = {
   connectionKey: string;
   snapshot: Snapshot | null;
   activityGeneration: number;
@@ -2750,7 +2750,7 @@ export function shouldCollapseHostScope(
   return storeLoaded && hostScope === "all" && enabledBridgeCount <= 1;
 }
 
-function BridgeConnectionController({
+export function BridgeConnectionController({
   runtime,
   connectionRefs,
   setConnectionStates,
@@ -2765,12 +2765,17 @@ function BridgeConnectionController({
 }) {
   const httpUrlRef = useRef(runtime.httpUrl);
   const wsUrlRef = useRef(runtime.wsUrl);
+  const onNotesChangedRef = useRef(onNotesChanged);
   const refreshOffsetRef = useRef(stableBridgeRefreshOffsetMs(runtime.id));
 
   useEffect(() => {
     httpUrlRef.current = runtime.httpUrl;
     wsUrlRef.current = runtime.wsUrl;
   }, [runtime.httpUrl, runtime.wsUrl]);
+
+  useEffect(() => {
+    onNotesChangedRef.current = onNotesChanged;
+  }, [onNotesChanged]);
 
   useEffect(() => {
     let disposed = false;
@@ -2924,7 +2929,7 @@ function BridgeConnectionController({
         return;
       }
       if (isNotesChangedEvent(event)) {
-        onNotesChanged(runtime.id);
+        onNotesChangedRef.current(runtime.id);
         return;
       }
       refresh();
@@ -2944,7 +2949,6 @@ function BridgeConnectionController({
     };
   }, [
     connectionRefs,
-    onNotesChanged,
     onPaneSelection,
     runtime.canConnect,
     runtime.connectionKey,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1736,6 +1736,10 @@ export function App() {
     if (!notesEnabled) {
       return;
     }
+    if (notesPanelOpen) {
+      setNotesPanelOpen(false);
+      return;
+    }
     const selectedNoteIsCurrentPaneNote =
       selectedScopedNote &&
       selectedRuntime &&

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -260,6 +260,7 @@ type DisplayPrefs = {
   notesListPaneWidth: number;
   notesListPaneCollapsed: boolean;
   notesEnabled: boolean;
+  notesPanelOpen: boolean;
   sidebarOpen: boolean;
   selectedBridgeId: BridgeId | null;
   selectedPane: ScopedPaneRef | null;
@@ -312,6 +313,7 @@ function readDisplayPrefs(): DisplayPrefs {
     notesListPaneWidth: DEFAULT_NOTES_LIST_PANE_WIDTH,
     notesListPaneCollapsed: true,
     notesEnabled: true,
+    notesPanelOpen: false,
     sidebarOpen: true,
     selectedBridgeId: null,
     selectedPane: null,
@@ -413,6 +415,8 @@ function parseDisplayPrefsValue(
         : fallback.notesListPaneCollapsed,
     notesEnabled:
       typeof parsed.notesEnabled === "boolean" ? parsed.notesEnabled : fallback.notesEnabled,
+    notesPanelOpen:
+      typeof parsed.notesPanelOpen === "boolean" ? parsed.notesPanelOpen : fallback.notesPanelOpen,
     sidebarOpen,
     selectedBridgeId:
       typeof parsed.selectedBridgeId === "string" ? parsed.selectedBridgeId : fallback.selectedBridgeId,
@@ -521,6 +525,10 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
           : fallback.notesListPaneCollapsed,
       notesEnabled:
         typeof parsed.notesEnabled === "boolean" ? parsed.notesEnabled : fallback.notesEnabled,
+      notesPanelOpen:
+        typeof parsed.notesPanelOpen === "boolean"
+          ? parsed.notesPanelOpen
+          : fallback.notesPanelOpen,
       sidebarOpen,
       terminalFontSizePx: parseTerminalFontSizePx(parsed.terminalFontSizePx),
       terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
@@ -697,7 +705,9 @@ export function App() {
     initialPrefs.selectedBridgeId,
   );
   const [selectedNoteRef, setSelectedNoteRef] = useState<ScopedNoteRef | null>(null);
-  const [notesPanelOpen, setNotesPanelOpen] = useState(false);
+  const [notesPanelOpen, setNotesPanelOpen] = useState(
+    initialPrefs.notesEnabled && initialPrefs.notesPanelOpen,
+  );
   const [mobileNotesScreen, setMobileNotesScreen] = useState<MobileNotesScreen>("list");
   const [notesIncludeArchived, setNotesIncludeArchived] = useState(false);
   const [notesIncludeDeleted, setNotesIncludeDeleted] = useState(false);
@@ -816,6 +826,7 @@ export function App() {
       setNotesListPaneWidth(prefs.notesListPaneWidth);
       setNotesListPaneCollapsed(prefs.notesListPaneCollapsed);
       setNotesEnabled(prefs.notesEnabled);
+      setNotesPanelOpen(prefs.notesEnabled && prefs.notesPanelOpen);
       setSidebarOpen(prefs.sidebarOpen);
       setSelectedBridgeId(prefs.selectedBridgeId);
       setSelectedPaneRefState(prefs.selectedPane);
@@ -1124,6 +1135,7 @@ export function App() {
       notesListPaneWidth,
       notesListPaneCollapsed,
       notesEnabled,
+      notesPanelOpen,
       sidebarOpen,
       selectedBridgeId,
       selectedPane: selectedPaneRefState,
@@ -1156,6 +1168,7 @@ export function App() {
     notesListPaneWidth,
     notesListPaneCollapsed,
     notesEnabled,
+    notesPanelOpen,
     sidebarOpen,
     selectedBridgeId,
     selectedPaneRefState,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,13 +10,20 @@ import {
   Settings,
   SplitSquareHorizontal,
   SplitSquareVertical,
+  SquareTerminal,
   StickyNote,
   Trash2,
   Unlink,
   X,
 } from "lucide-react";
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import type { CSSProperties, Dispatch, MutableRefObject, SetStateAction } from "react";
+import type {
+  CSSProperties,
+  Dispatch,
+  KeyboardEvent as ReactKeyboardEvent,
+  MutableRefObject,
+  SetStateAction,
+} from "react";
 import { Capacitor } from "@capacitor/core";
 import { Preferences } from "@capacitor/preferences";
 import { AgentIcon, agentIconKind } from "./AgentIcon";
@@ -249,6 +256,10 @@ type DisplayPrefs = {
   agentSort: AgentSort;
   agentGroup: AgentGroup;
   sidebarWidth: number;
+  notesPanelWidth: number;
+  notesListPaneWidth: number;
+  notesListPaneCollapsed: boolean;
+  notesEnabled: boolean;
   sidebarOpen: boolean;
   selectedBridgeId: BridgeId | null;
   selectedPane: ScopedPaneRef | null;
@@ -282,6 +293,12 @@ const MOBILE_DETAIL_HISTORY_KEY = "herdrWebMobileDetail";
 const DEFAULT_SIDEBAR_WIDTH = 320;
 const MIN_SIDEBAR_WIDTH = 260;
 const MAX_SIDEBAR_WIDTH = 560;
+const DEFAULT_NOTES_PANEL_WIDTH = 560;
+const MIN_NOTES_PANEL_WIDTH = 420;
+const MAX_NOTES_PANEL_WIDTH = 840;
+const DEFAULT_NOTES_LIST_PANE_WIDTH = 240;
+const MIN_NOTES_LIST_PANE_WIDTH = 200;
+const MAX_NOTES_LIST_PANE_WIDTH = 420;
 
 function readDisplayPrefs(): DisplayPrefs {
   const fallback: DisplayPrefs = {
@@ -291,6 +308,10 @@ function readDisplayPrefs(): DisplayPrefs {
     agentSort: "attention",
     agentGroup: "none",
     sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+    notesPanelWidth: DEFAULT_NOTES_PANEL_WIDTH,
+    notesListPaneWidth: DEFAULT_NOTES_LIST_PANE_WIDTH,
+    notesListPaneCollapsed: true,
+    notesEnabled: true,
     sidebarOpen: true,
     selectedBridgeId: null,
     selectedPane: null,
@@ -345,6 +366,16 @@ function parseDisplayPrefsValue(
   parsed: Partial<DisplayPrefs> & { mobileTouchSelection?: unknown },
   fallback: DisplayPrefs,
 ): DisplayPrefs {
+  const sidebarWidth =
+    typeof parsed.sidebarWidth === "number"
+      ? clampSidebarWidth(parsed.sidebarWidth)
+      : fallback.sidebarWidth;
+  const sidebarOpen =
+    typeof parsed.sidebarOpen === "boolean" ? parsed.sidebarOpen : fallback.sidebarOpen;
+  const notesPanelWidth =
+    typeof parsed.notesPanelWidth === "number"
+      ? clampNotesPanelWidth(parsed.notesPanelWidth, sidebarWidth, sidebarOpen)
+      : fallback.notesPanelWidth;
   return {
     hostScope:
       parsed.hostScope === "selected" || parsed.hostScope === "all"
@@ -370,12 +401,19 @@ function parseDisplayPrefsValue(
       parsed.agentGroup === "hostWorkspace"
         ? parsed.agentGroup
         : fallback.agentGroup,
-    sidebarWidth:
-      typeof parsed.sidebarWidth === "number"
-        ? clampSidebarWidth(parsed.sidebarWidth)
-        : fallback.sidebarWidth,
-    sidebarOpen:
-      typeof parsed.sidebarOpen === "boolean" ? parsed.sidebarOpen : fallback.sidebarOpen,
+    sidebarWidth,
+    notesPanelWidth,
+    notesListPaneWidth:
+      typeof parsed.notesListPaneWidth === "number"
+        ? clampNotesListPaneWidth(parsed.notesListPaneWidth, notesPanelWidth)
+        : fallback.notesListPaneWidth,
+    notesListPaneCollapsed:
+      typeof parsed.notesListPaneCollapsed === "boolean"
+        ? parsed.notesListPaneCollapsed
+        : fallback.notesListPaneCollapsed,
+    notesEnabled:
+      typeof parsed.notesEnabled === "boolean" ? parsed.notesEnabled : fallback.notesEnabled,
+    sidebarOpen,
     selectedBridgeId:
       typeof parsed.selectedBridgeId === "string" ? parsed.selectedBridgeId : fallback.selectedBridgeId,
     selectedPane: parseScopedPaneRef(parsed.selectedPane),
@@ -435,6 +473,16 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
       selectedPaneId?: unknown;
       mobileTouchSelection?: unknown;
     } & Partial<DisplayPrefs>;
+    const sidebarWidth =
+      typeof parsed.sidebarWidth === "number"
+        ? clampSidebarWidth(parsed.sidebarWidth)
+        : fallback.sidebarWidth;
+    const sidebarOpen =
+      typeof parsed.sidebarOpen === "boolean" ? parsed.sidebarOpen : fallback.sidebarOpen;
+    const notesPanelWidth =
+      typeof parsed.notesPanelWidth === "number"
+        ? clampNotesPanelWidth(parsed.notesPanelWidth, sidebarWidth, sidebarOpen)
+        : fallback.notesPanelWidth;
     return {
       ...fallback,
       hostScope:
@@ -461,12 +509,19 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
         parsed.agentGroup === "hostWorkspace"
           ? parsed.agentGroup
           : fallback.agentGroup,
-      sidebarWidth:
-        typeof parsed.sidebarWidth === "number"
-          ? clampSidebarWidth(parsed.sidebarWidth)
-          : fallback.sidebarWidth,
-      sidebarOpen:
-        typeof parsed.sidebarOpen === "boolean" ? parsed.sidebarOpen : fallback.sidebarOpen,
+      sidebarWidth,
+      notesPanelWidth,
+      notesListPaneWidth:
+        typeof parsed.notesListPaneWidth === "number"
+          ? clampNotesListPaneWidth(parsed.notesListPaneWidth, notesPanelWidth)
+          : fallback.notesListPaneWidth,
+      notesListPaneCollapsed:
+        typeof parsed.notesListPaneCollapsed === "boolean"
+          ? parsed.notesListPaneCollapsed
+          : fallback.notesListPaneCollapsed,
+      notesEnabled:
+        typeof parsed.notesEnabled === "boolean" ? parsed.notesEnabled : fallback.notesEnabled,
+      sidebarOpen,
       terminalFontSizePx: parseTerminalFontSizePx(parsed.terminalFontSizePx),
       terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
       terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
@@ -530,6 +585,30 @@ function clampSidebarWidth(width: number) {
       ? MAX_SIDEBAR_WIDTH
       : Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, window.innerWidth - 360));
   return Math.round(Math.min(Math.max(width, MIN_SIDEBAR_WIDTH), viewportMax));
+}
+
+function clampNotesPanelWidth(
+  width: number,
+  sidebarWidth = DEFAULT_SIDEBAR_WIDTH,
+  sidebarOpen = true,
+) {
+  const reservedWidth = sidebarOpen ? sidebarWidth : 0;
+  const viewportMax =
+    typeof window === "undefined"
+      ? MAX_NOTES_PANEL_WIDTH
+      : Math.max(
+          MIN_NOTES_PANEL_WIDTH,
+          Math.min(MAX_NOTES_PANEL_WIDTH, window.innerWidth - reservedWidth - 320),
+        );
+  return Math.round(Math.min(Math.max(width, MIN_NOTES_PANEL_WIDTH), viewportMax));
+}
+
+function clampNotesListPaneWidth(width: number, notesPanelWidth = DEFAULT_NOTES_PANEL_WIDTH) {
+  const maxWidth = Math.max(
+    MIN_NOTES_LIST_PANE_WIDTH,
+    Math.min(MAX_NOTES_LIST_PANE_WIDTH, notesPanelWidth - 260),
+  );
+  return Math.round(Math.min(Math.max(width, MIN_NOTES_LIST_PANE_WIDTH), maxWidth));
 }
 
 async function writeDisplayPrefs(prefs: DisplayPrefs) {
@@ -639,11 +718,21 @@ export function App() {
   const [agentSort, setAgentSort] = useState<AgentSort>(initialPrefs.agentSort);
   const [agentGroup, setAgentGroup] = useState<AgentGroup>(initialPrefs.agentGroup);
   const [sidebarWidth, setSidebarWidth] = useState(initialPrefs.sidebarWidth);
+  const [notesPanelWidth, setNotesPanelWidth] = useState(initialPrefs.notesPanelWidth);
+  const [notesListPaneWidth, setNotesListPaneWidth] = useState(initialPrefs.notesListPaneWidth);
+  const [notesListPaneCollapsed, setNotesListPaneCollapsed] = useState(
+    initialPrefs.notesListPaneCollapsed,
+  );
+  const [notesEnabled, setNotesEnabled] = useState(initialPrefs.notesEnabled);
   const [resizingSidebar, setResizingSidebar] = useState(false);
+  const [resizingNotesPanel, setResizingNotesPanel] = useState(false);
+  const [resizingNotesListPane, setResizingNotesListPane] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(initialPrefs.sidebarOpen);
   const [showDetail, setShowDetail] = useState(false);
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [dialog, setDialog] = useState<DialogState | null>(null);
+  const [noteDeleteTarget, setNoteDeleteTarget] = useState<ScopedNoteEntry | null>(null);
+  const [deletingNote, setDeletingNote] = useState(false);
   const [backendSettingsOpen, setBackendSettingsOpen] = useState(false);
   const [terminalFontSizePx, setTerminalFontSizePx] = useState(
     initialPrefs.terminalFontSizePx,
@@ -698,6 +787,8 @@ export function App() {
   const mobileSidebarHistoryRef = useRef(false);
   const mobileDetailHistoryRef = useRef(false);
   const legacySelectionAppliedRef = useRef(false);
+  const selectedNotePaneKeyRef = useRef("");
+  const notesListResizeLeftRef = useRef(0);
   const sidebarResizePressRef = useRef<{
     timer: number;
     pointerId: number;
@@ -721,6 +812,10 @@ export function App() {
       setAgentSort(prefs.agentSort);
       setAgentGroup(prefs.agentGroup);
       setSidebarWidth(prefs.sidebarWidth);
+      setNotesPanelWidth(prefs.notesPanelWidth);
+      setNotesListPaneWidth(prefs.notesListPaneWidth);
+      setNotesListPaneCollapsed(prefs.notesListPaneCollapsed);
+      setNotesEnabled(prefs.notesEnabled);
       setSidebarOpen(prefs.sidebarOpen);
       setSelectedBridgeId(prefs.selectedBridgeId);
       setSelectedPaneRefState(prefs.selectedPane);
@@ -769,6 +864,10 @@ export function App() {
         setDialog(null);
         return true;
       }
+      if (noteDeleteTarget) {
+        setNoteDeleteTarget(null);
+        return true;
+      }
       if (menu) {
         setMenu(null);
         return true;
@@ -782,6 +881,7 @@ export function App() {
     launchTarget,
     menu,
     mobileNotesScreen,
+    noteDeleteTarget,
     notesPanelOpen,
   ]);
 
@@ -1023,6 +1123,10 @@ export function App() {
       agentSort,
       agentGroup,
       sidebarWidth,
+      notesPanelWidth,
+      notesListPaneWidth,
+      notesListPaneCollapsed,
+      notesEnabled,
       sidebarOpen,
       selectedBridgeId,
       selectedPane: selectedPaneRefState,
@@ -1051,6 +1155,10 @@ export function App() {
     agentSort,
     agentGroup,
     sidebarWidth,
+    notesPanelWidth,
+    notesListPaneWidth,
+    notesListPaneCollapsed,
+    notesEnabled,
     sidebarOpen,
     selectedBridgeId,
     selectedPaneRefState,
@@ -1094,7 +1202,20 @@ export function App() {
 
   useEffect(() => {
     setSidebarWidth((width) => clampSidebarWidth(width));
-  }, [isCompactLayout]);
+    setNotesPanelWidth((width) => clampNotesPanelWidth(width, sidebarWidth, sidebarOpen));
+    setNotesListPaneWidth((width) => clampNotesListPaneWidth(width, notesPanelWidth));
+  }, [isCompactLayout, notesPanelWidth, sidebarOpen, sidebarWidth]);
+
+  useEffect(() => {
+    if (notesEnabled) {
+      return;
+    }
+    setNotesPanelOpen(false);
+    setSelectedNoteRef(null);
+    if (sidebarView === "notes") {
+      setSidebarView("agents");
+    }
+  }, [notesEnabled, sidebarView]);
 
   const clearSidebarResizePress = () => {
     const pending = sidebarResizePressRef.current;
@@ -1129,6 +1250,54 @@ export function App() {
       document.body.style.userSelect = "";
     };
   }, [resizingSidebar]);
+
+  useEffect(() => {
+    if (!resizingNotesPanel) {
+      return;
+    }
+    const onPointerMove = (event: PointerEvent) => {
+      setNotesPanelWidth(
+        clampNotesPanelWidth(window.innerWidth - event.clientX, sidebarWidth, sidebarOpen),
+      );
+    };
+    const onPointerUp = () => setResizingNotesPanel(false);
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp, { once: true });
+    window.addEventListener("pointercancel", onPointerUp, { once: true });
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [resizingNotesPanel, sidebarOpen, sidebarWidth]);
+
+  useEffect(() => {
+    if (!resizingNotesListPane) {
+      return;
+    }
+    const onPointerMove = (event: PointerEvent) => {
+      setNotesListPaneWidth(
+        clampNotesListPaneWidth(event.clientX - notesListResizeLeftRef.current, notesPanelWidth),
+      );
+    };
+    const onPointerUp = () => setResizingNotesListPane(false);
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp, { once: true });
+    window.addEventListener("pointercancel", onPointerUp, { once: true });
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [notesPanelWidth, resizingNotesListPane]);
 
   useEffect(
     () => () => {
@@ -1257,11 +1426,37 @@ export function App() {
     selectedRuntime && notesStates[selectedRuntime.id]?.connectionKey === selectedRuntime.connectionKey
       ? notesStates[selectedRuntime.id]
       : null;
-  const selectedBridgeNotes = selectedNotesState?.response?.notes ?? [];
+  const selectedBridgeNotes = notesEnabled ? selectedNotesState?.response?.notes ?? [] : [];
   const selectedPaneNotes = useMemo(
     () => notesForPane(selectedBridgeNotes, selectedPane?.pane_id),
     [selectedBridgeNotes, selectedPane?.pane_id],
   );
+  const selectedRuntimeId = selectedRuntime?.id ?? null;
+  const selectedPaneKey =
+    notesEnabled && selectedRuntimeId && selectedPane
+      ? `${selectedRuntimeId}:${selectedPane.pane_id}`
+      : "";
+  useEffect(() => {
+    const paneChanged = selectedNotePaneKeyRef.current !== selectedPaneKey;
+    selectedNotePaneKeyRef.current = selectedPaneKey;
+    if (!selectedPaneKey || !selectedRuntimeId) {
+      setSelectedNoteRef(null);
+      return;
+    }
+    setSelectedNoteRef((current) => {
+      const currentIsPaneNote =
+        current?.bridgeId === selectedRuntimeId &&
+        selectedPaneNotes.some((note) => note.note_id === current.noteId);
+      if (currentIsPaneNote) {
+        return current;
+      }
+      if (!paneChanged && current) {
+        return current;
+      }
+      const firstNote = selectedPaneNotes[0] ?? null;
+      return firstNote ? { bridgeId: selectedRuntimeId, noteId: firstNote.note_id } : null;
+    });
+  }, [selectedPaneKey, selectedPaneNotes, selectedRuntimeId]);
   const selectedPaneMenuPress = useLongPress((x, y) => {
     if (selectedPane && selectedRuntime) {
       setMenu({
@@ -1300,8 +1495,11 @@ export function App() {
     );
   }, [snapshot, activeWorkspaceId, selectedPane]);
   const visibleNotes = useMemo(
-    () =>
-      buildVisibleScopedNotes(
+    () => {
+      if (!notesEnabled) {
+        return [];
+      }
+      return buildVisibleScopedNotes(
         bridgeViews,
         notesStates,
         selectedRuntime?.id ?? null,
@@ -1311,12 +1509,14 @@ export function App() {
         activeWorkspacesByBridgeId,
         notesIncludeArchived,
         notesIncludeDeleted,
-      ),
+      );
+    },
     [
       activeSpace,
       activeWorkspacesByBridgeId,
       bridgeViews,
       hostScope,
+      notesEnabled,
       notesStates,
       notesIncludeArchived,
       notesIncludeDeleted,
@@ -1325,8 +1525,11 @@ export function App() {
     ],
   );
   const allScopedNotes = useMemo(
-    () =>
-      buildVisibleScopedNotes(
+    () => {
+      if (!notesEnabled) {
+        return [];
+      }
+      return buildVisibleScopedNotes(
         bridgeViews,
         notesStates,
         null,
@@ -1337,15 +1540,13 @@ export function App() {
         true,
         true,
         false,
-      ),
-    [bridgeViews, notesStates],
+      );
+    },
+    [bridgeViews, notesEnabled, notesStates],
   );
   const selectedScopedNote = useMemo(
-    () =>
-      selectedNoteRef
-        ? findScopedNote(allScopedNotes, selectedNoteRef, false)
-        : (visibleNotes[0] ?? null),
-    [allScopedNotes, selectedNoteRef, visibleNotes],
+    () => (selectedNoteRef ? findScopedNote(allScopedNotes, selectedNoteRef, false) : null),
+    [allScopedNotes, selectedNoteRef],
   );
 
   // The active tab's split layout, normalized to fractions of the tab area so we
@@ -1510,6 +1711,9 @@ export function App() {
   };
 
   const selectNote = (bridgeId: BridgeId, noteId: string) => {
+    if (!notesEnabled) {
+      return;
+    }
     setSelectedNoteRef({ bridgeId, noteId });
     if (isCompactLayout) {
       setMobileNotesScreen("editor");
@@ -1518,6 +1722,9 @@ export function App() {
   };
 
   const openNotesPanel = () => {
+    if (!notesEnabled) {
+      return;
+    }
     setMobileNotesScreen("list");
     if (!selectedNoteRef && selectedRuntime && selectedPaneNotes.length > 0) {
       setSelectedNoteRef({
@@ -1529,6 +1736,10 @@ export function App() {
   };
 
   const createNoteForCurrentPane = async () => {
+    if (!notesEnabled) {
+      setError("Notes are disabled in settings");
+      return;
+    }
     if (!selectedRuntime || !selectedPane || !supportsNotes(selectedRuntime.capabilities)) {
       setError("Notes are not available for this bridge");
       return;
@@ -1551,6 +1762,10 @@ export function App() {
   };
 
   const createDetachedBridgeNote = async (bridgeId = selectedRuntime?.id ?? null) => {
+    if (!notesEnabled) {
+      setError("Notes are disabled in settings");
+      return;
+    }
     const runtime = bridgeId ? bridge.getRuntime(bridgeId) : null;
     if (!runtime || !supportsNotes(runtime.capabilities)) {
       setError("Notes are not available for this bridge");
@@ -1672,16 +1887,46 @@ export function App() {
     const runtime = bridge.getRuntime(entry.bridgeId);
     if (!runtime) {
       setError("Bridge is not ready");
-      return;
+      return false;
     }
     try {
       await deleteNote(runtime.httpUrl, entry.note.note_id, {
         expectedRevision: entry.note.revision,
       });
       clearNoteDraft(entry);
-      await refreshBridgeNotes(runtime, false);
+      const deletedSelected =
+        selectedNoteRef?.bridgeId === entry.bridgeId &&
+        selectedNoteRef.noteId === entry.note.note_id;
+      if (deletedSelected) {
+        setSelectedNoteRef(null);
+      }
+      const response = await refreshBridgeNotes(runtime, false);
+      if (deletedSelected && selectedRuntime?.id === runtime.id && selectedPane) {
+        const nextPaneNote = notesForPane(response?.notes ?? [], selectedPane.pane_id).find(
+          (note) => note.note_id !== entry.note.note_id,
+        );
+        setSelectedNoteRef(
+          nextPaneNote ? { bridgeId: runtime.id, noteId: nextPaneNote.note_id } : null,
+        );
+      }
+      return true;
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Could not delete note");
+      return false;
+    }
+  };
+
+  const confirmDeleteNote = async () => {
+    if (!noteDeleteTarget) {
+      return;
+    }
+    setDeletingNote(true);
+    try {
+      if (await deleteScopedNote(noteDeleteTarget)) {
+        setNoteDeleteTarget(null);
+      }
+    } finally {
+      setDeletingNote(false);
     }
   };
 
@@ -1984,7 +2229,12 @@ export function App() {
 
   async function refreshBridgeNotes(runtime: BridgeRuntime, setLoading: boolean) {
     const requestConnectionKey = runtime.connectionKey;
-    if (!runtime.canConnect || runtime.capabilityState !== "ready" || !supportsNotes(runtime.capabilities)) {
+    if (
+      !notesEnabled ||
+      !runtime.canConnect ||
+      runtime.capabilityState !== "ready" ||
+      !supportsNotes(runtime.capabilities)
+    ) {
       setNotesStates((current) => ({
         ...current,
         [runtime.id]: {
@@ -2050,6 +2300,9 @@ export function App() {
   }
 
   const refreshNotesForBridge = (bridgeId: BridgeId) => {
+    if (!notesEnabled) {
+      return;
+    }
     const runtime = bridge.getRuntime(bridgeId);
     if (runtime) {
       void refreshBridgeNotes(runtime, false);
@@ -2057,14 +2310,20 @@ export function App() {
   };
 
   useEffect(() => {
+    if (!notesEnabled) {
+      return;
+    }
     for (const runtime of bridge.enabledRuntimes) {
       if (runtime.capabilityState === "ready" && supportsNotes(runtime.capabilities)) {
         void refreshBridgeNotes(runtime, true);
       }
     }
-  }, [bridge.enabledRuntimes]);
+  }, [bridge.enabledRuntimes, notesEnabled]);
 
   useEffect(() => {
+    if (!notesEnabled) {
+      return;
+    }
     if (!notesPanelOpen && sidebarView !== "notes") {
       return;
     }
@@ -2077,7 +2336,7 @@ export function App() {
     };
     const timer = window.setInterval(refresh, NOTES_REFRESH_INTERVAL_MS);
     return () => window.clearInterval(timer);
-  }, [bridge.enabledRuntimes, notesPanelOpen, sidebarView]);
+  }, [bridge.enabledRuntimes, notesEnabled, notesPanelOpen, sidebarView]);
 
   async function exec(
     runtime: BridgeRuntime | null,
@@ -2265,12 +2524,16 @@ export function App() {
   const renderTerminal = !isCompactLayout || showDetail;
   const appStyle = {
     "--sidebar-w": `${sidebarWidth}px`,
+    "--notes-w": `${notesPanelWidth}px`,
+    "--notes-list-w": `${notesListPaneWidth}px`,
     "--content-inset-top": `${contentInsetTopPx}px`,
     "--content-inset-bottom": `${contentInsetBottomPx}px`,
     "--mobile-controls-scale": String(mobileControlsScalePercent / 100),
   } as CSSProperties &
     Record<
       | "--sidebar-w"
+      | "--notes-w"
+      | "--notes-list-w"
       | "--content-inset-top"
       | "--content-inset-bottom"
       | "--mobile-controls-scale",
@@ -2282,7 +2545,10 @@ export function App() {
       className="app"
       style={appStyle}
       data-sidebar={sidebarOpen ? "open" : "closed"}
+      data-notes={notesPanelOpen ? "open" : "closed"}
       data-resizing-sidebar={resizingSidebar ? "true" : "false"}
+      data-resizing-notes={resizingNotesPanel ? "true" : "false"}
+      data-resizing-notes-list={resizingNotesListPane ? "true" : "false"}
       data-compact={isCompactLayout ? "true" : "false"}
       data-touch={isTouchInput ? "true" : "false"}
       data-detail={isCompactLayout && showDetail ? "true" : "false"}
@@ -2311,6 +2577,7 @@ export function App() {
           capabilityState={selectedRuntime?.capabilityState ?? "idle"}
           scope={scope}
           sidebarView={sidebarView}
+          notesEnabled={notesEnabled}
           notesStates={notesStates}
           visibleNotes={visibleNotes}
           selectedNote={selectedScopedNote}
@@ -2495,7 +2762,7 @@ export function App() {
               </button>
             </>
           ) : null}
-          {selectedPane ? (
+          {selectedPane && notesEnabled ? (
             <button
               className="icon-btn notes-button"
               type="button"
@@ -2581,11 +2848,12 @@ export function App() {
         )}
       </section>
 
-      {notesPanelOpen ? (
+      {notesPanelOpen && notesEnabled ? (
         <NotesSurface
           compact={isCompactLayout}
           mobileScreen={mobileNotesScreen}
           selectedEntry={selectedScopedNote}
+          selectedBridgeId={selectedRuntime?.id ?? null}
           selectedPane={selectedPane}
           selectedPaneNotes={selectedRuntime ? selectedPaneNotes.map((note) => ({
             bridgeId: selectedRuntime.id,
@@ -2631,8 +2899,76 @@ export function App() {
           onDetach={(entry) => void detachScopedNote(entry)}
           onArchive={(entry) => void archiveScopedNote(entry)}
           onRestore={(entry) => void restoreScopedNote(entry)}
-          onDelete={(entry) => void deleteScopedNote(entry)}
+          onDelete={setNoteDeleteTarget}
           onViewPane={viewScopedNotePane}
+          width={notesPanelWidth}
+          listWidth={notesListPaneWidth}
+          listCollapsed={notesListPaneCollapsed}
+          onListCollapsed={setNotesListPaneCollapsed}
+          onResizeStart={(clientX) => {
+            if (isCompactLayout) {
+              return;
+            }
+            setNotesPanelWidth(
+              clampNotesPanelWidth(window.innerWidth - clientX, sidebarWidth, sidebarOpen),
+            );
+            setResizingNotesPanel(true);
+          }}
+          onResizeKeyDown={(event) => {
+            if (isCompactLayout) {
+              return;
+            }
+            if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+              event.preventDefault();
+              const step = event.shiftKey ? 32 : 12;
+              setNotesPanelWidth((width) =>
+                clampNotesPanelWidth(
+                  width + (event.key === "ArrowLeft" ? step : -step),
+                  sidebarWidth,
+                  sidebarOpen,
+                ),
+              );
+            } else if (event.key === "Home") {
+              event.preventDefault();
+              setNotesPanelWidth(MIN_NOTES_PANEL_WIDTH);
+            } else if (event.key === "End") {
+              event.preventDefault();
+              setNotesPanelWidth(
+                clampNotesPanelWidth(MAX_NOTES_PANEL_WIDTH, sidebarWidth, sidebarOpen),
+              );
+            }
+          }}
+          onListResizeStart={(surfaceLeft, clientX) => {
+            if (isCompactLayout || notesListPaneCollapsed) {
+              return;
+            }
+            notesListResizeLeftRef.current = surfaceLeft;
+            setNotesListPaneWidth(clampNotesListPaneWidth(clientX - surfaceLeft, notesPanelWidth));
+            setResizingNotesListPane(true);
+          }}
+          onListResizeKeyDown={(event) => {
+            if (isCompactLayout || notesListPaneCollapsed) {
+              return;
+            }
+            if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+              event.preventDefault();
+              const step = event.shiftKey ? 32 : 12;
+              setNotesListPaneWidth((width) =>
+                clampNotesListPaneWidth(
+                  width + (event.key === "ArrowRight" ? step : -step),
+                  notesPanelWidth,
+                ),
+              );
+            } else if (event.key === "Home") {
+              event.preventDefault();
+              setNotesListPaneWidth(MIN_NOTES_LIST_PANE_WIDTH);
+            } else if (event.key === "End") {
+              event.preventDefault();
+              setNotesListPaneWidth(
+                clampNotesListPaneWidth(MAX_NOTES_LIST_PANE_WIDTH, notesPanelWidth),
+              );
+            }
+          }}
         />
       ) : null}
 
@@ -2670,6 +3006,21 @@ export function App() {
         />
       ) : null}
 
+      {noteDeleteTarget ? (
+        <ConfirmDialog
+          title="Delete note"
+          message={`Delete "${noteDeleteTarget.note.title || "Untitled note"}"? This cannot be undone.`}
+          confirmLabel="Delete"
+          busy={deletingNote}
+          onCancel={() => {
+            if (!deletingNote) {
+              setNoteDeleteTarget(null);
+            }
+          }}
+          onConfirm={() => void confirmDeleteNote()}
+        />
+      ) : null}
+
       {launchTarget ? (
         <LaunchDialog
           target={launchTarget}
@@ -2682,6 +3033,8 @@ export function App() {
       {backendSettingsOpen ? (
         <BackendSettingsDialog
           showMobileTerminalSettings={isTouchInput}
+          notesEnabled={notesEnabled}
+          onNotesEnabled={setNotesEnabled}
           terminalFontSizePx={terminalFontSizePx}
           onTerminalFontSizePx={setTerminalFontSizePx}
           terminalInputTransport={terminalInputTransport}
@@ -3337,7 +3690,7 @@ export function shouldBlockDirtyNoteAutosave({
   serverBody: string;
   serverRevision: number;
 }) {
-  if (!dirty || baseRevision === null || serverRevision === baseRevision) {
+  if (!dirty || baseRevision === null || serverRevision <= baseRevision) {
     return false;
   }
   return title !== serverTitle || body !== serverBody;
@@ -3730,6 +4083,7 @@ function Switcher({
   capabilityState,
   scope,
   sidebarView,
+  notesEnabled,
   notesStates,
   visibleNotes,
   selectedNote,
@@ -3769,6 +4123,7 @@ function Switcher({
   capabilityState: "idle" | "probing" | "ready" | "error";
   scope: Scope;
   sidebarView: SidebarView;
+  notesEnabled: boolean;
   notesStates: Record<string, BridgeNotesState>;
   visibleNotes: ScopedNoteEntry[];
   selectedNote: ScopedNoteEntry | null;
@@ -3847,15 +4202,20 @@ function Switcher({
           (view) => !view.snapshot && (!view.runtime.canConnect || view.loadState === "error"),
         )
       : [];
-  const notesSupported = hostBridgeViews.some((view) => supportsNotes(view.runtime.capabilities));
-  const notesLoading = hostBridgeViews.some(
+  const notesSupported =
+    notesEnabled && hostBridgeViews.some((view) => supportsNotes(view.runtime.capabilities));
+  const notesLoading = notesEnabled && hostBridgeViews.some(
     (view) => notesStates[view.runtime.id]?.loadState === "loading",
   );
-  const notesError = hostBridgeViews
-    .map((view) => notesStates[view.runtime.id]?.error)
-    .find((message): message is string => Boolean(message));
+  const notesError = notesEnabled
+    ? hostBridgeViews
+        .map((view) => notesStates[view.runtime.id]?.error)
+        .find((message): message is string => Boolean(message))
+    : undefined;
   const hasNotesList =
-    sidebarView === "notes" && (notesSupported || visibleNotes.length > 0 || notesLoading || notesError);
+    notesEnabled &&
+    sidebarView === "notes" &&
+    (notesSupported || visibleNotes.length > 0 || notesLoading || notesError);
   const hasListSnapshot =
     hasNotesList ||
     (hostScope === "all"
@@ -3898,7 +4258,7 @@ function Switcher({
       activeSpace &&
       selectedBridgeId,
   );
-  const canCreateNoteFromHeader = sidebarView === "notes" && notesSupported;
+  const canCreateNoteFromHeader = notesEnabled && sidebarView === "notes" && notesSupported;
 
   useEffect(() => {
     if (optionsMenu && !showOptionsControl) {
@@ -4186,14 +4546,16 @@ function Switcher({
         >
           Tabs
         </button>
-        <button
-          type="button"
-          data-on={sidebarView === "notes"}
-          aria-pressed={sidebarView === "notes"}
-          onClick={() => onSidebarView("notes")}
-        >
-          Notes
-        </button>
+        {notesEnabled ? (
+          <button
+            type="button"
+            data-on={sidebarView === "notes"}
+            aria-pressed={sidebarView === "notes"}
+            onClick={() => onSidebarView("notes")}
+          >
+            Notes
+          </button>
+        ) : null}
       </div>
       <div className="sidebar-scope" role="group" aria-label="Sidebar scope">
         <button
@@ -4590,6 +4952,7 @@ function NotesSurface({
   compact,
   mobileScreen,
   selectedEntry,
+  selectedBridgeId,
   selectedPane,
   selectedPaneNotes,
   visibleNotes,
@@ -4613,10 +4976,19 @@ function NotesSurface({
   onRestore,
   onDelete,
   onViewPane,
+  width,
+  listWidth,
+  listCollapsed,
+  onListCollapsed,
+  onResizeStart,
+  onResizeKeyDown,
+  onListResizeStart,
+  onListResizeKeyDown,
 }: {
   compact: boolean;
   mobileScreen: MobileNotesScreen;
   selectedEntry: ScopedNoteEntry | null;
+  selectedBridgeId: BridgeId | null;
   selectedPane: PaneInfo | null;
   selectedPaneNotes: ScopedNoteEntry[];
   visibleNotes: ScopedNoteEntry[];
@@ -4645,16 +5017,70 @@ function NotesSurface({
   onRestore: (entry: ScopedNoteEntry) => void;
   onDelete: (entry: ScopedNoteEntry) => void;
   onViewPane: (entry: ScopedNoteEntry) => void;
+  width: number;
+  listWidth: number;
+  listCollapsed: boolean;
+  onListCollapsed: (collapsed: boolean) => void;
+  onResizeStart: (clientX: number) => void;
+  onResizeKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
+  onListResizeStart: (surfaceLeft: number, clientX: number) => void;
+  onListResizeKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
 }) {
+  const effectiveListCollapsed = !compact && listCollapsed;
+  const otherNotes = useMemo(
+    () =>
+      visibleNotes.filter(
+        (entry) =>
+          !(
+            selectedBridgeId &&
+            selectedPane &&
+            entry.bridgeId === selectedBridgeId &&
+            entry.note.attachment?.pane_id === selectedPane.pane_id
+          ),
+      ),
+    [selectedBridgeId, selectedPane, visibleNotes],
+  );
+
   return (
     <aside
       className="notes-surface"
       data-compact={compact ? "true" : "false"}
       data-mobile-screen={mobileScreen}
-      role="dialog"
+      data-list={effectiveListCollapsed ? "collapsed" : "open"}
+      role={compact ? "dialog" : "complementary"}
       aria-label="Notes"
     >
+      <div
+        className="notes-resizer"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize notes"
+        aria-valuemin={MIN_NOTES_PANEL_WIDTH}
+        aria-valuemax={MAX_NOTES_PANEL_WIDTH}
+        aria-valuenow={width}
+        tabIndex={compact ? -1 : 0}
+        onPointerDown={(event) => {
+          if (compact) {
+            return;
+          }
+          event.preventDefault();
+          onResizeStart(event.clientX);
+        }}
+        onKeyDown={onResizeKeyDown}
+      />
       <header className="notes-head">
+        {!compact ? (
+          <button
+            className="icon-btn"
+            type="button"
+            aria-label={effectiveListCollapsed ? "Show notes list" : "Hide notes list"}
+            title={effectiveListCollapsed ? "Show notes list" : "Hide notes list"}
+            aria-pressed={!effectiveListCollapsed}
+            onClick={() => onListCollapsed(!effectiveListCollapsed)}
+          >
+            <PanelLeft size={18} />
+          </button>
+        ) : null}
         {compact && mobileScreen === "editor" ? (
           <button
             className="icon-btn"
@@ -4676,41 +5102,46 @@ function NotesSurface({
           <X size={18} />
         </button>
       </header>
+      {selectedPane ? (
+        <div className="pane-note-tabs" role="tablist" aria-label="Pane notes">
+          {selectedPaneNotes.map((entry) => (
+            <button
+              key={`${entry.bridgeId}:${entry.note.note_id}`}
+              className="pane-note-tab"
+              type="button"
+              role="tab"
+              aria-selected={
+                selectedEntry?.bridgeId === entry.bridgeId &&
+                selectedEntry.note.note_id === entry.note.note_id
+              }
+              data-active={
+                selectedEntry?.bridgeId === entry.bridgeId &&
+                selectedEntry.note.note_id === entry.note.note_id
+                  ? "true"
+                  : "false"
+              }
+              onClick={() => onSelectNote(entry.bridgeId, entry.note.note_id)}
+            >
+              {entry.note.title || "Untitled note"}
+            </button>
+          ))}
+          <button
+            className="pane-note-tab pane-note-tab-new"
+            type="button"
+            aria-label="New pane note"
+            title="New pane note"
+            disabled={!currentBridgeSupportsNotes}
+            onClick={onCreatePaneNote}
+          >
+            <Plus size={15} />
+          </button>
+        </div>
+      ) : null}
       <div className="notes-shell">
         <div className="notes-list-pane">
           <section className="notes-section">
             <div className="notes-section-head">
-              <span>Pane</span>
-              <button
-                className="icon-btn"
-                type="button"
-                aria-label="New pane note"
-                title="New pane note"
-                disabled={!selectedPane || !currentBridgeSupportsNotes}
-                onClick={onCreatePaneNote}
-              >
-                <Plus size={15} />
-              </button>
-            </div>
-            {selectedPaneNotes.length === 0 ? (
-              <div className="notes-empty">No notes attached to this pane</div>
-            ) : (
-              selectedPaneNotes.map((entry) => (
-                <NotesListItem
-                  key={`${entry.bridgeId}:${entry.note.note_id}`}
-                  entry={entry}
-                  active={
-                    selectedEntry?.bridgeId === entry.bridgeId &&
-                    selectedEntry.note.note_id === entry.note.note_id
-                  }
-                  onSelect={() => onSelectNote(entry.bridgeId, entry.note.note_id)}
-                />
-              ))
-            )}
-          </section>
-          <section className="notes-section">
-            <div className="notes-section-head">
-              <span>All</span>
+              <span>Other</span>
               <label className="notes-filter">
                 <input
                   type="checkbox"
@@ -4738,14 +5169,14 @@ function NotesSurface({
                 <Plus size={15} />
               </button>
             </div>
-            {notesLoadState === "loading" && visibleNotes.length === 0 ? (
+            {notesLoadState === "loading" && otherNotes.length === 0 ? (
               <div className="notes-empty">Loading notes</div>
-            ) : notesError && visibleNotes.length === 0 ? (
+            ) : notesError && otherNotes.length === 0 ? (
               <div className="notes-empty">{notesError}</div>
-            ) : visibleNotes.length === 0 ? (
-              <div className="notes-empty">No notes yet</div>
+            ) : otherNotes.length === 0 ? (
+              <div className="notes-empty">No other notes</div>
             ) : (
-              visibleNotes.map((entry) => (
+              otherNotes.map((entry) => (
                 <NotesListItem
                   key={`${entry.bridgeId}:${entry.note.note_id}`}
                   entry={entry}
@@ -4758,9 +5189,33 @@ function NotesSurface({
               ))
             )}
           </section>
+          <div
+            className="notes-list-resizer"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize notes list"
+            aria-valuemin={MIN_NOTES_LIST_PANE_WIDTH}
+            aria-valuemax={MAX_NOTES_LIST_PANE_WIDTH}
+            aria-valuenow={listWidth}
+            tabIndex={effectiveListCollapsed ? -1 : 0}
+            onPointerDown={(event) => {
+              if (effectiveListCollapsed) {
+                return;
+              }
+              const surface = event.currentTarget.closest(".notes-surface");
+              if (!(surface instanceof HTMLElement)) {
+                return;
+              }
+              event.preventDefault();
+              onListResizeStart(surface.getBoundingClientRect().left, event.clientX);
+            }}
+            onKeyDown={onListResizeKeyDown}
+          />
         </div>
         <NoteEditor
           entry={selectedEntry}
+          currentBridgeId={selectedBridgeId}
+          currentPaneId={selectedPane?.pane_id ?? null}
           canAttachToCurrentPane={canAttachToCurrentPane}
           onSave={onSaveNote}
           onAttachToCurrentPane={onAttachToCurrentPane}
@@ -4803,6 +5258,8 @@ function NotesListItem({
 
 export function NoteEditor({
   entry,
+  currentBridgeId,
+  currentPaneId,
   canAttachToCurrentPane,
   onSave,
   onAttachToCurrentPane,
@@ -4813,6 +5270,8 @@ export function NoteEditor({
   onViewPane,
 }: {
   entry: ScopedNoteEntry | null;
+  currentBridgeId: BridgeId | null;
+  currentPaneId: string | null;
   canAttachToCurrentPane: boolean;
   onSave: (
     entry: ScopedNoteEntry,
@@ -5058,6 +5517,14 @@ export function NoteEditor({
   const note = entry.note;
   const deleted = Boolean(note.deleted_at);
   const archived = Boolean(note.archived_at);
+  const attachedToCurrentPane = Boolean(
+    currentBridgeId &&
+      currentPaneId &&
+      entry.bridgeId === currentBridgeId &&
+      note.attachment?.pane_id === currentPaneId,
+  );
+  const canViewLinkedPane = Boolean(entry.pane && !attachedToCurrentPane);
+  const canAttachCurrentPane = canAttachToCurrentPane && !attachedToCurrentPane;
   const markEdited = () => {
     const expectedRevision = baseRevision ?? entry.note.revision;
     if (baseRevision === null) {
@@ -5110,9 +5577,9 @@ export function NoteEditor({
                     ? "conflict"
                 : noteStateLabel(note).label}
         </span>
-        {note.link_state === "linked" ? (
+        {canViewLinkedPane ? (
           <button className="icon-btn" type="button" aria-label="View pane" title="View pane" onClick={() => onViewPane(entry)}>
-            <Link2 size={16} />
+            <SquareTerminal size={16} />
           </button>
         ) : null}
         {note.attachment ? (
@@ -5120,16 +5587,17 @@ export function NoteEditor({
             <Unlink size={16} />
           </button>
         ) : null}
-        <button
-          className="icon-btn"
-          type="button"
-          aria-label="Attach to current pane"
-          title="Attach to current pane"
-          disabled={!canAttachToCurrentPane}
-          onClick={() => onAttachToCurrentPane(entry)}
-        >
-          <Link2 size={16} />
-        </button>
+        {canAttachCurrentPane ? (
+          <button
+            className="icon-btn"
+            type="button"
+            aria-label="Attach to current pane"
+            title="Attach to current pane"
+            onClick={() => onAttachToCurrentPane(entry)}
+          >
+            <Link2 size={16} />
+          </button>
+        ) : null}
         {archived || deleted ? (
           <button className="icon-btn" type="button" aria-label="Restore note" title="Restore" onClick={() => onRestore(entry)}>
             <RotateCcw size={16} />
@@ -5145,11 +5613,7 @@ export function NoteEditor({
             type="button"
             aria-label="Delete note"
             title="Delete"
-            onClick={() => {
-              if (window.confirm("Delete this note?")) {
-                onDelete(entry);
-              }
-            }}
+            onClick={() => onDelete(entry)}
           >
             <Trash2 size={16} />
           </button>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3041,7 +3041,7 @@ export function App() {
       {noteDeleteTarget ? (
         <ConfirmDialog
           title="Delete note"
-          message={`Delete "${noteDeleteTarget.note.title || "Untitled note"}"? This cannot be undone.`}
+          message={`Move "${noteDeleteTarget.note.title || "Untitled note"}" to deleted notes? You can restore it later from the Deleted filter.`}
           confirmLabel="Delete"
           busy={deletingNote}
           onCancel={() => {
@@ -5367,8 +5367,21 @@ export function NoteEditor({
   const loadedNoteIdentityRef = useRef("");
   const saveBlockedRef = useRef(false);
   const noteSaveInFlightRef = useRef<NoteSaveInFlight | null>(null);
+  const entryRef = useRef(entry);
+  const onSaveRef = useRef(onSave);
   const noteIdentity = entry ? noteDraftStorageKey(entry) : "";
   const noteKey = entry ? `${entry.bridgeId}:${entry.note.note_id}:${entry.note.revision}` : "";
+  const serverTitle = entry?.note.title ?? "";
+  const serverBody = entry?.note.body ?? "";
+  const serverRevision = entry?.note.revision ?? 0;
+
+  useEffect(() => {
+    entryRef.current = entry;
+  }, [entry]);
+
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
 
   useEffect(() => {
     if (!entry) {
@@ -5472,27 +5485,31 @@ export function NoteEditor({
   }, [baseRevision, body, dirty, entry, title]);
 
   useEffect(() => {
-    if (!entry || !dirty) {
+    if (!noteIdentity || !dirty) {
       return;
     }
     if (editorNoteIdentity !== noteIdentity) {
       return;
     }
-    if (title === entry.note.title && body === entry.note.body) {
+    if (title === serverTitle && body === serverBody) {
       return;
     }
-    const expectedRevision = baseRevision ?? entry.note.revision;
+    const currentEntry = entryRef.current;
+    if (!currentEntry || noteDraftStorageKey(currentEntry) !== noteIdentity) {
+      return;
+    }
+    const expectedRevision = baseRevision ?? serverRevision;
     if (
       isInFlightNoteSaveVisible({
         inFlight: noteSaveInFlightRef.current,
         noteIdentity,
-        serverRevision: entry.note.revision,
-        serverTitle: entry.note.title,
-        serverBody: entry.note.body,
+        serverRevision,
+        serverTitle,
+        serverBody,
       })
     ) {
       setBaseRevision((current) =>
-        current === null || current < entry.note.revision ? entry.note.revision : current,
+        current === null || current < serverRevision ? serverRevision : current,
       );
       saveBlockedRef.current = false;
       setSaveState("pending");
@@ -5504,14 +5521,14 @@ export function NoteEditor({
         title,
         body,
         baseRevision: expectedRevision,
-        serverTitle: entry.note.title,
-        serverBody: entry.note.body,
-        serverRevision: entry.note.revision,
+        serverTitle,
+        serverBody,
+        serverRevision,
       })
     ) {
       saveBlockedRef.current = true;
       setSaveState("conflict");
-      writeNoteDraft(entry, title, body, expectedRevision);
+      writeNoteDraft(currentEntry, title, body, expectedRevision);
       return;
     }
     if (saveBlockedRef.current) {
@@ -5532,7 +5549,12 @@ export function NoteEditor({
         body,
       };
       noteSaveInFlightRef.current = inFlight;
-      void onSave(entry, title, body, expectedRevision)
+      const saveEntry = entryRef.current;
+      if (!saveEntry || noteDraftStorageKey(saveEntry) !== inFlight.noteIdentity) {
+        noteSaveInFlightRef.current = null;
+        return;
+      }
+      void onSaveRef.current(saveEntry, title, body, expectedRevision)
         .then((savedRevision) => {
           if (loadedNoteIdentityRef.current === inFlight.noteIdentity) {
             setBaseRevision((current) =>
@@ -5567,10 +5589,11 @@ export function NoteEditor({
     body,
     dirty,
     editorNoteIdentity,
-    entry,
     noteIdentity,
-    onSave,
     saveRetryCycle,
+    serverBody,
+    serverRevision,
+    serverTitle,
     title,
   ]);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4827,6 +4827,7 @@ function NoteEditor({
   const [body, setBody] = useState("");
   const [dirty, setDirty] = useState(false);
   const [baseRevision, setBaseRevision] = useState<number | null>(null);
+  const [saveRetryCycle, setSaveRetryCycle] = useState(0);
   const [saveState, setSaveState] = useState<
     "idle" | "pending" | "saving" | "saved" | "error" | "conflict"
   >("idle");
@@ -4868,7 +4869,6 @@ function NoteEditor({
         serverBody: entry.note.body,
       })
     ) {
-      noteSaveInFlightRef.current = null;
       setBaseRevision((current) =>
         current === null || current < entry.note.revision ? entry.note.revision : current,
       );
@@ -4945,6 +4945,22 @@ function NoteEditor({
     }
     const expectedRevision = baseRevision ?? entry.note.revision;
     if (
+      isInFlightNoteSaveVisible({
+        inFlight: noteSaveInFlightRef.current,
+        noteIdentity,
+        serverRevision: entry.note.revision,
+        serverTitle: entry.note.title,
+        serverBody: entry.note.body,
+      })
+    ) {
+      setBaseRevision((current) =>
+        current === null || current < entry.note.revision ? entry.note.revision : current,
+      );
+      saveBlockedRef.current = false;
+      setSaveState("pending");
+      return;
+    }
+    if (
       shouldBlockDirtyNoteAutosave({
         dirty,
         title,
@@ -4998,6 +5014,9 @@ function NoteEditor({
         .finally(() => {
           if (noteSaveInFlightRef.current === inFlight) {
             noteSaveInFlightRef.current = null;
+            if (cancelled && loadedNoteIdentityRef.current === inFlight.noteIdentity) {
+              setSaveRetryCycle((cycle) => cycle + 1);
+            }
           }
         });
     }, 700);
@@ -5005,7 +5024,7 @@ function NoteEditor({
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, [baseRevision, body, dirty, entry, onSave, title]);
+  }, [baseRevision, body, dirty, entry, noteIdentity, onSave, saveRetryCycle, title]);
 
   if (!entry) {
     return (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -204,6 +204,7 @@ export type ScopedNoteEntry = {
   connectionKey: string;
   storeId: string;
   sessionKey: string;
+  bridgeSessionKey: string;
   bridgeIndex: number;
   bridgeLabel: string;
   bridgeColor: string;
@@ -2249,7 +2250,13 @@ export function App() {
   }
 
   async function refreshBridgeNotes(runtime: BridgeRuntime, setLoading: boolean) {
+    ensureBridgeConnectionRef(connectionRefs, runtime);
     const requestConnectionKey = runtime.connectionKey;
+    const isCurrentConnection = () =>
+      isConnectionResultCurrent(
+        connectionRefs.current[runtime.id]?.connectionKey ?? "",
+        requestConnectionKey,
+      );
     if (
       !notesEnabled ||
       !runtime.canConnect ||
@@ -2288,7 +2295,7 @@ export function App() {
         includeOtherSessions: true,
       });
       setNotesStates((current) => {
-        if (bridge.getRuntime(runtime.id)?.connectionKey !== requestConnectionKey) {
+        if (!isCurrentConnection()) {
           return current;
         }
         return {
@@ -2304,6 +2311,9 @@ export function App() {
       return response;
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : "Notes unavailable";
+      if (!isCurrentConnection()) {
+        return null;
+      }
       setNotesStates((current) => ({
         ...current,
         [runtime.id]: {
@@ -2880,7 +2890,8 @@ export function App() {
             bridgeId: selectedRuntime.id,
             connectionKey: selectedRuntime.connectionKey,
             storeId: selectedNotesState?.response?.store_id ?? "unknown-store",
-            sessionKey: selectedNotesState?.response?.session_key ?? note.session_key,
+            sessionKey: note.session_key,
+            bridgeSessionKey: selectedNotesState?.response?.session_key ?? note.session_key,
             bridgeIndex: Math.max(
               0,
               bridgeViews.findIndex((view) => view.runtime.id === selectedRuntime.id),
@@ -3565,18 +3576,10 @@ export function buildVisibleScopedNotes(
   dedupeStores = true,
 ): ScopedNoteEntry[] {
   const hostBridgeViews = visibleHostBridgeViews(bridgeViews, selectedBridgeId, hostScope);
-  const seenStores = new Set<string>();
   const entries = hostBridgeViews.flatMap((view) => {
     const notesState = notesStates[view.runtime.id];
     if (!notesState || notesState.connectionKey !== view.runtime.connectionKey) {
       return [];
-    }
-    if (dedupeStores && hostScope === "all" && notesState.response) {
-      const storeKey = `${notesState.response.store_id}:${notesState.response.session_key}`;
-      if (seenStores.has(storeKey)) {
-        return [];
-      }
-      seenStores.add(storeKey);
     }
     const snapshot = view.snapshot;
     const bridgeIndex = Math.max(
@@ -3602,7 +3605,8 @@ export function buildVisibleScopedNotes(
           bridgeId: view.runtime.id,
           connectionKey: view.runtime.connectionKey,
           storeId: notesState.response?.store_id ?? "unknown-store",
-          sessionKey: notesState.response?.session_key ?? note.session_key,
+          sessionKey: note.session_key,
+          bridgeSessionKey: notesState.response?.session_key ?? note.session_key,
           bridgeIndex,
           bridgeLabel: view.runtime.label,
           bridgeColor: view.runtime.color,
@@ -3615,13 +3619,42 @@ export function buildVisibleScopedNotes(
         };
       });
   });
-  return entries.sort((a, b) => {
+  const visibleEntries =
+    dedupeStores && hostScope === "all" ? dedupeScopedNoteEntries(entries) : entries;
+  return visibleEntries.sort((a, b) => {
     const bridge = a.bridgeIndex - b.bridgeIndex;
     if (bridge !== 0) {
       return bridge;
     }
     return compareNotes(a.note, b.note);
   });
+}
+
+function dedupeScopedNoteEntries(entries: ScopedNoteEntry[]) {
+  const byNoteIdentity = new Map<string, ScopedNoteEntry>();
+  for (const entry of entries) {
+    const identity = scopedNoteIdentity(entry);
+    const existing = byNoteIdentity.get(identity);
+    if (!existing || shouldPreferScopedNoteEntry(entry, existing)) {
+      byNoteIdentity.set(identity, entry);
+    }
+  }
+  return Array.from(byNoteIdentity.values());
+}
+
+function scopedNoteIdentity(entry: ScopedNoteEntry) {
+  return `${entry.storeId}:${entry.note.session_key}:${entry.note.note_id}`;
+}
+
+function shouldPreferScopedNoteEntry(candidate: ScopedNoteEntry, existing: ScopedNoteEntry) {
+  const score = (entry: ScopedNoteEntry) =>
+    (entry.bridgeSessionKey === entry.note.session_key ? 2 : 0) + (entry.pane ? 1 : 0);
+  const candidateScore = score(candidate);
+  const existingScore = score(existing);
+  if (candidateScore !== existingScore) {
+    return candidateScore > existingScore;
+  }
+  return candidate.bridgeIndex < existing.bridgeIndex;
 }
 
 function noteVisibleByLifecycle(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,17 @@ import {
   Unlink,
   X,
 } from "lucide-react";
-import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type {
   CSSProperties,
   Dispatch,
@@ -127,6 +137,8 @@ import type {
   WorkspaceInfo,
 } from "./types";
 
+const NoteMarkdownPreview = lazy(() => import("./NoteMarkdownPreview"));
+
 type LoadState = "loading" | "ready" | "error";
 type Scope = "space" | "all";
 type HostScope = "selected" | "all";
@@ -233,6 +245,7 @@ type NoteSaveInFlight = {
   title: string;
   body: string;
 };
+type NoteEditorMode = "edit" | "preview";
 type MenuState = {
   kind: MenuKind;
   bridgeId: BridgeId;
@@ -734,7 +747,12 @@ export function App() {
   const [notesListPaneCollapsed, setNotesListPaneCollapsed] = useState(
     initialPrefs.notesListPaneCollapsed,
   );
-  const [notesEnabled, setNotesEnabled] = useState(initialPrefs.notesEnabled);
+  const notesEnabledRef = useRef(initialPrefs.notesEnabled);
+  const [notesEnabled, setNotesEnabledState] = useState(initialPrefs.notesEnabled);
+  const setNotesEnabled = useCallback((enabled: boolean) => {
+    notesEnabledRef.current = enabled;
+    setNotesEnabledState(enabled);
+  }, []);
   const [resizingSidebar, setResizingSidebar] = useState(false);
   const [resizingNotesPanel, setResizingNotesPanel] = useState(false);
   const [resizingNotesListPane, setResizingNotesListPane] = useState(false);
@@ -1223,6 +1241,7 @@ export function App() {
     }
     setNotesPanelOpen(false);
     setSelectedNoteRef(null);
+    setNotesStates({});
     if (sidebarView === "notes") {
       setSidebarView("agents");
     }
@@ -2298,6 +2317,9 @@ export function App() {
         includeDeleted: true,
         includeOtherSessions: true,
       });
+      if (!notesEnabledRef.current) {
+        return null;
+      }
       setNotesStates((current) => {
         if (!isCurrentConnection()) {
           return current;
@@ -2315,6 +2337,9 @@ export function App() {
       return response;
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : "Notes unavailable";
+      if (!notesEnabledRef.current) {
+        return null;
+      }
       if (!isCurrentConnection()) {
         return null;
       }
@@ -2580,7 +2605,7 @@ export function App() {
       className="app"
       style={appStyle}
       data-sidebar={sidebarOpen ? "open" : "closed"}
-      data-notes={notesPanelOpen ? "open" : "closed"}
+      data-notes={notesPanelOpen && notesEnabled ? "open" : "closed"}
       data-resizing-sidebar={resizingSidebar ? "true" : "false"}
       data-resizing-notes={resizingNotesPanel ? "true" : "false"}
       data-resizing-notes-list={resizingNotesListPane ? "true" : "false"}
@@ -3114,6 +3139,7 @@ export function App() {
 const SNAPSHOT_REFRESH_INTERVAL_MS = 10000;
 const NOTES_REFRESH_INTERVAL_MS = 15000;
 const NOTE_DRAFT_STORAGE_PREFIX = "herdr-web:note-draft:v1:";
+const NOTE_EDITOR_MODE_STORAGE_KEY = "herdr-web:note-editor-mode:v1";
 
 export function resolveInitialSelectedBridgeId(
   currentBridgeId: BridgeId | null,
@@ -3890,6 +3916,24 @@ function clearNoteDraft(entry: ScopedNoteEntry) {
   }
 }
 
+function readNoteEditorMode(): NoteEditorMode {
+  try {
+    return globalThis.localStorage?.getItem(NOTE_EDITOR_MODE_STORAGE_KEY) === "preview"
+      ? "preview"
+      : "edit";
+  } catch {
+    return "edit";
+  }
+}
+
+function writeNoteEditorMode(mode: NoteEditorMode) {
+  try {
+    globalThis.localStorage?.setItem(NOTE_EDITOR_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
 export function nextVisibleAgentPaneEntry(
   entries: ScopedAgentPane[],
   currentIndex: number,
@@ -4322,9 +4366,9 @@ function Switcher({
         .map((view) => notesStates[view.runtime.id]?.error)
         .find((message): message is string => Boolean(message))
     : undefined;
+  const notesViewActive = notesEnabled && sidebarView === "notes";
   const hasNotesList =
-    notesEnabled &&
-    sidebarView === "notes" &&
+    notesViewActive &&
     (notesSupported || visibleNotes.length > 0 || notesLoading || notesError);
   const hasListSnapshot =
     hasNotesList ||
@@ -4368,7 +4412,7 @@ function Switcher({
       activeSpace &&
       selectedBridgeId,
   );
-  const canCreateNoteFromHeader = notesEnabled && sidebarView === "notes" && notesSupported;
+  const canCreateNoteFromHeader = notesViewActive && notesSupported;
 
   useEffect(() => {
     if (optionsMenu && !showOptionsControl) {
@@ -4807,7 +4851,7 @@ function Switcher({
             ) : null}
 
             {/* PANES ----------------------------------------------------- */}
-            {sidebarView === "notes" ||
+            {notesViewActive ||
             (hostScope === "all" ? hasListSnapshot : snapshot && snapshot.workspaces.length > 0) ? (
             <section className="sec">
               <div className="sec-head">
@@ -4816,7 +4860,7 @@ function Switcher({
                     ? scope === "all"
                       ? "all agents"
                       : "space agents"
-                    : sidebarView === "notes"
+                    : notesViewActive
                       ? scope === "all"
                         ? "all notes"
                         : "space notes"
@@ -4871,7 +4915,7 @@ function Switcher({
                 ) : null}
               </div>
 
-              {sidebarView === "notes" ? (
+              {notesViewActive ? (
                 renderNoteRows()
               ) : sidebarView === "agents" ? (
                 agentPanes.length === 0 && disconnectedBridgeViews.length === 0 ? (
@@ -5403,6 +5447,7 @@ export function NoteEditor({
   const [saveState, setSaveState] = useState<
     "idle" | "pending" | "saving" | "saved" | "error" | "conflict"
   >("idle");
+  const [editorMode, setEditorModeState] = useState<NoteEditorMode>(() => readNoteEditorMode());
   const loadedNoteIdentityRef = useRef("");
   const saveBlockedRef = useRef(false);
   const noteSaveInFlightRef = useRef<NoteSaveInFlight | null>(null);
@@ -5421,6 +5466,11 @@ export function NoteEditor({
   useEffect(() => {
     onSaveRef.current = onSave;
   }, [onSave]);
+
+  const setEditorMode = (mode: NoteEditorMode) => {
+    setEditorModeState(mode);
+    writeNoteEditorMode(mode);
+  };
 
   useEffect(() => {
     if (!entry) {
@@ -5692,60 +5742,82 @@ export function NoteEditor({
   return (
     <div className="note-editor">
       <div className="note-editor-toolbar">
-        <span className="note-editor-status mono">
-          {saveState === "pending"
-            ? "pending"
-            : saveState === "saving"
-              ? "saving"
-              : saveState === "saved"
-                ? "saved"
-                : saveState === "error"
-                  ? "save failed"
-                  : saveState === "conflict"
-                    ? "conflict"
-                : noteLifecycleStatusLabel(note)}
-        </span>
-        {canViewLinkedPane ? (
-          <button className="icon-btn" type="button" aria-label="View pane" title="View pane" onClick={() => onViewPane(entry)}>
-            <SquareTerminal size={16} />
-          </button>
-        ) : null}
-        {note.attachment ? (
-          <button className="icon-btn" type="button" aria-label="Detach note" title="Detach" onClick={() => onDetach(entry)}>
-            <Unlink size={16} />
-          </button>
-        ) : null}
-        {canAttachCurrentPane ? (
-          <button
-            className="icon-btn"
-            type="button"
-            aria-label="Attach to current pane"
-            title="Attach to current pane"
-            onClick={() => onAttachToCurrentPane(entry)}
-          >
-            <Link2 size={16} />
-          </button>
-        ) : null}
-        {archived || deleted ? (
-          <button className="icon-btn" type="button" aria-label="Restore note" title="Restore" onClick={() => onRestore(entry)}>
-            <RotateCcw size={16} />
-          </button>
-        ) : (
-          <button className="icon-btn" type="button" aria-label="Archive note" title="Archive" onClick={() => onArchive(entry)}>
-            <Archive size={16} />
-          </button>
-        )}
-        {!deleted ? (
-          <button
-            className="icon-btn danger"
-            type="button"
-            aria-label="Delete note"
-            title="Delete"
-            onClick={() => onDelete(entry)}
-          >
-            <Trash2 size={16} />
-          </button>
-        ) : null}
+        <div className="note-editor-toolbar-left">
+          <span className="note-editor-status mono">
+            {saveState === "pending"
+              ? "pending"
+              : saveState === "saving"
+                ? "saving"
+                : saveState === "saved"
+                  ? "saved"
+                  : saveState === "error"
+                    ? "save failed"
+                    : saveState === "conflict"
+                      ? "conflict"
+                  : noteLifecycleStatusLabel(note)}
+          </span>
+          <div className="note-editor-mode segmented-control" role="group" aria-label="Note editor mode">
+            <button
+              type="button"
+              data-on={editorMode === "edit"}
+              aria-pressed={editorMode === "edit"}
+              onClick={() => setEditorMode("edit")}
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              data-on={editorMode === "preview"}
+              aria-pressed={editorMode === "preview"}
+              onClick={() => setEditorMode("preview")}
+            >
+              Preview
+            </button>
+          </div>
+        </div>
+        <div className="note-editor-actions">
+          {canViewLinkedPane ? (
+            <button className="icon-btn" type="button" aria-label="View pane" title="View pane" onClick={() => onViewPane(entry)}>
+              <SquareTerminal size={16} />
+            </button>
+          ) : null}
+          {note.attachment ? (
+            <button className="icon-btn" type="button" aria-label="Detach note" title="Detach" onClick={() => onDetach(entry)}>
+              <Unlink size={16} />
+            </button>
+          ) : null}
+          {canAttachCurrentPane ? (
+            <button
+              className="icon-btn"
+              type="button"
+              aria-label="Attach to current pane"
+              title="Attach to current pane"
+              onClick={() => onAttachToCurrentPane(entry)}
+            >
+              <Link2 size={16} />
+            </button>
+          ) : null}
+          {archived || deleted ? (
+            <button className="icon-btn" type="button" aria-label="Restore note" title="Restore" onClick={() => onRestore(entry)}>
+              <RotateCcw size={16} />
+            </button>
+          ) : (
+            <button className="icon-btn" type="button" aria-label="Archive note" title="Archive" onClick={() => onArchive(entry)}>
+              <Archive size={16} />
+            </button>
+          )}
+          {!deleted ? (
+            <button
+              className="icon-btn danger"
+              type="button"
+              aria-label="Delete note"
+              title="Delete"
+              onClick={() => onDelete(entry)}
+            >
+              <Trash2 size={16} />
+            </button>
+          ) : null}
+        </div>
       </div>
       {saveState === "conflict" ? (
         <div className="note-conflict" role="alert">
@@ -5768,16 +5840,24 @@ export function NoteEditor({
         placeholder="Untitled note"
         disabled={deleted}
       />
-      <textarea
-        className="note-body-input"
-        value={body}
-        onChange={(event) => {
-          setBody(event.currentTarget.value);
-          markEdited();
-        }}
-        placeholder="Write a note"
-        disabled={deleted}
-      />
+      {editorMode === "preview" ? (
+        <div className="note-body-preview">
+          <Suspense fallback={<span className="note-body-preview-empty">Loading preview</span>}>
+            <NoteMarkdownPreview body={body} />
+          </Suspense>
+        </div>
+      ) : (
+        <textarea
+          className="note-body-input"
+          value={body}
+          onChange={(event) => {
+            setBody(event.currentTarget.value);
+            markEdited();
+          }}
+          placeholder="Write a note"
+          disabled={deleted}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5437,7 +5437,6 @@ export function NoteEditor({
   const [saveState, setSaveState] = useState<
     "idle" | "pending" | "saving" | "saved" | "error" | "conflict"
   >("idle");
-  const [showSavedStatus, setShowSavedStatus] = useState(false);
   const [editorMode, setEditorModeState] = useState<NoteEditorMode>(() => readNoteEditorMode());
   const loadedNoteIdentityRef = useRef("");
   const saveBlockedRef = useRef(false);
@@ -5677,16 +5676,6 @@ export function NoteEditor({
     title,
   ]);
 
-  useEffect(() => {
-    if (saveState !== "saved") {
-      setShowSavedStatus(false);
-      return;
-    }
-    setShowSavedStatus(true);
-    const timer = window.setTimeout(() => setShowSavedStatus(false), 1400);
-    return () => window.clearTimeout(timer);
-  }, [saveState]);
-
   if (!entry) {
     return (
       <div className="note-editor note-editor-empty">
@@ -5705,17 +5694,7 @@ export function NoteEditor({
   );
   const canAttachCurrentPane = canAttachToCurrentPane && !attachedToCurrentPane;
   const saveStatusLabel =
-    saveState === "pending"
-      ? "pending"
-      : saveState === "saving"
-        ? "saving"
-        : saveState === "saved" && showSavedStatus
-          ? "saved"
-          : saveState === "error"
-            ? "save failed"
-            : saveState === "conflict"
-              ? "conflict"
-              : null;
+    saveState === "error" ? "save failed" : saveState === "conflict" ? "conflict" : null;
   const markEdited = () => {
     const expectedRevision = baseRevision ?? entry.note.revision;
     if (baseRevision === null) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -844,6 +844,12 @@ export function App() {
 
   useEffect(() => {
     return addNativeBackHandler(() => {
+      if (noteDeleteTarget) {
+        if (!deletingNote) {
+          setNoteDeleteTarget(null);
+        }
+        return true;
+      }
       if (notesPanelOpen) {
         if (isCompactLayout && mobileNotesScreen === "editor") {
           setMobileNotesScreen("list");
@@ -864,10 +870,6 @@ export function App() {
         setDialog(null);
         return true;
       }
-      if (noteDeleteTarget) {
-        setNoteDeleteTarget(null);
-        return true;
-      }
       if (menu) {
         setMenu(null);
         return true;
@@ -876,6 +878,7 @@ export function App() {
     });
   }, [
     backendSettingsOpen,
+    deletingNote,
     dialog,
     isCompactLayout,
     launchTarget,
@@ -3642,6 +3645,21 @@ function findScopedNote(
   return found ?? (fallback ? (entries[0] ?? null) : null);
 }
 
+function scopedNoteLinkedToPane(
+  entry: ScopedNoteEntry,
+  bridgeId: BridgeId | null,
+  paneId: string | null | undefined,
+) {
+  return Boolean(
+    bridgeId &&
+      paneId &&
+      entry.bridgeId === bridgeId &&
+      entry.note.link_state === "linked" &&
+      entry.note.attachment?.pane_id === paneId &&
+      entry.pane?.pane_id === paneId,
+  );
+}
+
 function noteStateLabel(note: PaneNote) {
   if (note.deleted_at) {
     return { label: "deleted", status: "blocked" as AgentStatus };
@@ -5030,16 +5048,11 @@ function NotesSurface({
   const otherNotes = useMemo(
     () =>
       visibleNotes.filter(
-        (entry) =>
-          !(
-            selectedBridgeId &&
-            selectedPane &&
-            entry.bridgeId === selectedBridgeId &&
-            entry.note.attachment?.pane_id === selectedPane.pane_id
-          ),
+        (entry) => !scopedNoteLinkedToPane(entry, selectedBridgeId, selectedPane?.pane_id),
       ),
-    [selectedBridgeId, selectedPane, visibleNotes],
+    [selectedBridgeId, selectedPane?.pane_id, visibleNotes],
   );
+  const showPaneNoteTabs = Boolean(selectedPane && !(compact && mobileScreen === "editor"));
 
   return (
     <aside
@@ -5102,7 +5115,7 @@ function NotesSurface({
           <X size={18} />
         </button>
       </header>
-      {selectedPane ? (
+      {showPaneNoteTabs ? (
         <div className="pane-note-tabs" role="tablist" aria-label="Pane notes">
           {selectedPaneNotes.map((entry) => (
             <button
@@ -5517,12 +5530,7 @@ export function NoteEditor({
   const note = entry.note;
   const deleted = Boolean(note.deleted_at);
   const archived = Boolean(note.archived_at);
-  const attachedToCurrentPane = Boolean(
-    currentBridgeId &&
-      currentPaneId &&
-      entry.bridgeId === currentBridgeId &&
-      note.attachment?.pane_id === currentPaneId,
-  );
+  const attachedToCurrentPane = scopedNoteLinkedToPane(entry, currentBridgeId, currentPaneId);
   const canViewLinkedPane = Boolean(entry.pane && !attachedToCurrentPane);
   const canAttachCurrentPane = canAttachToCurrentPane && !attachedToCurrentPane;
   const markEdited = () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -219,6 +219,12 @@ type NoteDraft = {
   baseRevision: number;
   updatedAt: number;
 };
+type NoteSaveInFlight = {
+  noteIdentity: string;
+  expectedRevision: number;
+  title: string;
+  body: string;
+};
 type MenuState = {
   kind: MenuKind;
   bridgeId: BridgeId;
@@ -3333,6 +3339,28 @@ export function shouldBlockDirtyNoteAutosave({
   return title !== serverTitle || body !== serverBody;
 }
 
+export function isInFlightNoteSaveVisible({
+  inFlight,
+  noteIdentity,
+  serverRevision,
+  serverTitle,
+  serverBody,
+}: {
+  inFlight: NoteSaveInFlight | null;
+  noteIdentity: string;
+  serverRevision: number;
+  serverTitle: string;
+  serverBody: string;
+}) {
+  return Boolean(
+    inFlight &&
+      inFlight.noteIdentity === noteIdentity &&
+      serverRevision > inFlight.expectedRevision &&
+      serverTitle === inFlight.title &&
+      serverBody === inFlight.body,
+  );
+}
+
 export function noteDraftStorageKey(entry: ScopedNoteEntry) {
   return `${NOTE_DRAFT_STORAGE_PREFIX}${[
     entry.bridgeId,
@@ -4804,6 +4832,7 @@ function NoteEditor({
   >("idle");
   const loadedNoteIdentityRef = useRef("");
   const saveBlockedRef = useRef(false);
+  const noteSaveInFlightRef = useRef<NoteSaveInFlight | null>(null);
   const noteIdentity = entry ? noteDraftStorageKey(entry) : "";
   const noteKey = entry ? `${entry.bridgeId}:${entry.note.note_id}:${entry.note.revision}` : "";
 
@@ -4816,6 +4845,7 @@ function NoteEditor({
       setBaseRevision(null);
       setSaveState("idle");
       saveBlockedRef.current = false;
+      noteSaveInFlightRef.current = null;
       return;
     }
     const noteChanged = loadedNoteIdentityRef.current !== noteIdentity;
@@ -4828,6 +4858,24 @@ function NoteEditor({
       return;
     }
     const expectedRevision = baseRevision ?? entry.note.revision;
+    if (
+      !noteChanged &&
+      isInFlightNoteSaveVisible({
+        inFlight: noteSaveInFlightRef.current,
+        noteIdentity,
+        serverRevision: entry.note.revision,
+        serverTitle: entry.note.title,
+        serverBody: entry.note.body,
+      })
+    ) {
+      noteSaveInFlightRef.current = null;
+      setBaseRevision((current) =>
+        current === null || current < entry.note.revision ? entry.note.revision : current,
+      );
+      saveBlockedRef.current = false;
+      setSaveState("pending");
+      return;
+    }
     if (
       !noteChanged &&
       shouldBlockDirtyNoteAutosave({
@@ -4915,14 +4963,29 @@ function NoteEditor({
     if (saveBlockedRef.current) {
       return;
     }
+    if (noteSaveInFlightRef.current?.noteIdentity === noteIdentity) {
+      setSaveState("pending");
+      return;
+    }
     setSaveState("pending");
     let cancelled = false;
     const timer = window.setTimeout(() => {
       setSaveState("saving");
+      const inFlight: NoteSaveInFlight = {
+        noteIdentity,
+        expectedRevision,
+        title,
+        body,
+      };
+      noteSaveInFlightRef.current = inFlight;
       void onSave(entry, title, body, expectedRevision)
         .then((savedRevision) => {
+          if (loadedNoteIdentityRef.current === inFlight.noteIdentity) {
+            setBaseRevision((current) =>
+              current === null || current < savedRevision ? savedRevision : current,
+            );
+          }
           if (!cancelled) {
-            setBaseRevision(savedRevision);
             setSaveState("saved");
           }
         })
@@ -4930,6 +4993,11 @@ function NoteEditor({
           if (!cancelled) {
             saveBlockedRef.current = true;
             setSaveState(isNotesConflictError(caught) ? "conflict" : "error");
+          }
+        })
+        .finally(() => {
+          if (noteSaveInFlightRef.current === inFlight) {
+            noteSaveInFlightRef.current = null;
           }
         });
     }, 700);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -216,7 +216,7 @@ type ScopedAgentGroup = {
 type NoteDraft = {
   title: string;
   body: string;
-  revision: number;
+  baseRevision: number;
   updatedAt: number;
 };
 type MenuState = {
@@ -1566,7 +1566,12 @@ export function App() {
     }
   };
 
-  const saveScopedNote = async (entry: ScopedNoteEntry, title: string, body: string) => {
+  const saveScopedNote = async (
+    entry: ScopedNoteEntry,
+    title: string,
+    body: string,
+    expectedRevision: number,
+  ) => {
     const runtime = bridge.getRuntime(entry.bridgeId);
     if (!runtime) {
       setError("Bridge is not ready");
@@ -1576,7 +1581,7 @@ export function App() {
       await updateNote(runtime.httpUrl, entry.note.note_id, {
         title,
         body,
-        expectedRevision: entry.note.revision,
+        expectedRevision,
       });
       await refreshBridgeNotes(runtime, false);
     } catch (caught) {
@@ -3304,6 +3309,29 @@ function noteSubtitle(entry: ScopedNoteEntry, showBridge: boolean) {
     .join(" · ");
 }
 
+export function shouldBlockDirtyNoteAutosave({
+  dirty,
+  title,
+  body,
+  baseRevision,
+  serverTitle,
+  serverBody,
+  serverRevision,
+}: {
+  dirty: boolean;
+  title: string;
+  body: string;
+  baseRevision: number | null;
+  serverTitle: string;
+  serverBody: string;
+  serverRevision: number;
+}) {
+  if (!dirty || baseRevision === null || serverRevision === baseRevision) {
+    return false;
+  }
+  return title !== serverTitle || body !== serverBody;
+}
+
 export function noteDraftStorageKey(entry: ScopedNoteEntry) {
   return `${NOTE_DRAFT_STORAGE_PREFIX}${[
     entry.bridgeId,
@@ -3323,13 +3351,17 @@ function readNoteDraft(entry: ScopedNoteEntry): NoteDraft | null {
       return null;
     }
     const parsed = JSON.parse(raw) as Partial<NoteDraft>;
-    if (typeof parsed.title !== "string" || typeof parsed.body !== "string") {
+    if (
+      typeof parsed.title !== "string" ||
+      typeof parsed.body !== "string" ||
+      typeof parsed.baseRevision !== "number"
+    ) {
       return null;
     }
     return {
       title: parsed.title,
       body: parsed.body,
-      revision: typeof parsed.revision === "number" ? parsed.revision : entry.note.revision,
+      baseRevision: parsed.baseRevision,
       updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : 0,
     };
   } catch {
@@ -3337,12 +3369,17 @@ function readNoteDraft(entry: ScopedNoteEntry): NoteDraft | null {
   }
 }
 
-function writeNoteDraft(entry: ScopedNoteEntry, title: string, body: string) {
+function writeNoteDraft(
+  entry: ScopedNoteEntry,
+  title: string,
+  body: string,
+  baseRevision: number,
+) {
   try {
     const draft: NoteDraft = {
       title,
       body,
-      revision: entry.note.revision,
+      baseRevision,
       updatedAt: Date.now(),
     };
     globalThis.localStorage?.setItem(noteDraftStorageKey(entry), JSON.stringify(draft));
@@ -4563,7 +4600,12 @@ function NotesSurface({
   onCreateDetachedNote: () => void;
   onIncludeArchived: (include: boolean) => void;
   onIncludeDeleted: (include: boolean) => void;
-  onSaveNote: (entry: ScopedNoteEntry, title: string, body: string) => Promise<void>;
+  onSaveNote: (
+    entry: ScopedNoteEntry,
+    title: string,
+    body: string,
+    expectedRevision: number,
+  ) => Promise<void>;
   onAttachToCurrentPane: (entry: ScopedNoteEntry) => void;
   onDetach: (entry: ScopedNoteEntry) => void;
   onArchive: (entry: ScopedNoteEntry) => void;
@@ -4739,7 +4781,12 @@ function NoteEditor({
 }: {
   entry: ScopedNoteEntry | null;
   canAttachToCurrentPane: boolean;
-  onSave: (entry: ScopedNoteEntry, title: string, body: string) => Promise<void>;
+  onSave: (
+    entry: ScopedNoteEntry,
+    title: string,
+    body: string,
+    expectedRevision: number,
+  ) => Promise<void>;
   onAttachToCurrentPane: (entry: ScopedNoteEntry) => void;
   onDetach: (entry: ScopedNoteEntry) => void;
   onArchive: (entry: ScopedNoteEntry) => void;
@@ -4750,6 +4797,7 @@ function NoteEditor({
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [dirty, setDirty] = useState(false);
+  const [baseRevision, setBaseRevision] = useState<number | null>(null);
   const [saveState, setSaveState] = useState<
     "idle" | "pending" | "saving" | "saved" | "error" | "conflict"
   >("idle");
@@ -4764,6 +4812,7 @@ function NoteEditor({
       setTitle("");
       setBody("");
       setDirty(false);
+      setBaseRevision(null);
       setSaveState("idle");
       saveBlockedRef.current = false;
       return;
@@ -4771,46 +4820,95 @@ function NoteEditor({
     const noteChanged = loadedNoteIdentityRef.current !== noteIdentity;
     if (!noteChanged && dirty && title === entry.note.title && body === entry.note.body) {
       setDirty(false);
+      setBaseRevision(entry.note.revision);
       setSaveState("saved");
       saveBlockedRef.current = false;
       clearNoteDraft(entry);
       return;
     }
-    if (noteChanged || !dirty) {
+    const expectedRevision = baseRevision ?? entry.note.revision;
+    if (
+      !noteChanged &&
+      shouldBlockDirtyNoteAutosave({
+        dirty,
+        title,
+        body,
+        baseRevision: expectedRevision,
+        serverTitle: entry.note.title,
+        serverBody: entry.note.body,
+        serverRevision: entry.note.revision,
+      })
+    ) {
+      saveBlockedRef.current = true;
+      setSaveState("conflict");
+      writeNoteDraft(entry, title, body, expectedRevision);
+      return;
+    }
+    if (noteChanged) {
       const draft = readNoteDraft(entry);
       loadedNoteIdentityRef.current = noteIdentity;
       if (draft && (draft.title !== entry.note.title || draft.body !== entry.note.body)) {
+        const hasConflict = draft.baseRevision !== entry.note.revision;
         setTitle(draft.title);
         setBody(draft.body);
         setDirty(true);
-        setSaveState("pending");
+        setBaseRevision(draft.baseRevision);
+        setSaveState(hasConflict ? "conflict" : "pending");
+        saveBlockedRef.current = hasConflict;
       } else {
         setTitle(entry.note.title);
         setBody(entry.note.body);
         setDirty(false);
+        setBaseRevision(entry.note.revision);
         setSaveState("idle");
+        saveBlockedRef.current = false;
         clearNoteDraft(entry);
       }
-      saveBlockedRef.current = false;
+      return;
     }
-  }, [body, dirty, entry, noteIdentity, noteKey, title]);
+    if (!dirty) {
+      setTitle(entry.note.title);
+      setBody(entry.note.body);
+      setBaseRevision(entry.note.revision);
+      setSaveState("idle");
+      saveBlockedRef.current = false;
+      clearNoteDraft(entry);
+    }
+  }, [baseRevision, body, dirty, entry, noteIdentity, noteKey, title]);
 
   useEffect(() => {
     if (!entry) {
       return;
     }
     if (dirty && (title !== entry.note.title || body !== entry.note.body)) {
-      writeNoteDraft(entry, title, body);
+      writeNoteDraft(entry, title, body, baseRevision ?? entry.note.revision);
     } else {
       clearNoteDraft(entry);
     }
-  }, [body, dirty, entry, title]);
+  }, [baseRevision, body, dirty, entry, title]);
 
   useEffect(() => {
     if (!entry || !dirty) {
       return;
     }
     if (title === entry.note.title && body === entry.note.body) {
+      return;
+    }
+    const expectedRevision = baseRevision ?? entry.note.revision;
+    if (
+      shouldBlockDirtyNoteAutosave({
+        dirty,
+        title,
+        body,
+        baseRevision: expectedRevision,
+        serverTitle: entry.note.title,
+        serverBody: entry.note.body,
+        serverRevision: entry.note.revision,
+      })
+    ) {
+      saveBlockedRef.current = true;
+      setSaveState("conflict");
+      writeNoteDraft(entry, title, body, expectedRevision);
       return;
     }
     if (saveBlockedRef.current) {
@@ -4820,7 +4918,7 @@ function NoteEditor({
     let cancelled = false;
     const timer = window.setTimeout(() => {
       setSaveState("saving");
-      void onSave(entry, title, body)
+      void onSave(entry, title, body, expectedRevision)
         .then(() => {
           if (!cancelled) {
             setSaveState("saved");
@@ -4837,7 +4935,7 @@ function NoteEditor({
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, [body, dirty, entry, onSave, title]);
+  }, [baseRevision, body, dirty, entry, onSave, title]);
 
   if (!entry) {
     return (
@@ -4852,9 +4950,13 @@ function NoteEditor({
   const deleted = Boolean(note.deleted_at);
   const archived = Boolean(note.archived_at);
   const markEdited = () => {
+    const expectedRevision = baseRevision ?? entry.note.revision;
+    if (baseRevision === null) {
+      setBaseRevision(expectedRevision);
+    }
     setDirty(true);
     if (saveState === "conflict") {
-      writeNoteDraft(entry, title, body);
+      writeNoteDraft(entry, title, body, expectedRevision);
       return;
     }
     saveBlockedRef.current = false;
@@ -4863,9 +4965,10 @@ function NoteEditor({
   const overwriteConflict = () => {
     saveBlockedRef.current = false;
     setSaveState("saving");
-    void onSave(entry, title, body)
+    void onSave(entry, title, body, entry.note.revision)
       .then(() => {
         clearNoteDraft(entry);
+        setBaseRevision(entry.note.revision);
         setSaveState("saved");
       })
       .catch((caught) => {
@@ -4877,6 +4980,7 @@ function NoteEditor({
     setTitle(entry.note.title);
     setBody(entry.note.body);
     setDirty(false);
+    setBaseRevision(entry.note.revision);
     saveBlockedRef.current = false;
     setSaveState("idle");
     clearNoteDraft(entry);

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -8,6 +8,7 @@ import {
   SlidersHorizontal,
   Smartphone,
   SquareTerminal,
+  StickyNote,
   X,
 } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
@@ -57,6 +58,8 @@ import { TERMINAL_OUTPUT_COALESCE_OPTIONS_MS } from "./terminalOutputCoalescing"
 
 type Props = {
   showMobileTerminalSettings: boolean;
+  notesEnabled: boolean;
+  onNotesEnabled: (enabled: boolean) => void;
   terminalFontSizePx: number;
   onTerminalFontSizePx: (value: number) => void;
   terminalInputTransport: TerminalInputTransport;
@@ -97,10 +100,12 @@ type FormState = {
 };
 
 type SelectionMode = "same-origin" | "new" | "backend";
-type SettingsArea = "bridge" | "display" | "terminal" | "mobile";
+type SettingsArea = "bridge" | "features" | "display" | "terminal" | "mobile";
 
 export function BackendSettingsDialog({
   showMobileTerminalSettings,
+  notesEnabled,
+  onNotesEnabled,
   terminalFontSizePx,
   onTerminalFontSizePx,
   terminalInputTransport,
@@ -262,6 +267,7 @@ export function BackendSettingsDialog({
   const showSameOrigin = bridge.sameOriginAvailable;
   const areas: { id: SettingsArea; label: string; icon: typeof Server }[] = [
     { id: "bridge", label: "Bridge", icon: Server },
+    { id: "features", label: "Features", icon: StickyNote },
     { id: "display", label: "Display", icon: SlidersHorizontal },
     { id: "terminal", label: "Terminal", icon: SquareTerminal },
     ...(showMobileTerminalSettings
@@ -464,6 +470,33 @@ export function BackendSettingsDialog({
                   </div>
                 ) : null}
               </>
+            ) : null}
+
+            {activeArea === "features" ? (
+              <div className="settings-section settings-section-flat">
+                <div className="settings-label">Client features</div>
+                <div className="settings-row">
+                  <span>Notes</span>
+                  <div className="segmented-control" role="group" aria-label="Notes feature">
+                    <button
+                      type="button"
+                      data-on={!notesEnabled}
+                      aria-pressed={!notesEnabled}
+                      onClick={() => onNotesEnabled(false)}
+                    >
+                      Off
+                    </button>
+                    <button
+                      type="button"
+                      data-on={notesEnabled}
+                      aria-pressed={notesEnabled}
+                      onClick={() => onNotesEnabled(true)}
+                    >
+                      On
+                    </button>
+                  </div>
+                </div>
+              </div>
             ) : null}
 
             {activeArea === "display" ? (

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -214,6 +214,26 @@ describe("NoteEditor actions", () => {
     expect(container.querySelector('[aria-label="Attach to current pane"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="View pane"]')).toBeNull();
   });
+
+  it("can show the current linked pane action for compact full-screen notes", async () => {
+    const onSave = vi.fn(() => Promise.resolve(6));
+    const { container, render } = createEditorHarness(onSave);
+    const currentPaneNote = noteEntry({
+      revision: 5,
+      body: "",
+      linkState: "linked",
+      attachmentPaneId: "pane-a",
+      resolvedPaneId: "pane-a",
+    });
+
+    await render(currentPaneNote);
+
+    expect(container.querySelector('[aria-label="View pane"]')).toBeNull();
+
+    await render(currentPaneNote, { showCurrentPaneViewAction: true });
+
+    expect(container.querySelector('[aria-label="View pane"]')).not.toBeNull();
+  });
 });
 
 function createEditorHarness(
@@ -224,7 +244,10 @@ function createEditorHarness(
   const root = createRoot(container);
   roots.push(root);
 
-  const render = async (entry: ScopedNoteEntry) => {
+  const render = async (
+    entry: ScopedNoteEntry,
+    options: { showCurrentPaneViewAction?: boolean } = {},
+  ) => {
     await act(async () => {
       root.render(
         <NoteEditor
@@ -232,6 +255,7 @@ function createEditorHarness(
           currentBridgeId="bridge-a"
           currentPaneId="pane-a"
           canAttachToCurrentPane
+          showCurrentPaneViewAction={options.showCurrentPaneViewAction}
           onSave={onSave}
           onAttachToCurrentPane={vi.fn()}
           onDetach={vi.fn()}
@@ -254,6 +278,7 @@ function noteEntry({
   body,
   linkState = "detached",
   attachmentPaneId,
+  resolvedPaneId,
 }: {
   noteId?: string;
   revision: number;
@@ -261,7 +286,19 @@ function noteEntry({
   body: string;
   linkState?: "linked" | "unresolved" | "detached";
   attachmentPaneId?: string;
+  resolvedPaneId?: string;
 }): ScopedNoteEntry {
+  const resolvedPane = resolvedPaneId
+    ? {
+        pane_id: resolvedPaneId,
+        terminal_id: "terminal-a",
+        workspace_id: "workspace-a",
+        tab_id: "tab-a",
+        focused: true,
+        agent_status: "idle" as const,
+        revision: 1,
+      }
+    : undefined;
   return {
     bridgeId: "bridge-a",
     connectionKey: "http://bridge-a",
@@ -291,7 +328,9 @@ function noteEntry({
       attachment_history: [],
       revision,
       link_state: linkState,
+      resolved_pane: resolvedPane,
     },
+    pane: resolvedPane,
   };
 }
 

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -224,6 +224,76 @@ describe("NoteEditor autosave conflicts", () => {
 });
 
 describe("NoteEditor actions", () => {
+  it("renders markdown preview and persists the selected editor mode", async () => {
+    const onSave = vi.fn(() => Promise.resolve(6));
+    const { container, render } = createEditorHarness(onSave);
+
+    await render(noteEntry({ revision: 5, body: "# Heading\n\n- item" }));
+    await act(async () => {
+      buttonByText(container, "Preview").click();
+      await vi.dynamicImportSettled();
+    });
+
+    expect(container.querySelector(".note-body-input")).toBeNull();
+    expect(container.querySelector(".note-body-preview h1")?.textContent).toBe("Heading");
+    expect(container.querySelector(".note-body-preview li")?.textContent).toBe("item");
+    expect(localStorage.getItem("herdr-web:note-editor-mode:v1")).toBe("preview");
+
+    await act(async () => {
+      buttonByText(container, "Edit").click();
+    });
+
+    expect(noteBodyInput(container).value).toBe("# Heading\n\n- item");
+    expect(localStorage.getItem("herdr-web:note-editor-mode:v1")).toBe("edit");
+  });
+
+  it("restores the persisted markdown preview mode", async () => {
+    localStorage.setItem("herdr-web:note-editor-mode:v1", "preview");
+    const onSave = vi.fn(() => Promise.resolve(6));
+    const { container, render } = createEditorHarness(onSave);
+
+    await render(noteEntry({ revision: 5, body: "**bold**" }));
+    await act(async () => {
+      await vi.dynamicImportSettled();
+    });
+
+    expect(container.querySelector(".note-body-input")).toBeNull();
+    expect(container.querySelector(".note-body-preview strong")?.textContent).toBe("bold");
+  });
+
+  it("escapes raw HTML, blocks remote images, and restricts markdown links", async () => {
+    const onSave = vi.fn(() => Promise.resolve(6));
+    const { container, render } = createEditorHarness(onSave);
+
+    await render(
+      noteEntry({
+        revision: 5,
+        body: [
+          "<script>alert('x')</script>",
+          "![pixel](https://attacker.example/pixel.png)",
+          "[web](https://example.com)",
+          "[mail](mailto:test@example.com)",
+          "[script](javascript:alert(1))",
+        ].join("\n\n"),
+      }),
+    );
+    await act(async () => {
+      buttonByText(container, "Preview").click();
+      await vi.dynamicImportSettled();
+    });
+
+    expect(container.querySelector(".note-body-preview script")).toBeNull();
+    expect(container.querySelector(".note-body-preview img")).toBeNull();
+    const webLink = container.querySelector<HTMLAnchorElement>(
+      '.note-body-preview a[href="https://example.com/"]',
+    );
+    expect(webLink?.target).toBe("_blank");
+    expect(webLink?.rel).toContain("noopener");
+    expect(webLink?.rel).toContain("noreferrer");
+    expect(container.querySelector('.note-body-preview a[href^="mailto:"]')).toBeNull();
+    expect(container.querySelector('.note-body-preview a[href^="javascript:"]')).toBeNull();
+  });
+
   it("allows unresolved notes with a matching stale pane id to be reattached", async () => {
     const onSave = vi.fn(() => Promise.resolve(6));
     const { container, render } = createEditorHarness(onSave);
@@ -394,6 +464,16 @@ function noteBodyInput(container: HTMLElement) {
     throw new Error("missing note body input");
   }
   return input;
+}
+
+function buttonByText(container: HTMLElement, text: string) {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (item) => item.textContent === text,
+  );
+  if (!button) {
+    throw new Error(`missing button: ${text}`);
+  }
+  return button;
 }
 
 function setNativeValue(element: HTMLTextAreaElement, value: string) {

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -161,6 +161,32 @@ describe("NoteEditor autosave conflicts", () => {
     expect(noteBodyInput(container).value).toBe("local draft");
   });
 
+  it("does not starve autosave when parent renders replace entry and save callback identities", async () => {
+    const saves: Array<{ body: string; expectedRevision: number }> = [];
+    const saveFactory = () =>
+      vi.fn((_entry: ScopedNoteEntry, _title: string, body: string, expectedRevision: number) => {
+        saves.push({ body, expectedRevision });
+        return Promise.resolve(6);
+      });
+    const { container, render } = createEditorHarness(saveFactory());
+
+    await render(noteEntry({ revision: 5, body: "" }));
+    await changeTextarea(container, "local draft");
+
+    for (let index = 0; index < 3; index += 1) {
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+      await render(noteEntry({ revision: 5, body: "" }), { onSave: saveFactory() });
+    }
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(saves).toEqual([{ body: "local draft", expectedRevision: 5 }]);
+  });
+
   it("reloads persisted dirty drafts as conflict only when the server revision advanced", async () => {
     const onSave = vi.fn(() => Promise.resolve(7));
     const { container, render } = createEditorHarness(onSave);
@@ -246,7 +272,15 @@ function createEditorHarness(
 
   const render = async (
     entry: ScopedNoteEntry,
-    options: { showCurrentPaneViewAction?: boolean } = {},
+    options: {
+      showCurrentPaneViewAction?: boolean;
+      onSave?: (
+        entry: ScopedNoteEntry,
+        title: string,
+        body: string,
+        expectedRevision: number,
+      ) => Promise<number>;
+    } = {},
   ) => {
     await act(async () => {
       root.render(
@@ -256,7 +290,7 @@ function createEditorHarness(
           currentPaneId="pane-a"
           canAttachToCurrentPane
           showCurrentPaneViewAction={options.showCurrentPaneViewAction}
-          onSave={onSave}
+          onSave={options.onSave ?? onSave}
           onAttachToCurrentPane={vi.fn()}
           onDetach={vi.fn()}
           onArchive={vi.fn()}

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -197,6 +197,25 @@ describe("NoteEditor autosave conflicts", () => {
   });
 });
 
+describe("NoteEditor actions", () => {
+  it("allows unresolved notes with a matching stale pane id to be reattached", async () => {
+    const onSave = vi.fn(() => Promise.resolve(6));
+    const { container, render } = createEditorHarness(onSave);
+
+    await render(
+      noteEntry({
+        revision: 5,
+        body: "",
+        linkState: "unresolved",
+        attachmentPaneId: "pane-a",
+      }),
+    );
+
+    expect(container.querySelector('[aria-label="Attach to current pane"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="View pane"]')).toBeNull();
+  });
+});
+
 function createEditorHarness(
   onSave: (entry: ScopedNoteEntry, title: string, body: string, expectedRevision: number) => Promise<number>,
 ) {
@@ -233,11 +252,15 @@ function noteEntry({
   revision,
   title = "Server title",
   body,
+  linkState = "detached",
+  attachmentPaneId,
 }: {
   noteId?: string;
   revision: number;
   title?: string;
   body: string;
+  linkState?: "linked" | "unresolved" | "detached";
+  attachmentPaneId?: string;
 }): ScopedNoteEntry {
   return {
     bridgeId: "bridge-a",
@@ -255,9 +278,19 @@ function noteEntry({
       created_at: "1",
       updated_at: String(revision),
       session_key: "session-a",
+      attachment: attachmentPaneId
+        ? {
+            type: "pane",
+            pane_id: attachmentPaneId,
+            workspace_id: "workspace-a",
+            tab_id: "tab-a",
+            captured_at: "1",
+            context: {},
+          }
+        : undefined,
       attachment_history: [],
       revision,
-      link_state: "detached",
+      link_state: linkState,
     },
   };
 }

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -455,7 +455,7 @@ async function advanceAutosaveTimer() {
 }
 
 function editorStatus(container: HTMLElement) {
-  return container.querySelector(".note-editor-status")?.textContent ?? "";
+  return container.querySelector(".note-editor-save-status")?.textContent ?? "";
 }
 
 function noteBodyInput(container: HTMLElement) {

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -218,7 +218,7 @@ describe("NoteEditor autosave conflicts", () => {
     );
     await render(matchingBaseEntry);
 
-    expect(editorStatus(container)).toBe("pending");
+    expect(editorStatus(container)).toBe("");
     expect(noteBodyInput(container).value).toBe("local draft");
   });
 });

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -1,11 +1,12 @@
 /**
  * @vitest-environment jsdom
  */
-import { act } from "react";
+import { act, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { NoteEditor, noteDraftStorageKey } from "./App";
-import type { ScopedNoteEntry } from "./App";
+import { BridgeConnectionController, NoteEditor, noteDraftStorageKey } from "./App";
+import type { BridgeConnectionRef, BridgeConnectionState, ScopedNoteEntry } from "./App";
+import type { BridgeRuntime } from "./bridge";
 
 type Deferred<T> = {
   promise: Promise<T>;
@@ -17,6 +18,7 @@ const roots: Root[] = [];
 
 beforeEach(() => {
   (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  FakeWebSocket.instances = [];
   vi.useFakeTimers();
 });
 
@@ -29,6 +31,41 @@ afterEach(async () => {
   document.body.innerHTML = "";
   localStorage.clear();
   vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("BridgeConnectionController sockets", () => {
+  it("does not recreate event sockets when only the notes callback identity changes", async () => {
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(emptySnapshot()), { status: 200 })),
+    );
+    const connectionRefs = { current: {} } as MutableRefObject<Record<string, BridgeConnectionRef>>;
+    const setConnectionStates = vi.fn() as unknown as Dispatch<
+      SetStateAction<Record<string, BridgeConnectionState>>
+    >;
+    const runtime = bridgeRuntime("bridge-a");
+    const { render } = createConnectionHarness({
+      runtime,
+      connectionRefs,
+      setConnectionStates,
+    });
+
+    await render(vi.fn());
+
+    expect(FakeWebSocket.instances.map((socket) => socket.url)).toEqual([
+      "ws://bridge-a/ws/events",
+      "ws://bridge-a/ws/activity",
+      "ws://bridge-a/ws/ui-events",
+    ]);
+
+    await render(vi.fn());
+
+    expect(FakeWebSocket.instances).toHaveLength(3);
+    expect(FakeWebSocket.instances.filter((socket) => socket.closed)).toHaveLength(0);
+  });
 });
 
 describe("NoteEditor autosave conflicts", () => {
@@ -229,4 +266,82 @@ function createDeferred<T>(): Deferred<T> {
     reject = promiseReject;
   });
   return { promise, resolve, reject };
+}
+
+function createConnectionHarness({
+  runtime,
+  connectionRefs,
+  setConnectionStates,
+}: {
+  runtime: BridgeRuntime;
+  connectionRefs: MutableRefObject<Record<string, BridgeConnectionRef>>;
+  setConnectionStates: Dispatch<SetStateAction<Record<string, BridgeConnectionState>>>;
+}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const onPaneSelection = vi.fn();
+  roots.push(root);
+
+  const render = async (onNotesChanged: (bridgeId: string) => void) => {
+    await act(async () => {
+      root.render(
+        <BridgeConnectionController
+          runtime={runtime}
+          connectionRefs={connectionRefs}
+          setConnectionStates={setConnectionStates}
+          onPaneSelection={onPaneSelection}
+          onNotesChanged={onNotesChanged}
+        />,
+      );
+      await Promise.resolve();
+    });
+  };
+
+  return { render };
+}
+
+function bridgeRuntime(bridgeId: string): BridgeRuntime {
+  return {
+    id: bridgeId,
+    mode: "configured",
+    label: bridgeId,
+    color: "#89b4fa",
+    backend: null,
+    connectionKey: bridgeId,
+    resumeToken: 0,
+    capabilities: { commands: [], notes: { version: 1 } },
+    capabilityState: "ready",
+    capabilityError: null,
+    canConnect: true,
+    httpUrl: (path) => `http://${bridgeId}${path}`,
+    wsUrl: (path) => `ws://${bridgeId}${path}`,
+  };
+}
+
+function emptySnapshot() {
+  return {
+    workspaces: [],
+    tabs: [],
+    panes: [],
+    layouts: [],
+  };
+}
+
+class FakeWebSocket extends EventTarget {
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  closed = false;
+
+  constructor(url: string | URL) {
+    super();
+    this.url = String(url);
+    FakeWebSocket.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+    this.dispatchEvent(new CloseEvent("close"));
+  }
 }

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -304,6 +304,7 @@ function noteEntry({
     connectionKey: "http://bridge-a",
     storeId: "store-a",
     sessionKey: "session-a",
+    bridgeSessionKey: "session-a",
     bridgeIndex: 0,
     bridgeLabel: "Bridge A",
     bridgeColor: "#89b4fa",

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NoteEditor, noteDraftStorageKey } from "./App";
+import type { ScopedNoteEntry } from "./App";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) {
+      root.unmount();
+    }
+  });
+  document.body.innerHTML = "";
+  localStorage.clear();
+  vi.useRealTimers();
+});
+
+describe("NoteEditor autosave conflicts", () => {
+  it("keeps continued typing pending when the user's in-flight save appears in a refetch", async () => {
+    const saves: Array<{
+      title: string;
+      body: string;
+      expectedRevision: number;
+      deferred: Deferred<number>;
+    }> = [];
+    const onSave = vi.fn((_entry: ScopedNoteEntry, title: string, body: string, expectedRevision: number) => {
+      const deferred = createDeferred<number>();
+      saves.push({ title, body, expectedRevision, deferred });
+      return deferred.promise;
+    });
+    const { container, render } = createEditorHarness(onSave);
+
+    await render(noteEntry({ revision: 5, body: "" }));
+    await changeTextarea(container, "abc");
+    await advanceAutosaveTimer();
+
+    expect(saves).toHaveLength(1);
+    expect(saves[0]).toMatchObject({ body: "abc", expectedRevision: 5 });
+
+    await changeTextarea(container, "abcd");
+    await render(noteEntry({ revision: 6, body: "abc" }));
+
+    expect(editorStatus(container)).not.toBe("conflict");
+    expect(noteBodyInput(container).value).toBe("abcd");
+
+    await act(async () => {
+      saves[0].deferred.resolve(6);
+      await Promise.resolve();
+    });
+    await advanceAutosaveTimer();
+
+    expect(editorStatus(container)).not.toBe("conflict");
+    expect(saves).toHaveLength(2);
+    expect(saves[1]).toMatchObject({ body: "abcd", expectedRevision: 6 });
+  });
+
+  it("enters conflict when a divergent server revision arrives under a dirty draft", async () => {
+    const saves: Array<{ body: string; expectedRevision: number; deferred: Deferred<number> }> = [];
+    const onSave = vi.fn((_entry: ScopedNoteEntry, _title: string, body: string, expectedRevision: number) => {
+      const deferred = createDeferred<number>();
+      saves.push({ body, expectedRevision, deferred });
+      return deferred.promise;
+    });
+    const { container, render } = createEditorHarness(onSave);
+
+    await render(noteEntry({ revision: 5, body: "" }));
+    await changeTextarea(container, "local draft");
+    await advanceAutosaveTimer();
+    await render(noteEntry({ revision: 6, body: "remote edit" }));
+
+    expect(saves).toHaveLength(1);
+    expect(saves[0]).toMatchObject({ body: "local draft", expectedRevision: 5 });
+    expect(editorStatus(container)).toBe("conflict");
+    expect(noteBodyInput(container).value).toBe("local draft");
+  });
+
+  it("reloads persisted dirty drafts as conflict only when the server revision advanced", async () => {
+    const onSave = vi.fn(() => Promise.resolve(7));
+    const { container, render } = createEditorHarness(onSave);
+    const advancedEntry = noteEntry({ revision: 6, body: "remote edit" });
+
+    localStorage.setItem(
+      noteDraftStorageKey(advancedEntry),
+      JSON.stringify({
+        title: "Local title",
+        body: "local draft",
+        baseRevision: 5,
+        updatedAt: 100,
+      }),
+    );
+    await render(advancedEntry);
+
+    expect(editorStatus(container)).toBe("conflict");
+    expect(noteBodyInput(container).value).toBe("local draft");
+
+    const matchingBaseEntry = noteEntry({ noteId: "note-2", revision: 6, body: "remote edit" });
+    localStorage.setItem(
+      noteDraftStorageKey(matchingBaseEntry),
+      JSON.stringify({
+        title: "Local title",
+        body: "local draft",
+        baseRevision: 6,
+        updatedAt: 200,
+      }),
+    );
+    await render(matchingBaseEntry);
+
+    expect(editorStatus(container)).toBe("pending");
+    expect(noteBodyInput(container).value).toBe("local draft");
+  });
+});
+
+function createEditorHarness(
+  onSave: (entry: ScopedNoteEntry, title: string, body: string, expectedRevision: number) => Promise<number>,
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+
+  const render = async (entry: ScopedNoteEntry) => {
+    await act(async () => {
+      root.render(
+        <NoteEditor
+          entry={entry}
+          canAttachToCurrentPane
+          onSave={onSave}
+          onAttachToCurrentPane={vi.fn()}
+          onDetach={vi.fn()}
+          onArchive={vi.fn()}
+          onRestore={vi.fn()}
+          onDelete={vi.fn()}
+          onViewPane={vi.fn()}
+        />,
+      );
+    });
+  };
+
+  return { container, render };
+}
+
+function noteEntry({
+  noteId = "note-1",
+  revision,
+  title = "Server title",
+  body,
+}: {
+  noteId?: string;
+  revision: number;
+  title?: string;
+  body: string;
+}): ScopedNoteEntry {
+  return {
+    bridgeId: "bridge-a",
+    connectionKey: "http://bridge-a",
+    storeId: "store-a",
+    sessionKey: "session-a",
+    bridgeIndex: 0,
+    bridgeLabel: "Bridge A",
+    bridgeColor: "#89b4fa",
+    snapshot: null,
+    note: {
+      note_id: noteId,
+      title,
+      body,
+      created_at: "1",
+      updated_at: String(revision),
+      session_key: "session-a",
+      attachment_history: [],
+      revision,
+      link_state: "detached",
+    },
+  };
+}
+
+async function changeTextarea(container: HTMLElement, value: string) {
+  const input = noteBodyInput(container);
+  await act(async () => {
+    setNativeValue(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function advanceAutosaveTimer() {
+  await act(async () => {
+    vi.advanceTimersByTime(700);
+    await Promise.resolve();
+  });
+}
+
+function editorStatus(container: HTMLElement) {
+  return container.querySelector(".note-editor-status")?.textContent ?? "";
+}
+
+function noteBodyInput(container: HTMLElement) {
+  const input = container.querySelector<HTMLTextAreaElement>(".note-body-input");
+  if (!input) {
+    throw new Error("missing note body input");
+  }
+  return input;
+}
+
+function setNativeValue(element: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+  setter?.call(element, value);
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -107,6 +107,40 @@ describe("NoteEditor autosave conflicts", () => {
     expect(saves[1]).toMatchObject({ body: "abcd", expectedRevision: 6 });
   });
 
+  it("does not flag stale server props as a conflict after a local save resolves", async () => {
+    const saves: Array<{
+      body: string;
+      expectedRevision: number;
+      deferred: Deferred<number>;
+    }> = [];
+    const onSave = vi.fn((_entry: ScopedNoteEntry, _title: string, body: string, expectedRevision: number) => {
+      const deferred = createDeferred<number>();
+      saves.push({ body, expectedRevision, deferred });
+      return deferred.promise;
+    });
+    const { container, render } = createEditorHarness(onSave);
+
+    await render(noteEntry({ revision: 5, body: "" }));
+    await changeTextarea(container, "abc");
+    await advanceAutosaveTimer();
+
+    expect(saves).toHaveLength(1);
+    expect(saves[0]).toMatchObject({ body: "abc", expectedRevision: 5 });
+
+    await act(async () => {
+      saves[0].deferred.resolve(6);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await changeTextarea(container, "abcd");
+    await advanceAutosaveTimer();
+
+    expect(editorStatus(container)).not.toBe("conflict");
+    expect(noteBodyInput(container).value).toBe("abcd");
+    expect(saves).toHaveLength(2);
+    expect(saves[1]).toMatchObject({ body: "abcd", expectedRevision: 6 });
+  });
+
   it("enters conflict when a divergent server revision arrives under a dirty draft", async () => {
     const saves: Array<{ body: string; expectedRevision: number; deferred: Deferred<number> }> = [];
     const onSave = vi.fn((_entry: ScopedNoteEntry, _title: string, body: string, expectedRevision: number) => {
@@ -176,6 +210,8 @@ function createEditorHarness(
       root.render(
         <NoteEditor
           entry={entry}
+          currentBridgeId="bridge-a"
+          currentPaneId="pane-a"
           canAttachToCurrentPane
           onSave={onSave}
           onAttachToCurrentPane={vi.fn()}

--- a/web/src/NoteMarkdownPreview.tsx
+++ b/web/src/NoteMarkdownPreview.tsx
@@ -1,0 +1,44 @@
+import ReactMarkdown from "react-markdown";
+import type { UrlTransform } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export type NoteMarkdownPreviewProps = {
+  body: string;
+};
+
+export default function NoteMarkdownPreview({ body }: NoteMarkdownPreviewProps) {
+  if (!body.trim()) {
+    return <span className="note-body-preview-empty">No content</span>;
+  }
+  return (
+    <ReactMarkdown
+      disallowedElements={["img"]}
+      remarkPlugins={[remarkGfm]}
+      urlTransform={safeMarkdownUrl}
+      components={{
+        a: ({ children, href, ...props }) =>
+          href ? (
+            <a {...props} href={href} target="_blank" rel="noopener noreferrer">
+              {children}
+            </a>
+          ) : (
+            <span>{children}</span>
+          ),
+      }}
+    >
+      {body}
+    </ReactMarkdown>
+  );
+}
+
+const safeMarkdownUrl: UrlTransform = (url, key) => {
+  if (key !== "href") {
+    return null;
+  }
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed.href : null;
+  } catch {
+    return null;
+  }
+};

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -5,6 +5,7 @@ import {
   capabilityProbeFailure,
   capabilityProbeSuccess,
   capabilityRetryDelayMs,
+  configuredBridgeConnectionKey,
   duplicateBackend,
   loadBackendStore,
   normalizeBridgeBaseUrl,
@@ -12,6 +13,7 @@ import {
   parseBackendStore,
   parseCapabilities,
   probeBridgeBaseUrl,
+  removeNoteDraftsForBridgeConnection,
   SAME_ORIGIN_BRIDGE_ID,
 } from "./bridge";
 
@@ -251,6 +253,31 @@ describe("backend store parsing", () => {
 
     expect(duplicateBackend(backends, "192.168.1.20:4000")?.id).toBe("one");
     expect(duplicateBackend(backends, "192.168.1.20:4000", "one")).toBeNull();
+  });
+
+  it("removes note drafts scoped to a retired backend connection", () => {
+    const retained = "herdr-web:note-draft:v1:two:configured%3Atwo%3Ahttp%3A%2F%2Fold:store:session:note";
+    const removed = `herdr-web:note-draft:v1:${encodeURIComponent("one")}:${encodeURIComponent(
+      configuredBridgeConnectionKey("one", "http://old"),
+    )}:store:session:note`;
+    const storage = new Map([
+      [retained, "{}"],
+      [removed, "{}"],
+    ]);
+    vi.stubGlobal("localStorage", {
+      get length() {
+        return storage.size;
+      },
+      key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+      removeItem: vi.fn((key: string) => {
+        storage.delete(key);
+      }),
+    });
+
+    removeNoteDraftsForBridgeConnection("one", configuredBridgeConnectionKey("one", "http://old"));
+
+    expect(storage.has(removed)).toBe(false);
+    expect(storage.has(retained)).toBe(true);
   });
 });
 

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -293,12 +293,14 @@ describe("capabilities", () => {
         bridge_version: "1.2.3",
         web_compat: 1,
         min_android_app_compat: 2,
+        notes: { version: 1 },
       }),
     ).toEqual({
       commands: ["pane.split"],
       bridge_version: "1.2.3",
       web_compat: 1,
       min_android_app_compat: 2,
+      notes: { version: 1 },
     });
   });
 

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -97,6 +97,7 @@ export type BackendInput = {
 
 const STORE_KEY = "herdrWeb.bridgeBackends.v2";
 const LEGACY_STORE_KEY = "herdrWeb.bridgeBackends.v1";
+const NOTE_DRAFT_STORAGE_PREFIX = "herdr-web:note-draft:v1:";
 const STORE_VERSION = 2;
 const APP_MIN_WEB_COMPAT = 1;
 export const SAME_ORIGIN_BRIDGE_COLOR = "#b4befe";
@@ -312,6 +313,9 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
     }
     storeEditedRef.current = true;
     const baseUrl = normalizeBridgeBaseUrl(input.baseUrl);
+    if (baseUrl !== existing.baseUrl) {
+      removeNoteDraftsForBridgeConnection(id, configuredBridgeConnectionKey(id, existing.baseUrl));
+    }
     const otherBackends = store.backends.filter((backend) => backend.id !== id);
     const updated: BridgeBackendProfile = {
       ...existing,
@@ -333,6 +337,10 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
   }, [store.backends, store.enabledBridgeIds]);
 
   const deleteBackend = useCallback((id: string) => {
+    const existing = store.backends.find((backend) => backend.id === id);
+    if (existing) {
+      removeNoteDraftsForBridgeConnection(id, configuredBridgeConnectionKey(id, existing.baseUrl));
+    }
     storeEditedRef.current = true;
     setStore((current) => {
       const backends = current.backends.filter((backend) => backend.id !== id);
@@ -346,7 +354,7 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
         backends,
       };
     });
-  }, []);
+  }, [store.backends]);
 
   const probeBackend = useCallback((baseUrl: string) => probeBridgeBaseUrl(baseUrl), []);
 
@@ -568,7 +576,10 @@ function createBridgeRuntime({
   probeState: BridgeProbeState | undefined;
   resumeToken: number;
 }): BridgeRuntime {
-  const connectionKey = mode === "same-origin" ? SAME_ORIGIN_BRIDGE_ID : `configured:${id}:${baseUrl}`;
+  const connectionKey =
+    mode === "same-origin"
+      ? SAME_ORIGIN_BRIDGE_ID
+      : configuredBridgeConnectionKey(id, baseUrl ?? "");
   const currentProbeState = probeState?.connectionKey === connectionKey ? probeState : undefined;
   const httpUrl = (path: string, query?: URLSearchParams) => buildHttpUrl(baseUrl, path, query);
   const wsUrl = (path: string, query?: URLSearchParams) => buildWsUrl(baseUrl, path, query);
@@ -937,6 +948,34 @@ export function buildWsUrl(
     url.search = query.toString();
   }
   return url.toString();
+}
+
+export function configuredBridgeConnectionKey(id: BridgeId, baseUrl: string) {
+  return `configured:${id}:${baseUrl}`;
+}
+
+export function removeNoteDraftsForBridgeConnection(bridgeId: BridgeId, connectionKey: string) {
+  const draftPrefix = `${NOTE_DRAFT_STORAGE_PREFIX}${encodeURIComponent(
+    bridgeId,
+  )}:${encodeURIComponent(connectionKey)}:`;
+  try {
+    const storage = globalThis.localStorage;
+    if (!storage) {
+      return;
+    }
+    const keys: string[] = [];
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key?.startsWith(draftPrefix)) {
+        keys.push(key);
+      }
+    }
+    for (const key of keys) {
+      storage.removeItem(key);
+    }
+  } catch {
+    // Draft cleanup is best-effort; stale keys are isolated by connection key.
+  }
 }
 
 function normalizeEndpointPath(path: string) {

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -36,6 +36,9 @@ export type BridgeMode = "same-origin" | "configured";
 
 export type BridgeCapabilities = {
   commands: string[];
+  notes?: {
+    version: 1;
+  };
   bridge_version?: string;
   web_compat?: number;
   min_android_app_compat?: number;
@@ -1019,6 +1022,10 @@ export function parseCapabilities(value: unknown): BridgeCapabilities {
     web_compat: typeof value.web_compat === "number" ? value.web_compat : undefined,
     min_android_app_compat:
       typeof value.min_android_app_compat === "number" ? value.min_android_app_compat : undefined,
+    notes:
+      isRecord(value.notes) && value.notes.version === 1
+        ? { version: 1 }
+        : undefined,
   };
 }
 

--- a/web/src/notes.test.ts
+++ b/web/src/notes.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { notesForPane, supportsNotes } from "./notes";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NotesApiError, createNote, isNotesConflictError, notesForPane, supportsNotes } from "./notes";
 import type { PaneNote } from "./notes";
 
 describe("notes helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("checks the bridge notes capability", () => {
     expect(supportsNotes({ commands: [], notes: { version: 1 } })).toBe(true);
     expect(supportsNotes({ commands: [] })).toBe(false);
@@ -19,6 +23,28 @@ describe("notes helpers", () => {
     ];
 
     expect(notesForPane(notes, "p1").map((item) => item.note_id)).toEqual(["n5", "n1"]);
+  });
+
+  it("preserves HTTP status for note mutation errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ error: "note has changed" }), {
+          status: 409,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(createNote((path) => `http://bridge${path}`, {})).rejects.toMatchObject({
+      name: "NotesApiError",
+      status: 409,
+      message: "note has changed",
+    });
+
+    const error = new NotesApiError("note has changed", 409);
+    expect(isNotesConflictError(error)).toBe(true);
+    expect(isNotesConflictError(new NotesApiError("bad", 400))).toBe(false);
   });
 });
 

--- a/web/src/notes.test.ts
+++ b/web/src/notes.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { notesForPane, supportsNotes } from "./notes";
+import type { PaneNote } from "./notes";
+
+describe("notes helpers", () => {
+  it("checks the bridge notes capability", () => {
+    expect(supportsNotes({ commands: [], notes: { version: 1 } })).toBe(true);
+    expect(supportsNotes({ commands: [] })).toBe(false);
+    expect(supportsNotes(null)).toBe(false);
+  });
+
+  it("returns only active linked notes for the selected pane", () => {
+    const notes: PaneNote[] = [
+      note("n1", "p1", "linked", "200"),
+      note("n2", "p1", "unresolved", "300"),
+      note("n3", "p2", "linked", "400"),
+      { ...note("n4", "p1", "linked", "500"), archived_at: "501" },
+      note("n5", "p1", "linked", "600"),
+    ];
+
+    expect(notesForPane(notes, "p1").map((item) => item.note_id)).toEqual(["n5", "n1"]);
+  });
+});
+
+function note(
+  noteId: string,
+  paneId: string,
+  linkState: PaneNote["link_state"],
+  updatedAt: string,
+): PaneNote {
+  return {
+    note_id: noteId,
+    title: noteId,
+    body: "",
+    created_at: "100",
+    updated_at: updatedAt,
+    session_key: "session:default",
+    attachment: {
+      type: "pane",
+      pane_id: paneId,
+      workspace_id: "w1",
+      tab_id: "t1",
+      terminal_id: "term1",
+      captured_at: "100",
+      context: {},
+    },
+    attachment_history: [],
+    revision: 1,
+    link_state: linkState,
+    resolved_pane:
+      linkState === "linked"
+        ? {
+            pane_id: paneId,
+            terminal_id: "term1",
+            workspace_id: "w1",
+            tab_id: "t1",
+            focused: false,
+            agent_status: "unknown",
+            revision: 1,
+          }
+        : undefined,
+  };
+}

--- a/web/src/notes.ts
+++ b/web/src/notes.ts
@@ -1,0 +1,216 @@
+import { fetchWithTimeout } from "./fetchWithTimeout";
+import type { PaneInfo } from "./types";
+import type { BridgeCapabilities } from "./bridge";
+
+export type NoteLinkState = "linked" | "unresolved" | "detached";
+
+export type NotePaneContext = {
+  pane_label?: string;
+  pane_title?: string;
+  agent?: string;
+  display_agent?: string;
+  cwd?: string;
+  foreground_cwd?: string;
+};
+
+export type NoteAttachment = {
+  type: "pane";
+  pane_id: string;
+  workspace_id: string;
+  tab_id: string;
+  terminal_id?: string;
+  pane_revision?: number;
+  observed_generation?: string;
+  captured_at: string;
+  context: NotePaneContext;
+};
+
+export type PaneNote = {
+  note_id: string;
+  title: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+  archived_at?: string;
+  deleted_at?: string;
+  session_key: string;
+  attachment?: NoteAttachment | null;
+  attachment_history: NoteAttachment[];
+  revision: number;
+  link_state: NoteLinkState;
+  resolved_pane?: PaneInfo;
+};
+
+export type NotesListResponse = {
+  store_id: string;
+  session_key: string;
+  notes: PaneNote[];
+};
+
+export type NotesListOptions = {
+  includeArchived?: boolean;
+  includeDeleted?: boolean;
+  includeOtherSessions?: boolean;
+  paneId?: string;
+};
+
+export type NoteCreateInput = {
+  title?: string;
+  body?: string;
+  paneId?: string;
+};
+
+export type NoteUpdateInput = {
+  title?: string;
+  body?: string;
+  expectedRevision: number;
+};
+
+export type NoteAttachInput = {
+  paneId: string;
+  expectedRevision: number;
+};
+
+export type NoteRevisionInput = {
+  expectedRevision: number;
+};
+
+export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
+
+export function supportsNotes(capabilities: BridgeCapabilities | null | undefined) {
+  return capabilities?.notes?.version === 1;
+}
+
+export async function fetchNotes(
+  httpUrl: BridgeHttpUrl,
+  options: NotesListOptions = {},
+): Promise<NotesListResponse> {
+  const query = new URLSearchParams();
+  if (options.includeArchived) {
+    query.set("include_archived", "true");
+  }
+  if (options.includeDeleted) {
+    query.set("include_deleted", "true");
+  }
+  if (options.includeOtherSessions) {
+    query.set("include_other_sessions", "true");
+  }
+  if (options.paneId) {
+    query.set("pane_id", options.paneId);
+  }
+  const response = await fetchWithTimeout(httpUrl("/api/notes", query));
+  return parseNotesResponse(response);
+}
+
+export function createNote(httpUrl: BridgeHttpUrl, input: NoteCreateInput) {
+  return sendNoteMutation(httpUrl, "/api/notes", {
+    title: input.title,
+    body: input.body,
+    pane_id: input.paneId,
+  });
+}
+
+export function updateNote(httpUrl: BridgeHttpUrl, noteId: string, input: NoteUpdateInput) {
+  return sendNoteMutation(httpUrl, notePath(noteId, "update"), {
+    title: input.title,
+    body: input.body,
+    expected_revision: input.expectedRevision,
+  });
+}
+
+export function attachNote(httpUrl: BridgeHttpUrl, noteId: string, input: NoteAttachInput) {
+  return sendNoteMutation(httpUrl, notePath(noteId, "attach"), {
+    pane_id: input.paneId,
+    expected_revision: input.expectedRevision,
+  });
+}
+
+export function detachNote(httpUrl: BridgeHttpUrl, noteId: string, input: NoteRevisionInput) {
+  return sendNoteMutation(httpUrl, notePath(noteId, "detach"), {
+    expected_revision: input.expectedRevision,
+  });
+}
+
+export function archiveNote(httpUrl: BridgeHttpUrl, noteId: string, input: NoteRevisionInput) {
+  return sendNoteMutation(httpUrl, notePath(noteId, "archive"), {
+    expected_revision: input.expectedRevision,
+  });
+}
+
+export function restoreNote(httpUrl: BridgeHttpUrl, noteId: string, input: NoteRevisionInput) {
+  return sendNoteMutation(httpUrl, notePath(noteId, "restore"), {
+    expected_revision: input.expectedRevision,
+  });
+}
+
+export function deleteNote(httpUrl: BridgeHttpUrl, noteId: string, input: NoteRevisionInput) {
+  return sendNoteMutation(httpUrl, notePath(noteId, "delete"), {
+    expected_revision: input.expectedRevision,
+  });
+}
+
+export function notesForPane(notes: readonly PaneNote[], paneId: string | null | undefined) {
+  if (!paneId) {
+    return [];
+  }
+  return notes
+    .filter((note) => !note.archived_at && !note.deleted_at)
+    .filter(
+      (note) =>
+        note.link_state === "linked" &&
+        note.resolved_pane?.pane_id === paneId &&
+        note.attachment?.pane_id === paneId,
+    )
+    .sort(compareNotes);
+}
+
+export function compareNotes(a: PaneNote, b: PaneNote) {
+  const updated = Number(b.updated_at || 0) - Number(a.updated_at || 0);
+  if (updated !== 0) {
+    return updated;
+  }
+  return a.note_id.localeCompare(b.note_id, undefined, { numeric: true });
+}
+
+async function sendNoteMutation(
+  httpUrl: BridgeHttpUrl,
+  path: string,
+  body: Record<string, unknown>,
+) {
+  const response = await fetch(httpUrl(path), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return parseNoteResponse(response);
+}
+
+async function parseNotesResponse(response: Response) {
+  if (!response.ok) {
+    throw await notesApiError(response, "notes");
+  }
+  return (await response.json()) as NotesListResponse;
+}
+
+async function parseNoteResponse(response: Response) {
+  if (!response.ok) {
+    throw await notesApiError(response, "note mutation");
+  }
+  return (await response.json()) as PaneNote;
+}
+
+async function notesApiError(response: Response, fallback: string) {
+  try {
+    const parsed = (await response.json()) as { error?: unknown };
+    if (typeof parsed.error === "string" && parsed.error.trim()) {
+      return new Error(parsed.error);
+    }
+  } catch {
+    // Fall through to the status-based error.
+  }
+  return new Error(`${fallback} failed: ${response.status}`);
+}
+
+function notePath(noteId: string, action: string) {
+  return `/api/notes/${encodeURIComponent(noteId)}/${action}`;
+}

--- a/web/src/notes.ts
+++ b/web/src/notes.ts
@@ -77,6 +77,20 @@ export type NoteRevisionInput = {
 
 export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
 
+export class NotesApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "NotesApiError";
+    this.status = status;
+  }
+}
+
+export function isNotesConflictError(error: unknown): error is NotesApiError {
+  return error instanceof NotesApiError && error.status === 409;
+}
+
 export function supportsNotes(capabilities: BridgeCapabilities | null | undefined) {
   return capabilities?.notes?.version === 1;
 }
@@ -177,7 +191,7 @@ async function sendNoteMutation(
   path: string,
   body: Record<string, unknown>,
 ) {
-  const response = await fetch(httpUrl(path), {
+  const response = await fetchWithTimeout(httpUrl(path), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -203,12 +217,12 @@ async function notesApiError(response: Response, fallback: string) {
   try {
     const parsed = (await response.json()) as { error?: unknown };
     if (typeof parsed.error === "string" && parsed.error.trim()) {
-      return new Error(parsed.error);
+      return new NotesApiError(parsed.error, response.status);
     }
   } catch {
     // Fall through to the status-based error.
   }
-  return new Error(`${fallback} failed: ${response.status}`);
+  return new NotesApiError(`${fallback} failed: ${response.status}`, response.status);
 }
 
 function notePath(noteId: string, action: string) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -964,27 +964,25 @@ button {
   position: relative;
 }
 
+.notes-button::after {
+  position: absolute;
+  right: 12px;
+  bottom: 6px;
+  left: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: transparent;
+  content: "";
+}
+
+.notes-button[data-has-notes="true"]::after {
+  background: color-mix(in srgb, var(--teal) 70%, var(--overlay1));
+}
+
 .notes-button[data-active="true"] {
   border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
   color: var(--text);
   background: var(--accent-soft);
-}
-
-.notes-count {
-  position: absolute;
-  top: -5px;
-  right: -5px;
-  display: inline-grid;
-  min-width: 16px;
-  height: 16px;
-  place-items: center;
-  padding: 0 4px;
-  border: 1px solid var(--crust);
-  border-radius: 999px;
-  background: var(--teal);
-  color: var(--crust);
-  font-size: 10px;
-  font-weight: 700;
 }
 
 /* --------------------------------------------------------------- notes */
@@ -1222,7 +1220,8 @@ button {
 
 .notes-list-item {
   display: grid;
-  grid-template-columns: 12px minmax(0, 1fr);
+  grid-template-columns: 12px minmax(0, 1fr) 18px;
+  align-items: center;
   gap: 9px;
   width: 100%;
   padding: 8px 7px;
@@ -1258,19 +1257,12 @@ button {
   white-space: nowrap;
 }
 
-.notes-list-item-sub,
-.notes-list-item-state {
+.notes-list-item-sub {
   overflow: hidden;
   color: var(--overlay0);
   font-size: 10.5px;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.notes-list-item-state {
-  grid-column: 2;
-  margin-top: -1px;
-  color: var(--overlay1);
 }
 
 .note-editor {
@@ -1306,6 +1298,27 @@ button {
   font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.note-state-icon {
+  display: inline-grid;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--overlay1);
+}
+
+.note-state-icon[data-status="blocked"] {
+  color: var(--st-blocked);
+}
+
+.note-state-icon[data-status="working"] {
+  color: var(--st-working);
+}
+
+.note-state-icon[data-status="done"] {
+  color: var(--st-done);
 }
 
 .note-conflict {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -273,11 +273,24 @@ button {
   animation: spin 0.7s linear infinite;
 }
 
+.icon-btn.danger {
+  color: var(--red);
+}
+
+.icon-btn:disabled,
+.icon-btn:disabled:hover {
+  border-color: transparent;
+  color: var(--overlay0);
+  background: transparent;
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
 /* ---------------------------------------------------------- sidebar mode */
 
 .sidebar-mode {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 3px;
   flex: 0 0 auto;
   padding: 4px;
@@ -685,6 +698,14 @@ button {
   border-color: color-mix(in srgb, var(--st-done) 18%, transparent);
 }
 
+.note-row[data-link="unresolved"] {
+  border-color: color-mix(in srgb, var(--st-working) 18%, transparent);
+}
+
+.note-row[data-link="detached"] {
+  border-color: color-mix(in srgb, var(--overlay0) 18%, transparent);
+}
+
 .pane-meta {
   overflow: hidden;
   font-size: 11px;
@@ -915,6 +936,261 @@ button {
 .badge[data-status="done"] {
   border-color: color-mix(in srgb, var(--st-done) 45%, var(--line));
   color: var(--st-done);
+}
+
+.notes-button {
+  position: relative;
+}
+
+.notes-button[data-active="true"] {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  color: var(--text);
+  background: var(--accent-soft);
+}
+
+.notes-count {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  display: inline-grid;
+  min-width: 16px;
+  height: 16px;
+  place-items: center;
+  padding: 0 4px;
+  border: 1px solid var(--crust);
+  border-radius: 999px;
+  background: var(--teal);
+  color: var(--crust);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+/* --------------------------------------------------------------- notes */
+
+.notes-surface {
+  position: fixed;
+  z-index: 5;
+  top: var(--content-inset-top);
+  right: 0;
+  display: flex;
+  width: min(560px, calc(100vw - 48px));
+  height: calc(100dvh - var(--content-inset-top) - var(--content-inset-bottom));
+  flex-direction: column;
+  border-left: 1px solid var(--line);
+  background: var(--base);
+  box-shadow: -18px 0 48px rgb(0 0 0 / 0.36);
+}
+
+.notes-head {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 14px 0 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--mantle);
+}
+
+.notes-title {
+  display: block;
+  font-size: 15px;
+  font-weight: 650;
+  color: var(--text);
+}
+
+.notes-sub {
+  display: block;
+  max-width: 360px;
+  overflow: hidden;
+  color: var(--overlay1);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notes-shell {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.8fr) minmax(0, 1.2fr);
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.notes-list-pane {
+  min-width: 0;
+  overflow-y: auto;
+  border-right: 1px solid var(--line);
+  background: var(--sidebar-bg);
+}
+
+.notes-section {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  padding: 8px;
+}
+
+.notes-section + .notes-section {
+  border-top: 1px solid var(--line-soft);
+}
+
+.notes-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-height: 32px;
+  padding: 0 2px 0 6px;
+  color: var(--overlay1);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.notes-section-head > span {
+  flex: 1 1 auto;
+}
+
+.notes-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--overlay1);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.notes-filter input {
+  width: 12px;
+  height: 12px;
+  accent-color: var(--accent);
+}
+
+.notes-empty {
+  padding: 14px 8px 16px;
+  color: var(--overlay0);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.notes-list-item {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr);
+  gap: 9px;
+  width: 100%;
+  padding: 8px 7px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  background: transparent;
+  text-align: left;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.notes-list-item:hover {
+  background: var(--row-hover);
+}
+
+.notes-list-item[data-active="true"] {
+  border-color: var(--line);
+  background: var(--row-active);
+}
+
+.notes-list-item-body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.notes-list-item-title {
+  overflow: hidden;
+  color: var(--subtext1);
+  font-size: 12.5px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notes-list-item-sub,
+.notes-list-item-state {
+  overflow: hidden;
+  color: var(--overlay0);
+  font-size: 10.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notes-list-item-state {
+  grid-column: 2;
+  margin-top: -1px;
+  color: var(--overlay1);
+}
+
+.note-editor {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  background: var(--base);
+}
+
+.note-editor-empty {
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--overlay0);
+  font-size: 13px;
+}
+
+.note-editor-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 45px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.note-editor-status {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: var(--overlay1);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.note-title-input,
+.note-body-input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: none;
+  color: var(--text);
+  background: transparent;
+  font: inherit;
+}
+
+.note-title-input {
+  flex: 0 0 auto;
+  padding: 16px 16px 10px;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 18px;
+  font-weight: 650;
+}
+
+.note-body-input {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 14px 16px 20px;
+  resize: none;
+  color: var(--subtext1);
+  font-size: 13.5px;
+  line-height: 1.55;
 }
 
 /* ------------------------------------------------------------ terminal */
@@ -2421,6 +2697,44 @@ button {
 }
 
 .app[data-compact="true"] .sidebar-resizer {
+  display: none;
+}
+
+.app[data-compact="true"] .notes-surface,
+.notes-surface[data-compact="true"] {
+  top: var(--content-inset-top);
+  left: 0;
+  right: auto;
+  width: 100vw;
+  height: calc(100dvh - var(--content-inset-top) - var(--content-inset-bottom));
+  border-left: 0;
+  box-shadow: none;
+}
+
+.app[data-compact="true"] .notes-shell,
+.notes-surface[data-compact="true"] .notes-shell {
+  grid-template-columns: 1fr;
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.app[data-compact="true"] .notes-list-pane,
+.notes-surface[data-compact="true"] .notes-list-pane {
+  border-right: 0;
+  border-bottom: 0;
+}
+
+.app[data-compact="true"] .notes-head,
+.notes-surface[data-compact="true"] .notes-head {
+  min-height: 60px;
+}
+
+.app[data-compact="true"] .notes-surface[data-mobile-screen="list"] .note-editor,
+.notes-surface[data-compact="true"][data-mobile-screen="list"] .note-editor {
+  display: none;
+}
+
+.app[data-compact="true"] .notes-surface[data-mobile-screen="editor"] .notes-list-pane,
+.notes-surface[data-compact="true"][data-mobile-screen="editor"] .notes-list-pane {
   display: none;
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1266,6 +1266,7 @@ button {
 }
 
 .note-editor {
+  position: relative;
   display: flex;
   min-width: 0;
   min-height: 0;
@@ -1305,16 +1306,6 @@ button {
 
 .note-editor-actions {
   justify-content: flex-end;
-}
-
-.note-editor-status {
-  min-width: 0;
-  flex: 0 1 auto;
-  overflow: hidden;
-  color: var(--overlay1);
-  font-size: 11px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .note-editor-mode {
@@ -1400,7 +1391,7 @@ button {
 .note-body-input {
   flex: 1 1 auto;
   min-height: 0;
-  padding: 14px 16px 20px;
+  padding: 14px 16px 42px;
   resize: none;
   color: var(--subtext1);
   font-size: 13.5px;
@@ -1411,10 +1402,37 @@ button {
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
-  padding: 14px 16px 20px;
+  padding: 14px 16px 42px;
   color: var(--subtext1);
   font-size: 13px;
   line-height: 1.5;
+}
+
+.note-editor-save-status {
+  position: absolute;
+  right: 12px;
+  bottom: 10px;
+  z-index: 1;
+  max-width: min(180px, calc(100% - 24px));
+  overflow: hidden;
+  padding: 4px 7px;
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  color: var(--overlay1);
+  background: color-mix(in srgb, var(--surface0) 88%, transparent);
+  box-shadow: 0 6px 18px rgb(0 0 0 / 20%);
+  font-size: 10.5px;
+  line-height: 1;
+  pointer-events: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.note-editor-save-status[data-state="error"],
+.note-editor-save-status[data-state="conflict"] {
+  border-color: color-mix(in srgb, var(--peach) 42%, var(--line-soft));
+  color: var(--peach);
+  background: color-mix(in srgb, var(--peach) 12%, var(--surface0));
 }
 
 .note-body-preview > :first-child {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -53,6 +53,8 @@
   --r-md: 9px;
   --r-lg: 13px;
   --sidebar-w: 320px;
+  --notes-w: 560px;
+  --notes-list-w: 240px;
   --content-inset-top: 0px;
   --content-inset-bottom: 0px;
   --mobile-controls-scale: 1;
@@ -104,7 +106,7 @@ button {
 
 .app {
   display: grid;
-  grid-template-columns: var(--sidebar-w) minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-w) minmax(0, 1fr) 0;
   width: 100%;
   height: 100%;
   padding-block: var(--content-inset-top) var(--content-inset-bottom);
@@ -113,17 +115,29 @@ button {
   transition: grid-template-columns 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.app[data-resizing-sidebar="true"] {
+.app[data-resizing-sidebar="true"],
+.app[data-resizing-notes="true"],
+.app[data-resizing-notes-list="true"] {
   cursor: col-resize;
   transition: none;
 }
 
-.app[data-resizing-sidebar="true"] * {
+.app[data-resizing-sidebar="true"] *,
+.app[data-resizing-notes="true"] *,
+.app[data-resizing-notes-list="true"] * {
   user-select: none;
 }
 
+.app[data-notes="open"] {
+  grid-template-columns: var(--sidebar-w) minmax(0, 1fr) var(--notes-w);
+}
+
 .app[data-sidebar="closed"] {
-  grid-template-columns: 0 minmax(0, 1fr);
+  grid-template-columns: 0 minmax(0, 1fr) 0;
+}
+
+.app[data-sidebar="closed"][data-notes="open"] {
+  grid-template-columns: 0 minmax(0, 1fr) var(--notes-w);
 }
 
 /* ---------------------------------------------------------------- sidebar */
@@ -968,28 +982,62 @@ button {
 /* --------------------------------------------------------------- notes */
 
 .notes-surface {
-  position: fixed;
-  z-index: 5;
-  top: var(--content-inset-top);
-  right: 0;
+  position: relative;
+  z-index: 1;
   display: flex;
-  width: min(560px, calc(100vw - 48px));
-  height: calc(100dvh - var(--content-inset-top) - var(--content-inset-bottom));
+  width: var(--notes-w);
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
   flex-direction: column;
   border-left: 1px solid var(--line);
   background: var(--base);
-  box-shadow: -18px 0 48px rgb(0 0 0 / 0.36);
+  box-shadow: none;
+}
+
+.notes-resizer {
+  position: absolute;
+  z-index: 4;
+  top: 0;
+  left: -4px;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  outline: none;
+  touch-action: none;
+}
+
+.notes-resizer::before {
+  position: absolute;
+  top: 0;
+  left: 3px;
+  width: 1px;
+  height: 100%;
+  background: transparent;
+  content: "";
+  transition: background 120ms ease, box-shadow 120ms ease;
+}
+
+.notes-resizer:hover::before,
+.notes-resizer:focus-visible::before,
+.app[data-resizing-notes="true"] .notes-resizer::before {
+  background: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-soft);
 }
 
 .notes-head {
   display: flex;
   min-height: 58px;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
   padding: 0 14px 0 16px;
   border-bottom: 1px solid var(--line);
   background: var(--mantle);
+}
+
+.notes-head > div {
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .notes-title {
@@ -1001,7 +1049,7 @@ button {
 
 .notes-sub {
   display: block;
-  max-width: 360px;
+  max-width: 100%;
   overflow: hidden;
   color: var(--overlay1);
   font-size: 11px;
@@ -1009,18 +1057,106 @@ button {
   white-space: nowrap;
 }
 
+.pane-note-tabs {
+  display: flex;
+  min-width: 0;
+  min-height: 42px;
+  align-items: center;
+  gap: 6px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--line-soft);
+  background: color-mix(in srgb, var(--mantle) 76%, var(--base));
+  scrollbar-width: thin;
+}
+
+.pane-note-tab {
+  display: inline-flex;
+  min-width: 64px;
+  max-width: 180px;
+  height: 28px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  color: var(--overlay1);
+  background: var(--surface0);
+  font-size: 12px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pane-note-tab[data-active="true"] {
+  border-color: color-mix(in srgb, var(--accent) 52%, var(--line));
+  color: var(--text);
+  background: var(--accent-soft);
+}
+
+.pane-note-tab-new {
+  min-width: 32px;
+  max-width: 32px;
+  padding: 0;
+}
+
 .notes-shell {
   display: grid;
-  grid-template-columns: minmax(180px, 0.8fr) minmax(0, 1.2fr);
+  grid-template-columns: var(--notes-list-w) minmax(0, 1fr);
   min-height: 0;
   flex: 1 1 auto;
+  transition: grid-template-columns 160ms ease;
+}
+
+.notes-surface[data-list="collapsed"] .notes-shell {
+  grid-template-columns: 0 minmax(0, 1fr);
 }
 
 .notes-list-pane {
+  position: relative;
   min-width: 0;
   overflow-y: auto;
   border-right: 1px solid var(--line);
   background: var(--sidebar-bg);
+}
+
+.notes-surface[data-list="collapsed"] .notes-list-pane {
+  overflow: hidden;
+  border-right: 0;
+  visibility: hidden;
+}
+
+.notes-list-resizer {
+  position: absolute;
+  z-index: 3;
+  top: 0;
+  right: -4px;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  outline: none;
+  touch-action: none;
+}
+
+.notes-list-resizer::before {
+  position: absolute;
+  top: 0;
+  right: 3px;
+  width: 1px;
+  height: 100%;
+  background: transparent;
+  content: "";
+  transition: background 120ms ease, box-shadow 120ms ease;
+}
+
+.notes-list-resizer:hover::before,
+.notes-list-resizer:focus-visible::before,
+.app[data-resizing-notes-list="true"] .notes-list-resizer::before {
+  background: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-soft);
 }
 
 .notes-section {
@@ -2730,6 +2866,8 @@ button {
 
 .app[data-compact="true"] .notes-surface,
 .notes-surface[data-compact="true"] {
+  position: fixed;
+  z-index: 5;
   top: var(--content-inset-top);
   left: 0;
   right: auto;
@@ -2737,6 +2875,13 @@ button {
   height: calc(100dvh - var(--content-inset-top) - var(--content-inset-bottom));
   border-left: 0;
   box-shadow: none;
+}
+
+.app[data-compact="true"] .notes-resizer,
+.notes-surface[data-compact="true"] .notes-resizer,
+.app[data-compact="true"] .notes-list-resizer,
+.notes-surface[data-compact="true"] .notes-list-resizer {
+  display: none;
 }
 
 .app[data-compact="true"] .notes-shell,
@@ -2767,6 +2912,16 @@ button {
 }
 
 .app[data-touch="true"] .sidebar-resizer {
+  right: -12px;
+  width: 24px;
+}
+
+.app[data-touch="true"] .notes-resizer {
+  left: -12px;
+  width: 24px;
+}
+
+.app[data-touch="true"] .notes-list-resizer {
   right: -12px;
   width: 24px;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1282,7 +1282,8 @@ button {
 }
 
 .note-editor-toolbar {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 6px;
   min-height: 45px;
@@ -1290,14 +1291,42 @@ button {
   border-bottom: 1px solid var(--line-soft);
 }
 
+.note-editor-toolbar-left,
+.note-editor-actions {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.note-editor-toolbar-left {
+  flex-wrap: wrap;
+}
+
+.note-editor-actions {
+  justify-content: flex-end;
+}
+
 .note-editor-status {
   min-width: 0;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   overflow: hidden;
   color: var(--overlay1);
   font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.note-editor-mode {
+  width: auto;
+  min-width: 122px;
+  flex: 0 0 auto;
+}
+
+.note-editor-mode button {
+  height: 26px;
+  padding: 0 8px;
+  font-size: 11px;
 }
 
 .note-state-icon {
@@ -1376,6 +1405,118 @@ button {
   color: var(--subtext1);
   font-size: 13.5px;
   line-height: 1.55;
+}
+
+.note-body-preview {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 14px 16px 20px;
+  color: var(--subtext1);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.note-body-preview > :first-child {
+  margin-top: 0;
+}
+
+.note-body-preview > :last-child {
+  margin-bottom: 0;
+}
+
+.note-body-preview h1,
+.note-body-preview h2,
+.note-body-preview h3 {
+  margin: 1em 0 0.45em;
+  color: var(--text);
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.note-body-preview h1 {
+  font-size: 20px;
+}
+
+.note-body-preview h2 {
+  font-size: 17px;
+}
+
+.note-body-preview h3 {
+  font-size: 15px;
+}
+
+.note-body-preview p,
+.note-body-preview ul,
+.note-body-preview ol,
+.note-body-preview blockquote,
+.note-body-preview pre,
+.note-body-preview table {
+  margin: 0 0 0.85em;
+}
+
+.note-body-preview ul,
+.note-body-preview ol {
+  padding-left: 1.35em;
+}
+
+.note-body-preview li + li {
+  margin-top: 0.25em;
+}
+
+.note-body-preview a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.note-body-preview code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--surface0);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.94em;
+}
+
+.note-body-preview pre {
+  overflow: auto;
+  padding: 10px;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--r-sm);
+  background: var(--crust);
+}
+
+.note-body-preview pre code {
+  padding: 0;
+  background: transparent;
+}
+
+.note-body-preview blockquote {
+  padding-left: 10px;
+  border-left: 2px solid var(--line);
+  color: var(--overlay1);
+}
+
+.note-body-preview table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.note-body-preview th,
+.note-body-preview td {
+  padding: 6px 7px;
+  border: 1px solid var(--line-soft);
+}
+
+.note-body-preview th {
+  color: var(--text);
+  background: var(--surface0);
+  font-weight: 650;
+}
+
+.note-body-preview-empty {
+  color: var(--overlay0);
 }
 
 /* ------------------------------------------------------------ terminal */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -835,12 +835,20 @@ button {
 .tabbar {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   height: 40px;
   flex: 0 0 auto;
-  padding: 0 10px;
+  padding: 0 8px 0 10px;
   border-bottom: 1px solid var(--line);
   background: var(--sidebar-bg);
+}
+
+.tabbar-scroll {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 4px;
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: thin;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1164,6 +1164,34 @@ button {
   white-space: nowrap;
 }
 
+.note-conflict {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--peach) 35%, var(--line-soft));
+  color: var(--peach);
+  background: color-mix(in srgb, var(--peach) 12%, var(--base));
+  font-size: 12px;
+}
+
+.note-conflict span {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.note-conflict button {
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  border: 1px solid color-mix(in srgb, var(--peach) 48%, var(--line));
+  border-radius: 6px;
+  color: var(--text);
+  background: color-mix(in srgb, var(--surface0) 75%, var(--peach));
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
 .note-title-input,
 .note-body-input {
   width: 100%;


### PR DESCRIPTION
## Summary
- Add bridge-owned pane notes with recovery-oriented link states and note mutation APIs
- Add desktop/mobile notes UI, autosave drafts, resize/collapse/open-state persistence, and mobile notes navigation
- Harden note identity, stale refresh guards, autosave behavior, backend draft cleanup, and pane observation invariants after adversarial and Keel review

## Verification
- npm run check
- Rebuilt web/dist and release bridge binary
- Restarted local user systemd service: herdr-web.service
- Built Android debug APK and transferred to srv:/srv/devtoolsd/prod/data/downloads/herdr-web-pane-notes-debug.apk

## Keel review
- Iterative Keel peer review completed clean with no remaining actionable findings
