### PR TITLE
Fix mobile command input wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 
 ### Fixed
 
-- Fixed the mobile terminal command input so long prompts wrap, grow taller while editing,
-  and remain viewable instead of scrolling sideways.
+- Added Mobile settings for an expanding terminal command input and Enter-as-newline
+  editing, allowing long prompts to wrap and remain viewable while preserving send-on-Enter
+  by default. [PR #21](https://github.com/kcosr/herdr-web/pull/21)
 - Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
   keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.
   [PR #19](https://github.com/kcosr/herdr-web/pull/19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed the mobile terminal command input so long prompts wrap, grow taller while editing,
+  and remain viewable instead of scrolling sideways.
 - Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
   keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.
   [PR #19](https://github.com/kcosr/herdr-web/pull/19)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,10 +34,14 @@ import { resolveLaunchSpec } from "./launch";
 import type { LaunchTarget } from "./launch";
 import { fetchWithTimeout } from "./fetchWithTimeout";
 import {
+  DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
+  DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT,
   DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
   DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR,
   DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
   DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
+  parseMobileCommandEnterNewline,
+  parseMobileCommandExpandingInput,
   parseMobileKeyboardHideRefit,
   parseMobileLongPressBehavior,
   parseMobileTouchSelectionEndpointTimeoutMs,
@@ -204,6 +208,8 @@ type DisplayPrefs = {
   mobileLongPressBehavior: MobileLongPressBehavior;
   mobileTouchSelectionEndpointTimeoutMs: MobileTouchSelectionEndpointTimeoutMs;
   mobileKeyboardHideRefit: boolean;
+  mobileCommandExpandingInput: boolean;
+  mobileCommandEnterNewline: boolean;
 };
 type LegacyDisplaySelectionPrefs = {
   activeSpaceId: string | null;
@@ -244,6 +250,8 @@ function readDisplayPrefs(): DisplayPrefs {
     mobileLongPressBehavior: DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR,
     mobileTouchSelectionEndpointTimeoutMs: DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
     mobileKeyboardHideRefit: DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
+    mobileCommandExpandingInput: DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT,
+    mobileCommandEnterNewline: DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
   };
   try {
     const raw = window.localStorage.getItem(DISPLAY_PREFS_KEY);
@@ -331,6 +339,12 @@ function parseDisplayPrefsValue(
       parsed.mobileTouchSelectionEndpointTimeoutMs,
     ),
     mobileKeyboardHideRefit: parseMobileKeyboardHideRefit(parsed.mobileKeyboardHideRefit),
+    mobileCommandExpandingInput: parseMobileCommandExpandingInput(
+      parsed.mobileCommandExpandingInput,
+    ),
+    mobileCommandEnterNewline: parseMobileCommandEnterNewline(
+      parsed.mobileCommandEnterNewline,
+    ),
   };
 }
 
@@ -408,6 +422,12 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
         parsed.mobileTouchSelectionEndpointTimeoutMs,
       ),
       mobileKeyboardHideRefit: parseMobileKeyboardHideRefit(parsed.mobileKeyboardHideRefit),
+      mobileCommandExpandingInput: parseMobileCommandExpandingInput(
+        parsed.mobileCommandExpandingInput,
+      ),
+      mobileCommandEnterNewline: parseMobileCommandEnterNewline(
+        parsed.mobileCommandEnterNewline,
+      ),
     };
   } catch {
     return fallback;
@@ -589,6 +609,12 @@ export function App() {
   const [mobileKeyboardHideRefit, setMobileKeyboardHideRefit] = useState(
     initialPrefs.mobileKeyboardHideRefit,
   );
+  const [mobileCommandExpandingInput, setMobileCommandExpandingInput] = useState(
+    initialPrefs.mobileCommandExpandingInput,
+  );
+  const [mobileCommandEnterNewline, setMobileCommandEnterNewline] = useState(
+    initialPrefs.mobileCommandEnterNewline,
+  );
   const [launchTarget, setLaunchTarget] = useState<ScopedLaunchTarget | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -644,6 +670,8 @@ export function App() {
       setMobileLongPressBehavior(prefs.mobileLongPressBehavior);
       setMobileTouchSelectionEndpointTimeoutMs(prefs.mobileTouchSelectionEndpointTimeoutMs);
       setMobileKeyboardHideRefit(prefs.mobileKeyboardHideRefit);
+      setMobileCommandExpandingInput(prefs.mobileCommandExpandingInput);
+      setMobileCommandEnterNewline(prefs.mobileCommandEnterNewline);
       setDisplayPrefsLoaded(true);
     });
     return () => {
@@ -928,6 +956,8 @@ export function App() {
       mobileLongPressBehavior,
       mobileTouchSelectionEndpointTimeoutMs,
       mobileKeyboardHideRefit,
+      mobileCommandExpandingInput,
+      mobileCommandEnterNewline,
     });
   }, [
     displayPrefsLoaded,
@@ -954,6 +984,8 @@ export function App() {
     mobileLongPressBehavior,
     mobileTouchSelectionEndpointTimeoutMs,
     mobileKeyboardHideRefit,
+    mobileCommandExpandingInput,
+    mobileCommandEnterNewline,
   ]);
 
   useEffect(() => {
@@ -2052,9 +2084,12 @@ export function App() {
             focusToken={terminalFocusToken}
             touchInput={isTouchInput}
             terminalFontSizePx={terminalFontSizePx}
+            mobileControlsScalePercent={mobileControlsScalePercent}
             mobileTapTarget={mobileTerminalTapTarget}
             mobileLongPressBehavior={mobileLongPressBehavior}
             mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
+            mobileCommandExpandingInput={mobileCommandExpandingInput}
+            mobileCommandEnterNewline={mobileCommandEnterNewline}
             terminalInputTransport={terminalInputTransport}
             terminalInputBatchDelayMs={terminalInputBatchDelayMs}
             terminalOutputCoalesceMs={terminalOutputCoalesceMs}
@@ -2074,9 +2109,12 @@ export function App() {
             scrollSensitivity={isTouchInput ? 2 : 0.4}
             mobileControls={isTouchInput}
             terminalFontSizePx={terminalFontSizePx}
+            mobileControlsScalePercent={mobileControlsScalePercent}
             mobileTapTarget={mobileTerminalTapTarget}
             mobileLongPressBehavior={mobileLongPressBehavior}
             mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
+            mobileCommandExpandingInput={mobileCommandExpandingInput}
+            mobileCommandEnterNewline={mobileCommandEnterNewline}
             terminalInputTransport={terminalInputTransport}
             terminalInputBatchDelayMs={terminalInputBatchDelayMs}
             terminalOutputCoalesceMs={terminalOutputCoalesceMs}
@@ -2156,6 +2194,10 @@ export function App() {
           onMobileTouchSelectionEndpointTimeoutMs={
             setMobileTouchSelectionEndpointTimeoutMs
           }
+          mobileCommandExpandingInput={mobileCommandExpandingInput}
+          onMobileCommandExpandingInput={setMobileCommandExpandingInput}
+          mobileCommandEnterNewline={mobileCommandEnterNewline}
+          onMobileCommandEnterNewline={setMobileCommandEnterNewline}
           showMobileKeyboardHideRefit={showMobileKeyboardHideRefit}
           mobileKeyboardHideRefit={mobileKeyboardHideRefit}
           onMobileKeyboardHideRefit={setMobileKeyboardHideRefit}
@@ -2754,9 +2796,12 @@ function SplitGrid({
   focusToken,
   touchInput,
   terminalFontSizePx,
+  mobileControlsScalePercent,
   mobileTapTarget,
   mobileLongPressBehavior,
   mobileTouchSelectionEndpointTimeoutMs,
+  mobileCommandExpandingInput,
+  mobileCommandEnterNewline,
   terminalInputTransport,
   terminalInputBatchDelayMs,
   terminalOutputCoalesceMs,
@@ -2772,9 +2817,12 @@ function SplitGrid({
   focusToken: number;
   touchInput: boolean;
   terminalFontSizePx: number;
+  mobileControlsScalePercent: number;
   mobileTapTarget: MobileTerminalTapTarget;
   mobileLongPressBehavior: MobileLongPressBehavior;
   mobileTouchSelectionEndpointTimeoutMs: MobileTouchSelectionEndpointTimeoutMs;
+  mobileCommandExpandingInput: boolean;
+  mobileCommandEnterNewline: boolean;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
   terminalOutputCoalesceMs: number;
@@ -2805,9 +2853,12 @@ function SplitGrid({
               scrollSensitivity={touchInput ? 2 : 0.4}
               mobileControls={selected && touchInput}
               terminalFontSizePx={terminalFontSizePx}
+              mobileControlsScalePercent={mobileControlsScalePercent}
               mobileTapTarget={mobileTapTarget}
               mobileLongPressBehavior={mobileLongPressBehavior}
               mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
+              mobileCommandExpandingInput={mobileCommandExpandingInput}
+              mobileCommandEnterNewline={mobileCommandEnterNewline}
               terminalInputTransport={terminalInputTransport}
               terminalInputBatchDelayMs={terminalInputBatchDelayMs}
               terminalOutputCoalesceMs={terminalOutputCoalesceMs}

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -79,6 +79,10 @@ type Props = {
   onMobileTouchSelectionEndpointTimeoutMs: (
     timeoutMs: MobileTouchSelectionEndpointTimeoutMs,
   ) => void;
+  mobileCommandExpandingInput: boolean;
+  onMobileCommandExpandingInput: (enabled: boolean) => void;
+  mobileCommandEnterNewline: boolean;
+  onMobileCommandEnterNewline: (enabled: boolean) => void;
   showMobileKeyboardHideRefit: boolean;
   mobileKeyboardHideRefit: boolean;
   onMobileKeyboardHideRefit: (enabled: boolean) => void;
@@ -117,6 +121,10 @@ export function BackendSettingsDialog({
   onMobileLongPressBehavior,
   mobileTouchSelectionEndpointTimeoutMs,
   onMobileTouchSelectionEndpointTimeoutMs,
+  mobileCommandExpandingInput,
+  onMobileCommandExpandingInput,
+  mobileCommandEnterNewline,
+  onMobileCommandEnterNewline,
   showMobileKeyboardHideRefit,
   mobileKeyboardHideRefit,
   onMobileKeyboardHideRefit,
@@ -125,7 +133,6 @@ export function BackendSettingsDialog({
   const bridge = useBridge();
   const titleId = useId();
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
-  const nameInputRef = useRef<HTMLInputElement | null>(null);
   const [form, setForm] = useState<FormState>(() => newBackendForm(bridge.store.backends));
   const [selectionMode, setSelectionMode] = useState<SelectionMode>(
     initialSelectionMode(bridge.lastSelectedBridgeId, bridge.sameOriginAvailable),
@@ -142,15 +149,8 @@ export function BackendSettingsDialog({
   const sameOriginEnabled = bridge.store.enabledBridgeIds.includes(SAME_ORIGIN_BRIDGE_ID);
 
   useEffect(() => {
-    if (activeArea !== "bridge") {
-      return;
-    }
-    if (selectionMode === "same-origin") {
-      closeButtonRef.current?.focus();
-      return;
-    }
-    nameInputRef.current?.focus();
-  }, [activeArea, selectionMode]);
+    closeButtonRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     if (activeArea === "mobile" && !showMobileTerminalSettings) {
@@ -381,7 +381,6 @@ export function BackendSettingsDialog({
                         <label className="field-label">
                           <span>Display name</span>
                           <input
-                            ref={nameInputRef}
                             className="field"
                             value={form.name}
                             placeholder="Home workstation"
@@ -658,6 +657,58 @@ export function BackendSettingsDialog({
                           {timeoutMs}
                         </button>
                       ))}
+                    </div>
+                  </div>
+                ) : null}
+                <div className="settings-row">
+                  <span>Expanding command input</span>
+                  <div
+                    className="segmented-control"
+                    role="group"
+                    aria-label="Expanding command input"
+                  >
+                    <button
+                      type="button"
+                      data-on={!mobileCommandExpandingInput}
+                      aria-pressed={!mobileCommandExpandingInput}
+                      onClick={() => onMobileCommandExpandingInput(false)}
+                    >
+                      Off
+                    </button>
+                    <button
+                      type="button"
+                      data-on={mobileCommandExpandingInput}
+                      aria-pressed={mobileCommandExpandingInput}
+                      onClick={() => onMobileCommandExpandingInput(true)}
+                    >
+                      On
+                    </button>
+                  </div>
+                </div>
+                {mobileCommandExpandingInput ? (
+                  <div className="settings-row">
+                    <span>Enter inserts newline</span>
+                    <div
+                      className="segmented-control"
+                      role="group"
+                      aria-label="Enter inserts newline"
+                    >
+                      <button
+                        type="button"
+                        data-on={!mobileCommandEnterNewline}
+                        aria-pressed={!mobileCommandEnterNewline}
+                        onClick={() => onMobileCommandEnterNewline(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={mobileCommandEnterNewline}
+                        aria-pressed={mobileCommandEnterNewline}
+                        onClick={() => onMobileCommandEnterNewline(true)}
+                      >
+                        On
+                      </button>
                     </div>
                   </div>
                 ) : null}

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -10,7 +10,7 @@ import {
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
-import type { ChangeEvent, ClipboardEvent, DragEvent, RefObject } from "react";
+import type { ChangeEvent, ClipboardEvent, DragEvent, KeyboardEvent, RefObject } from "react";
 import { autosizeMobileCommandTextarea } from "./mobileCommandTextarea";
 import { ConfirmDialog } from "./overlays";
 import { addNativeResumeHandler } from "./native";
@@ -63,12 +63,18 @@ type Props = {
   mobileControls?: boolean;
   /** Terminal renderer font size in CSS pixels. */
   terminalFontSizePx?: number;
+  /** Percentage scale applied to mobile terminal controls. */
+  mobileControlsScalePercent?: number;
   /** Where terminal taps should send focus on mobile. */
   mobileTapTarget?: MobileTerminalTapTarget;
   /** Gesture behavior for long-presses on touch terminals. */
   mobileLongPressBehavior?: MobileLongPressBehavior;
   /** How long the loupe endpoint waits for a second drag. */
   mobileTouchSelectionEndpointTimeoutMs?: MobileTouchSelectionEndpointTimeoutMs;
+  /** Whether the mobile command input wraps and grows while editing. */
+  mobileCommandExpandingInput?: boolean;
+  /** Whether Enter inserts a newline in the expanding mobile command input. */
+  mobileCommandEnterNewline?: boolean;
   /** Browser-to-bridge transport for terminal input payloads. */
   terminalInputTransport?: TerminalInputTransport;
   /** Delay for coalescing short terminal input payloads. Zero disables batching. */
@@ -129,9 +135,12 @@ export function TerminalView({
   scrollSensitivity = 1,
   mobileControls = false,
   terminalFontSizePx = DEFAULT_TERMINAL_FONT_SIZE_PX,
+  mobileControlsScalePercent = 100,
   mobileTapTarget = "command-input",
   mobileLongPressBehavior = "off",
   mobileTouchSelectionEndpointTimeoutMs = DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
+  mobileCommandExpandingInput = false,
+  mobileCommandEnterNewline = false,
   terminalInputTransport = "json",
   terminalInputBatchDelayMs = 0,
   terminalOutputCoalesceMs = DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
@@ -139,8 +148,9 @@ export function TerminalView({
   focusToken = 0,
 }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null);
+  const stageRef = useRef<HTMLElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const mobileCommandInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const mobileCommandInputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
   const rendererRef = useRef<TerminalRenderer | null>(null);
   const rendererGenerationRef = useRef(0);
   const rendererReadyRef = useRef<TerminalRendererReady | null>(null);
@@ -205,6 +215,17 @@ export function TerminalView({
     }
     input.focus();
     return true;
+  }, []);
+
+  const setMobileControlsHeight = useCallback((heightPx: number | null) => {
+    if (heightPx === null) {
+      stageRef.current?.style.removeProperty("--terminal-mobile-controls-height");
+      return;
+    }
+    stageRef.current?.style.setProperty(
+      "--terminal-mobile-controls-height",
+      `${Math.ceil(heightPx)}px`,
+    );
   }, []);
 
   const focusTerminalKeyboardInput = useCallback(() => {
@@ -1225,6 +1246,7 @@ export function TerminalView({
 
   return (
     <section
+      ref={stageRef}
       className="terminal-stage"
       aria-label="Selected pane terminal"
       onDragOverCapture={(event) => {
@@ -1273,6 +1295,10 @@ export function TerminalView({
           commandInputRef={mobileCommandInputRef}
           disabled={!pane || connectionState !== "attached"}
           uploadDisabled={uploadDisabled}
+          expandingInput={mobileCommandExpandingInput}
+          enterNewline={mobileCommandEnterNewline}
+          controlsScalePercent={mobileControlsScalePercent}
+          onControlsHeightChange={setMobileControlsHeight}
           onInput={sendTerminalInput}
           onTerminalFocus={() => rendererRef.current?.focusTextInput()}
           onUpload={openFilePicker}
@@ -1360,24 +1386,36 @@ function MobileTerminalControls({
   commandInputRef,
   disabled,
   uploadDisabled,
+  expandingInput,
+  enterNewline,
+  controlsScalePercent,
+  onControlsHeightChange,
   onInput,
   onTerminalFocus,
   onUpload,
   onStageCommand,
   onSubmitCommand,
 }: {
-  commandInputRef: RefObject<HTMLTextAreaElement | null>;
+  commandInputRef: RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
   disabled: boolean;
   uploadDisabled: boolean;
+  expandingInput: boolean;
+  enterNewline: boolean;
+  controlsScalePercent: number;
+  onControlsHeightChange: (heightPx: number | null) => void;
   onInput: (data: string) => void;
   onTerminalFocus: () => void;
   onUpload: () => void;
   onStageCommand: (command: string) => void;
   onSubmitCommand: (command: string) => void;
 }) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
   const [value, setValue] = useState("");
   const [expanded, setExpanded] = useState(false);
   const [ctrlLatch, setCtrlLatch] = useState(false);
+  const setCommandInputNode = (node: HTMLInputElement | HTMLTextAreaElement | null) => {
+    commandInputRef.current = node;
+  };
   const submit = () => {
     onSubmitCommand(value);
     setValue("");
@@ -1397,11 +1435,56 @@ function MobileTerminalControls({
   };
 
   useLayoutEffect(() => {
-    autosizeMobileCommandTextarea(commandInputRef.current);
-  }, [commandInputRef, value]);
+    if (expandingInput) {
+      autosizeMobileCommandTextarea(commandInputRef.current);
+    }
+  }, [commandInputRef, controlsScalePercent, expandingInput, value]);
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      onControlsHeightChange(null);
+      return;
+    }
+    const report = () => onControlsHeightChange(root.getBoundingClientRect().height);
+    report();
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", report);
+      return () => {
+        window.removeEventListener("resize", report);
+        onControlsHeightChange(null);
+      };
+    }
+    const observer = new ResizeObserver(report);
+    observer.observe(root);
+    return () => {
+      observer.disconnect();
+      onControlsHeightChange(null);
+    };
+  }, [onControlsHeightChange]);
+
+  const onCommandTextareaKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
+      return;
+    }
+    if (
+      event.key !== "Enter" ||
+      enterNewline ||
+      event.shiftKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    if (!disabled) {
+      submit();
+    }
+  };
 
   return (
-    <div className="terminal-mobile-controls" data-expanded={expanded ? "true" : "false"}>
+    <div ref={rootRef} className="terminal-mobile-controls" data-expanded={expanded ? "true" : "false"}>
       <div className="term-key-strip" aria-label="Common terminal keys">
         <div className="term-key-group" aria-label="Terminal quick keys">
           <button
@@ -1502,6 +1585,7 @@ function MobileTerminalControls({
 
       <form
         className="term-input-row"
+        data-expanding={expandingInput ? "true" : "false"}
         onSubmit={(event) => {
           event.preventDefault();
           if (!disabled) {
@@ -1509,19 +1593,37 @@ function MobileTerminalControls({
           }
         }}
       >
-        <textarea
-          ref={commandInputRef}
-          className="term-native-input mono"
-          rows={1}
-          autoCapitalize="none"
-          autoComplete="off"
-          autoCorrect="off"
-          spellCheck={false}
-          enterKeyHint="send"
-          disabled={disabled}
-          value={value}
-          onChange={(event) => setValue(event.target.value)}
-        />
+        {expandingInput ? (
+          <textarea
+            ref={setCommandInputNode}
+            className="term-native-input mono"
+            rows={1}
+            data-expanding="true"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            enterKeyHint={enterNewline ? "enter" : "send"}
+            disabled={disabled}
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onKeyDown={onCommandTextareaKeyDown}
+          />
+        ) : (
+          <input
+            ref={setCommandInputNode}
+            className="term-native-input mono"
+            type="text"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            enterKeyHint="send"
+            disabled={disabled}
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+          />
+        )}
         <button
           className="term-send term-stage-command"
           type="button"

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -9,8 +9,9 @@ import {
   TextCursorInput,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent, RefObject } from "react";
+import { autosizeMobileCommandTextarea } from "./mobileCommandTextarea";
 import { ConfirmDialog } from "./overlays";
 import { addNativeResumeHandler } from "./native";
 import { shellQuote } from "./shell";
@@ -139,7 +140,7 @@ export function TerminalView({
 }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const mobileCommandInputRef = useRef<HTMLInputElement | null>(null);
+  const mobileCommandInputRef = useRef<HTMLTextAreaElement | null>(null);
   const rendererRef = useRef<TerminalRenderer | null>(null);
   const rendererGenerationRef = useRef(0);
   const rendererReadyRef = useRef<TerminalRendererReady | null>(null);
@@ -1365,7 +1366,7 @@ function MobileTerminalControls({
   onStageCommand,
   onSubmitCommand,
 }: {
-  commandInputRef: RefObject<HTMLInputElement | null>;
+  commandInputRef: RefObject<HTMLTextAreaElement | null>;
   disabled: boolean;
   uploadDisabled: boolean;
   onInput: (data: string) => void;
@@ -1394,6 +1395,10 @@ function MobileTerminalControls({
       setCtrlLatch(false);
     }
   };
+
+  useLayoutEffect(() => {
+    autosizeMobileCommandTextarea(commandInputRef.current);
+  }, [commandInputRef, value]);
 
   return (
     <div className="terminal-mobile-controls" data-expanded={expanded ? "true" : "false"}>
@@ -1504,10 +1509,10 @@ function MobileTerminalControls({
           }
         }}
       >
-        <input
+        <textarea
           ref={commandInputRef}
           className="term-native-input mono"
-          type="text"
+          rows={1}
           autoCapitalize="none"
           autoComplete="off"
           autoCorrect="off"

--- a/web/src/mobileCommandTextarea.test.ts
+++ b/web/src/mobileCommandTextarea.test.ts
@@ -14,6 +14,19 @@ describe("autosizeMobileCommandTextarea", () => {
     expect(textarea.style.height).toBe("84px");
   });
 
+  it("includes the border height for border-box textareas", () => {
+    const textarea = {
+      scrollHeight: 84,
+      clientHeight: 80,
+      offsetHeight: 82,
+      style: { height: "34px" },
+    };
+
+    autosizeMobileCommandTextarea(textarea);
+
+    expect(textarea.style.height).toBe("86px");
+  });
+
   it("ignores missing textarea refs while controls mount", () => {
     expect(() => autosizeMobileCommandTextarea(null)).not.toThrow();
   });

--- a/web/src/mobileCommandTextarea.test.ts
+++ b/web/src/mobileCommandTextarea.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { autosizeMobileCommandTextarea } from "./mobileCommandTextarea";
+
+describe("autosizeMobileCommandTextarea", () => {
+  it("sizes the command textarea to its wrapped content height", () => {
+    const textarea = {
+      scrollHeight: 84,
+      style: { height: "34px" },
+    };
+
+    autosizeMobileCommandTextarea(textarea);
+
+    expect(textarea.style.height).toBe("84px");
+  });
+
+  it("ignores missing textarea refs while controls mount", () => {
+    expect(() => autosizeMobileCommandTextarea(null)).not.toThrow();
+  });
+});

--- a/web/src/mobileCommandTextarea.ts
+++ b/web/src/mobileCommandTextarea.ts
@@ -1,5 +1,7 @@
 export type MobileCommandTextareaAutosizeTarget = {
   scrollHeight: number;
+  clientHeight?: number;
+  offsetHeight?: number;
   style: {
     height: string;
   };
@@ -12,5 +14,9 @@ export function autosizeMobileCommandTextarea(
     return;
   }
   textarea.style.height = "auto";
-  textarea.style.height = `${textarea.scrollHeight}px`;
+  const borderHeight =
+    typeof textarea.offsetHeight === "number" && typeof textarea.clientHeight === "number"
+      ? Math.max(0, textarea.offsetHeight - textarea.clientHeight)
+      : 0;
+  textarea.style.height = `${textarea.scrollHeight + borderHeight}px`;
 }

--- a/web/src/mobileCommandTextarea.ts
+++ b/web/src/mobileCommandTextarea.ts
@@ -1,0 +1,16 @@
+export type MobileCommandTextareaAutosizeTarget = {
+  scrollHeight: number;
+  style: {
+    height: string;
+  };
+};
+
+export function autosizeMobileCommandTextarea(
+  textarea: MobileCommandTextareaAutosizeTarget | null,
+) {
+  if (!textarea) {
+    return;
+  }
+  textarea.style.height = "auto";
+  textarea.style.height = `${textarea.scrollHeight}px`;
+}

--- a/web/src/mobileTerminalPrefs.test.ts
+++ b/web/src/mobileTerminalPrefs.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
+  DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT,
   DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR,
   DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
   DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
   DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
   MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_OPTIONS_MS,
+  parseMobileCommandEnterNewline,
+  parseMobileCommandExpandingInput,
   parseMobileLongPressBehavior,
   parseMobileKeyboardHideRefit,
   parseMobileTouchSelectionEndpointTimeoutMs,
@@ -51,5 +55,18 @@ describe("mobile terminal preferences", () => {
     expect(parseMobileKeyboardHideRefit(true)).toBe(true);
     expect(parseMobileKeyboardHideRefit(false)).toBe(false);
     expect(parseMobileKeyboardHideRefit("false")).toBe(DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT);
+  });
+
+  it("parses mobile command input flags", () => {
+    expect(parseMobileCommandExpandingInput(true)).toBe(true);
+    expect(parseMobileCommandExpandingInput(false)).toBe(false);
+    expect(parseMobileCommandExpandingInput("true")).toBe(
+      DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT,
+    );
+    expect(parseMobileCommandEnterNewline(true)).toBe(true);
+    expect(parseMobileCommandEnterNewline(false)).toBe(false);
+    expect(parseMobileCommandEnterNewline("false")).toBe(
+      DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
+    );
   });
 });

--- a/web/src/mobileTerminalPrefs.ts
+++ b/web/src/mobileTerminalPrefs.ts
@@ -8,6 +8,8 @@ export type MobileTouchSelectionEndpointTimeoutMs =
   (typeof MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_OPTIONS_MS)[number];
 export const DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS: MobileTouchSelectionEndpointTimeoutMs = 1500;
 export const DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT = true;
+export const DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT = true;
+export const DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE = false;
 
 export function parseMobileTerminalTapTarget(value: unknown): MobileTerminalTapTarget {
   return value === "terminal" || value === "command-input"
@@ -33,4 +35,12 @@ export function parseMobileTouchSelectionEndpointTimeoutMs(
 
 export function parseMobileKeyboardHideRefit(value: unknown) {
   return typeof value === "boolean" ? value : DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT;
+}
+
+export function parseMobileCommandExpandingInput(value: unknown) {
+  return typeof value === "boolean" ? value : DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT;
+}
+
+export function parseMobileCommandEnterNewline(value: unknown) {
+  return typeof value === "boolean" ? value : DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -920,6 +920,7 @@ button {
 /* ------------------------------------------------------------ terminal */
 
 .terminal-stage {
+  --terminal-mobile-controls-height: calc(82px * var(--mobile-controls-scale));
   position: relative;
   display: flex;
   flex-direction: column;
@@ -1291,25 +1292,34 @@ button {
 }
 
 .term-input-row {
+  height: var(--mobile-input-row-height);
+}
+
+.term-input-row[data-expanding="true"] {
   align-items: flex-end;
+  height: auto;
 }
 
 .term-native-input {
-  box-sizing: border-box;
   min-width: 0;
-  min-height: var(--mobile-input-row-height);
-  max-height: min(34vh, calc(var(--mobile-input-row-height) * 7));
   flex: 1 1 auto;
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   outline: none;
+  padding: 0 var(--mobile-input-padding-x);
+  background: var(--crust);
+  color: var(--text);
+  font-size: clamp(11px, calc(13px * var(--mobile-controls-scale)), 20px);
+}
+
+.term-native-input[data-expanding="true"] {
+  box-sizing: border-box;
+  min-height: var(--mobile-input-row-height);
+  max-height: min(34vh, calc(var(--mobile-input-row-height) * 7));
   padding: calc(7px * var(--mobile-controls-scale)) var(--mobile-input-padding-x);
   overflow-x: hidden;
   overflow-y: auto;
   resize: none;
-  background: var(--crust);
-  color: var(--text);
-  font-size: clamp(11px, calc(13px * var(--mobile-controls-scale)), 20px);
   line-height: 1.35;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
@@ -2435,31 +2445,13 @@ button {
 }
 
 .app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-overlay {
-  bottom: calc(120px * var(--mobile-controls-scale));
+  bottom: calc(var(--terminal-mobile-controls-height) + 38px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-upload-status {
-  bottom: calc(90px * var(--mobile-controls-scale));
+  bottom: calc(var(--terminal-mobile-controls-height) + 8px * var(--mobile-controls-scale));
 }
 
 .app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-selection-sheet {
-  bottom: calc(90px * var(--mobile-controls-scale));
-}
-
-.app[data-touch="true"]
-  .terminal-stage:has(.terminal-mobile-controls[data-expanded="true"])
-  .terminal-overlay {
-  bottom: calc(158px * var(--mobile-controls-scale));
-}
-
-.app[data-touch="true"]
-  .terminal-stage:has(.terminal-mobile-controls[data-expanded="true"])
-  .terminal-upload-status {
-  bottom: calc(126px * var(--mobile-controls-scale));
-}
-
-.app[data-touch="true"]
-  .terminal-stage:has(.terminal-mobile-controls[data-expanded="true"])
-  .terminal-selection-sheet {
-  bottom: calc(126px * var(--mobile-controls-scale));
+  bottom: calc(var(--terminal-mobile-controls-height) + 8px * var(--mobile-controls-scale));
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1291,19 +1291,28 @@ button {
 }
 
 .term-input-row {
-  height: var(--mobile-input-row-height);
+  align-items: flex-end;
 }
 
 .term-native-input {
+  box-sizing: border-box;
   min-width: 0;
+  min-height: var(--mobile-input-row-height);
+  max-height: min(34vh, calc(var(--mobile-input-row-height) * 7));
   flex: 1 1 auto;
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   outline: none;
-  padding: 0 var(--mobile-input-padding-x);
+  padding: calc(7px * var(--mobile-controls-scale)) var(--mobile-input-padding-x);
+  overflow-x: hidden;
+  overflow-y: auto;
+  resize: none;
   background: var(--crust);
   color: var(--text);
   font-size: clamp(11px, calc(13px * var(--mobile-controls-scale)), 20px);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .term-native-input:focus {


### PR DESCRIPTION
## Motivation

i've been heavily using the mobile app version this week and a pain point when using gboard dictation that creates longer input prompts is the input box wouldn't expand to accomodate, it would just keep scrolling off the screen making edits and review of the full thing very difficult. this PR expands fixes that by creating an expanding Input editor box on mobile

## Summary

- Replaces the mobile terminal command input with a wrapping textarea.
- Auto-sizes the textarea to the prompt content so long dictated prompts stay visible while editing.
- Caps very tall prompts with vertical scrolling instead of sideways scrolling.
- Adds a small regression test for the textarea autosize helper.

## Testing

- `npm run test:web`
- `npm run lint:web`
- `npm run android:build:debug`
- Installed the debug APK on Android and verified long mobile prompts now wrap/grow instead of scrolling sideways.
