### PR TITLE
Add agent pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added server-side agent pins with pinned-first agent ordering, a pinned-only sidebar toggle, and
   a small pinned indicator on pinned agent rows.
+  [PR #22](https://github.com/kcosr/herdr-web/pull/22)
 - Added bridge-owned pane notes with a sidebar Notes view, desktop/mobile notes editor, pane
   attachment recovery states, and per-bridge note synchronization. Notes are exposed through the
   same bridge request policy as terminal controls, so allowed bridge clients can read and mutate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 
 - Added server-side agent pins with pinned-first agent ordering, a pinned-only sidebar toggle, and
-  a small pinned indicator on pinned agent rows.
+  a selected-pane header toggle plus a small pinned indicator on pinned agent rows.
   [PR #22](https://github.com/kcosr/herdr-web/pull/22)
 - Added bridge-owned pane notes with a sidebar Notes view, desktop/mobile notes editor, pane
   attachment recovery states, and per-bridge note synchronization. Notes are exposed through the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added server-side agent pins with pinned-first agent ordering, a pinned-only sidebar toggle, and
+  a small pinned indicator on pinned agent rows.
 - Added bridge-owned pane notes with a sidebar Notes view, desktop/mobile notes editor, pane
   attachment recovery states, and per-bridge note synchronization. Notes are exposed through the
   same bridge request policy as terminal controls, so allowed bridge clients can read and mutate

--- a/bridge/src/agent_pins.rs
+++ b/bridge/src/agent_pins.rs
@@ -1,0 +1,511 @@
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, ErrorKind, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use herdr_compat::api::schema::PaneInfo;
+use serde::{Deserialize, Serialize};
+
+const AGENT_PINS_STORE_VERSION: u32 = 1;
+
+#[derive(Clone)]
+pub struct AgentPinsManager {
+    pins_path: PathBuf,
+    pins_lock_path: PathBuf,
+    session_key: String,
+}
+
+#[derive(Debug)]
+pub enum AgentPinsError {
+    BadRequest(String),
+    Io(io::Error),
+    Store(String),
+}
+
+impl std::fmt::Display for AgentPinsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadRequest(message) => write!(f, "{message}"),
+            Self::Io(err) => write!(f, "{err}"),
+            Self::Store(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl From<io::Error> for AgentPinsError {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentPinsListResponse {
+    pub session_key: String,
+    pub pins: Vec<AgentPinResponse>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentPinResponse {
+    pub pane_id: String,
+    pub terminal_id: String,
+    pub workspace_id: String,
+    pub tab_id: String,
+    pub created_at: String,
+    pub context: AgentPinContext,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AgentPinsStore {
+    version: u32,
+    created_at: String,
+    updated_at: String,
+    pins: Vec<AgentPinRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AgentPinRecord {
+    session_key: String,
+    pane_id: String,
+    terminal_id: String,
+    workspace_id: String,
+    tab_id: String,
+    created_at: String,
+    context: AgentPinContext,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentPinContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreground_cwd: Option<String>,
+}
+
+impl AgentPinsManager {
+    pub fn new() -> io::Result<Self> {
+        let pins_dir = default_agent_pins_dir();
+        ensure_private_dir(&pins_dir)?;
+        Ok(Self {
+            pins_path: pins_dir.join("agent-pins.json"),
+            pins_lock_path: pins_dir.join("agent-pins.lock"),
+            session_key: session_key(),
+        })
+    }
+
+    #[cfg(test)]
+    fn for_test(dir: PathBuf, session_key: &str) -> io::Result<Self> {
+        ensure_private_dir(&dir)?;
+        Ok(Self {
+            pins_path: dir.join("agent-pins.json"),
+            pins_lock_path: dir.join("agent-pins.lock"),
+            session_key: session_key.to_string(),
+        })
+    }
+
+    pub fn list(&self, panes: &[PaneInfo]) -> Result<AgentPinsListResponse, AgentPinsError> {
+        let _lock = LockFile::exclusive(&self.pins_lock_path)?;
+        let store = self.load_or_create_store()?;
+        Ok(AgentPinsListResponse {
+            session_key: self.session_key.clone(),
+            pins: visible_pin_responses(store.pins, &self.session_key, panes),
+        })
+    }
+
+    pub fn pin(
+        &self,
+        pane_id: &str,
+        panes: &[PaneInfo],
+    ) -> Result<AgentPinsListResponse, AgentPinsError> {
+        let pane = find_pane(pane_id, panes)?;
+        let record = pin_record_for_pane(&self.session_key, pane);
+        let pins = self.with_store(|store, now| {
+            store.pins.retain(|pin| {
+                !(pin.session_key == self.session_key && pin.pane_id == pane.pane_id)
+            });
+            store.pins.push(record);
+            prune_session_pins_for_missing_panes(store, &self.session_key, panes);
+            store.updated_at = now;
+            Ok(store.pins.clone())
+        })?;
+        Ok(AgentPinsListResponse {
+            session_key: self.session_key.clone(),
+            pins: visible_pin_responses(pins, &self.session_key, panes),
+        })
+    }
+
+    pub fn unpin(
+        &self,
+        pane_id: &str,
+        panes: &[PaneInfo],
+    ) -> Result<AgentPinsListResponse, AgentPinsError> {
+        let pane_id = normalize_pane_id(pane_id)?;
+        let pins = self.with_store(|store, now| {
+            store
+                .pins
+                .retain(|pin| !(pin.session_key == self.session_key && pin.pane_id == pane_id));
+            prune_session_pins_for_missing_panes(store, &self.session_key, panes);
+            store.updated_at = now;
+            Ok(store.pins.clone())
+        })?;
+        Ok(AgentPinsListResponse {
+            session_key: self.session_key.clone(),
+            pins: visible_pin_responses(pins, &self.session_key, panes),
+        })
+    }
+
+    fn with_store<F, T>(&self, mutate: F) -> Result<T, AgentPinsError>
+    where
+        F: FnOnce(&mut AgentPinsStore, String) -> Result<T, AgentPinsError>,
+    {
+        let _lock = LockFile::exclusive(&self.pins_lock_path)?;
+        let mut store = self.load_or_create_store()?;
+        let result = mutate(&mut store, now_ms_string())?;
+        write_json_atomic(&self.pins_path, &store)?;
+        Ok(result)
+    }
+
+    fn load_or_create_store(&self) -> Result<AgentPinsStore, AgentPinsError> {
+        match fs::read(&self.pins_path) {
+            Ok(bytes) => parse_store(&bytes),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let now = now_ms_string();
+                Ok(AgentPinsStore {
+                    version: AGENT_PINS_STORE_VERSION,
+                    created_at: now.clone(),
+                    updated_at: now,
+                    pins: Vec::new(),
+                })
+            }
+            Err(err) => Err(AgentPinsError::Io(err)),
+        }
+    }
+}
+
+fn visible_pin_responses(
+    pins: Vec<AgentPinRecord>,
+    session_key: &str,
+    panes: &[PaneInfo],
+) -> Vec<AgentPinResponse> {
+    pins.into_iter()
+        .filter(|pin| pin.session_key == session_key)
+        .filter(|pin| panes.iter().any(|pane| pin_matches_pane(pin, pane)))
+        .map(|pin| AgentPinResponse {
+            pane_id: pin.pane_id,
+            terminal_id: pin.terminal_id,
+            workspace_id: pin.workspace_id,
+            tab_id: pin.tab_id,
+            created_at: pin.created_at,
+            context: pin.context,
+        })
+        .collect()
+}
+
+fn pin_matches_pane(pin: &AgentPinRecord, pane: &PaneInfo) -> bool {
+    pin.pane_id == pane.pane_id
+        && pin.terminal_id == pane.terminal_id
+        && pin.workspace_id == pane.workspace_id
+        && pin.tab_id == pane.tab_id
+}
+
+fn prune_session_pins_for_missing_panes(
+    store: &mut AgentPinsStore,
+    session_key: &str,
+    panes: &[PaneInfo],
+) {
+    let open_pane_ids: HashSet<&str> = panes.iter().map(|pane| pane.pane_id.as_str()).collect();
+    store.pins.retain(|pin| {
+        pin.session_key != session_key || open_pane_ids.contains(pin.pane_id.as_str())
+    });
+}
+
+fn find_pane<'a>(pane_id: &str, panes: &'a [PaneInfo]) -> Result<&'a PaneInfo, AgentPinsError> {
+    let pane_id = normalize_pane_id(pane_id)?;
+    panes
+        .iter()
+        .find(|pane| pane.pane_id == pane_id)
+        .ok_or_else(|| AgentPinsError::BadRequest(format!("pane not found: {pane_id}")))
+}
+
+fn normalize_pane_id(pane_id: &str) -> Result<String, AgentPinsError> {
+    let pane_id = pane_id.trim();
+    if pane_id.is_empty() {
+        return Err(AgentPinsError::BadRequest(
+            "pane_id is required".to_string(),
+        ));
+    }
+    Ok(pane_id.to_string())
+}
+
+fn pin_record_for_pane(session_key: &str, pane: &PaneInfo) -> AgentPinRecord {
+    AgentPinRecord {
+        session_key: session_key.to_string(),
+        pane_id: pane.pane_id.clone(),
+        terminal_id: pane.terminal_id.clone(),
+        workspace_id: pane.workspace_id.clone(),
+        tab_id: pane.tab_id.clone(),
+        created_at: now_ms_string(),
+        context: AgentPinContext {
+            pane_label: pane.label.clone(),
+            pane_title: pane.title.clone(),
+            agent: pane.agent.clone(),
+            display_agent: pane.display_agent.clone(),
+            cwd: pane.cwd.clone(),
+            foreground_cwd: pane.foreground_cwd.clone(),
+        },
+    }
+}
+
+fn parse_store(bytes: &[u8]) -> Result<AgentPinsStore, AgentPinsError> {
+    let store: AgentPinsStore = serde_json::from_slice(bytes)
+        .map_err(|err| AgentPinsError::Store(format!("agent pins store is unreadable: {err}")))?;
+    if store.version != AGENT_PINS_STORE_VERSION {
+        return Err(AgentPinsError::Store(format!(
+            "unsupported agent pins store version: {}",
+            store.version
+        )));
+    }
+    Ok(store)
+}
+
+fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<(), AgentPinsError> {
+    if let Some(parent) = path.parent() {
+        ensure_private_dir(parent)?;
+    }
+    let temp_path = path.with_extension(format!("{}.tmp", std::process::id()));
+    let bytes = serde_json::to_vec_pretty(value)
+        .map_err(|err| AgentPinsError::Store(format!("failed to serialize agent pins: {err}")))?;
+    let mut file = File::create(&temp_path)?;
+    set_private_file_permissions(&temp_path)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    drop(file);
+    fs::rename(&temp_path, path)?;
+    set_private_file_permissions(path)?;
+    if let Some(parent) = path.parent() {
+        File::open(parent)?.sync_all()?;
+    }
+    Ok(())
+}
+
+fn default_agent_pins_dir() -> PathBuf {
+    if let Some(path) = non_empty_env_path("HERDR_WEB_AGENT_PINS_DIR") {
+        return path;
+    }
+    if let Some(data_home) = non_empty_env_path("XDG_DATA_HOME") {
+        return data_home.join("herdr-web").join("agent-pins");
+    }
+    if let Some(home) = non_empty_env_path("HOME") {
+        return home
+            .join(".local")
+            .join("share")
+            .join("herdr-web")
+            .join("agent-pins");
+    }
+    PathBuf::from("herdr-web-agent-pins")
+}
+
+fn non_empty_env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn session_key() -> String {
+    if let Some(name) = crate::session::active_name() {
+        return format!("session:{name}");
+    }
+    if let Ok(path) = std::env::var(herdr_compat::api::SOCKET_PATH_ENV_VAR) {
+        if !path.is_empty() && !crate::session::explicit_session_requested() {
+            let canonical = fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(path));
+            return format!(
+                "socket:{:016x}",
+                stable_hash(canonical.to_string_lossy().as_ref())
+            );
+        }
+    }
+    "session:default".to_string()
+}
+
+fn stable_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn now_ms_string() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .to_string()
+}
+
+fn ensure_private_dir(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    set_private_dir_permissions(path)
+}
+
+#[cfg(unix)]
+fn set_private_dir_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn set_private_dir_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+fn set_private_file_permissions(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+struct LockFile {
+    file: File,
+}
+
+impl LockFile {
+    fn exclusive(path: &Path) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            ensure_private_dir(parent)?;
+        }
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(path)?;
+        set_private_file_permissions(path)?;
+        lock_file(&file)?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for LockFile {
+    fn drop(&mut self) {
+        let _ = unlock_file(&self.file);
+    }
+}
+
+#[cfg(unix)]
+fn lock_file(file: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+fn lock_file(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn unlock_file(file: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+fn unlock_file(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use herdr_compat::api::schema::AgentStatus;
+
+    #[test]
+    fn list_returns_current_session_matching_open_pins() {
+        let dir = test_dir("list-current");
+        let manager = AgentPinsManager::for_test(dir, "session:a").unwrap();
+        let panes = vec![pane("pane-1", "terminal-1")];
+
+        manager.pin("pane-1", &panes).unwrap();
+        let pins = manager.list(&panes).unwrap();
+
+        assert_eq!(pins.session_key, "session:a");
+        assert_eq!(pins.pins.len(), 1);
+        assert_eq!(pins.pins[0].pane_id, "pane-1");
+    }
+
+    #[test]
+    fn stale_terminal_identity_is_not_visible() {
+        let dir = test_dir("stale-terminal");
+        let manager = AgentPinsManager::for_test(dir, "session:a").unwrap();
+
+        manager
+            .pin("pane-1", &[pane("pane-1", "terminal-1")])
+            .unwrap();
+        let pins = manager.list(&[pane("pane-1", "terminal-2")]).unwrap();
+
+        assert!(pins.pins.is_empty());
+    }
+
+    #[test]
+    fn unpin_removes_visible_pin() {
+        let dir = test_dir("unpin");
+        let manager = AgentPinsManager::for_test(dir, "session:a").unwrap();
+        let panes = vec![pane("pane-1", "terminal-1")];
+
+        manager.pin("pane-1", &panes).unwrap();
+        let pins = manager.unpin("pane-1", &panes).unwrap();
+
+        assert!(pins.pins.is_empty());
+    }
+
+    fn pane(pane_id: &str, terminal_id: &str) -> PaneInfo {
+        PaneInfo {
+            pane_id: pane_id.to_string(),
+            terminal_id: terminal_id.to_string(),
+            workspace_id: "workspace-a".to_string(),
+            tab_id: "tab-a".to_string(),
+            focused: false,
+            cwd: None,
+            foreground_cwd: None,
+            label: None,
+            agent: Some("codex".to_string()),
+            agent_session: None,
+            title: None,
+            display_agent: Some("Codex".to_string()),
+            agent_status: AgentStatus::Idle,
+            custom_status: None,
+            state_labels: HashMap::new(),
+            revision: 1,
+        }
+    }
+
+    fn test_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "herdr-web-agent-pins-test-{name}-{}",
+            now_ms_string()
+        ))
+    }
+}

--- a/bridge/src/agent_pins.rs
+++ b/bridge/src/agent_pins.rs
@@ -8,6 +8,7 @@ use herdr_compat::api::schema::PaneInfo;
 use serde::{Deserialize, Serialize};
 
 const AGENT_PINS_STORE_VERSION: u32 = 1;
+const MAX_AGENT_PIN_RECORDS: usize = 1_000;
 
 #[derive(Clone)]
 pub struct AgentPinsManager {
@@ -175,7 +176,13 @@ impl AgentPinsManager {
 
     fn load_or_create_store(&self) -> Result<AgentPinsStore, AgentPinsError> {
         match fs::read(&self.pins_path) {
-            Ok(bytes) => parse_store(&bytes),
+            Ok(bytes) => match parse_store(&bytes) {
+                Ok(store) => Ok(store),
+                Err(err) => {
+                    copy_corrupt_once(&self.pins_path);
+                    Err(err)
+                }
+            },
             Err(err) if err.kind() == ErrorKind::NotFound => {
                 let now = now_ms_string();
                 Ok(AgentPinsStore {
@@ -197,23 +204,24 @@ fn visible_pin_responses(
 ) -> Vec<AgentPinResponse> {
     pins.into_iter()
         .filter(|pin| pin.session_key == session_key)
-        .filter(|pin| panes.iter().any(|pane| pin_matches_pane(pin, pane)))
-        .map(|pin| AgentPinResponse {
-            pane_id: pin.pane_id,
-            terminal_id: pin.terminal_id,
-            workspace_id: pin.workspace_id,
-            tab_id: pin.tab_id,
-            created_at: pin.created_at,
-            context: pin.context,
+        .filter_map(|pin| {
+            panes
+                .iter()
+                .find(|pane| pin_matches_pane(&pin, pane))
+                .map(|pane| AgentPinResponse {
+                    pane_id: pane.pane_id.clone(),
+                    terminal_id: pane.terminal_id.clone(),
+                    workspace_id: pane.workspace_id.clone(),
+                    tab_id: pane.tab_id.clone(),
+                    created_at: pin.created_at,
+                    context: pin.context,
+                })
         })
         .collect()
 }
 
 fn pin_matches_pane(pin: &AgentPinRecord, pane: &PaneInfo) -> bool {
-    pin.pane_id == pane.pane_id
-        && pin.terminal_id == pane.terminal_id
-        && pin.workspace_id == pane.workspace_id
-        && pin.tab_id == pane.tab_id
+    pin.pane_id == pane.pane_id && pin.terminal_id == pane.terminal_id
 }
 
 fn prune_session_pins_for_missing_panes(
@@ -225,6 +233,15 @@ fn prune_session_pins_for_missing_panes(
     store.pins.retain(|pin| {
         pin.session_key != session_key || open_pane_ids.contains(pin.pane_id.as_str())
     });
+    prune_oldest_pin_records(store);
+}
+
+fn prune_oldest_pin_records(store: &mut AgentPinsStore) {
+    if store.pins.len() <= MAX_AGENT_PIN_RECORDS {
+        return;
+    }
+    store.pins.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    store.pins.truncate(MAX_AGENT_PIN_RECORDS);
 }
 
 fn find_pane<'a>(pane_id: &str, panes: &'a [PaneInfo]) -> Result<&'a PaneInfo, AgentPinsError> {
@@ -294,6 +311,39 @@ fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<(), AgentPi
         File::open(parent)?.sync_all()?;
     }
     Ok(())
+}
+
+fn copy_corrupt_once(path: &Path) {
+    if corrupt_copy_exists(path) {
+        return;
+    }
+    let Ok(bytes) = fs::read(path) else {
+        return;
+    };
+    let corrupt_path = path.with_extension(format!("{}.corrupt", now_ms_string()));
+    if fs::write(&corrupt_path, bytes).is_ok() {
+        let _ = set_private_file_permissions(&corrupt_path);
+    }
+}
+
+fn corrupt_copy_exists(path: &Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    let Ok(entries) = fs::read_dir(parent) else {
+        return false;
+    };
+    let prefix = format!("{stem}.");
+    entries.flatten().any(|entry| {
+        entry
+            .path()
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".corrupt"))
+    })
 }
 
 fn default_agent_pins_dir() -> PathBuf {
@@ -470,6 +520,22 @@ mod tests {
     }
 
     #[test]
+    fn pin_follows_pane_moves() {
+        let dir = test_dir("pane-move");
+        let manager = AgentPinsManager::for_test(dir, "session:a").unwrap();
+
+        manager
+            .pin("pane-1", &[pane("pane-1", "terminal-1")])
+            .unwrap();
+        let moved_pane = pane_in_location("pane-1", "terminal-1", "workspace-b", "tab-b");
+        let pins = manager.list(&[moved_pane]).unwrap();
+
+        assert_eq!(pins.pins.len(), 1);
+        assert_eq!(pins.pins[0].workspace_id, "workspace-b");
+        assert_eq!(pins.pins[0].tab_id, "tab-b");
+    }
+
+    #[test]
     fn unpin_removes_visible_pin() {
         let dir = test_dir("unpin");
         let manager = AgentPinsManager::for_test(dir, "session:a").unwrap();
@@ -481,12 +547,33 @@ mod tests {
         assert!(pins.pins.is_empty());
     }
 
+    #[test]
+    fn corrupt_store_is_copied_aside_before_error() {
+        let dir = test_dir("corrupt-store");
+        ensure_private_dir(&dir).unwrap();
+        let path = dir.join("agent-pins.json");
+        fs::write(&path, b"{not json").unwrap();
+        let manager = AgentPinsManager::for_test(dir.clone(), "session:a").unwrap();
+
+        assert!(manager.list(&[]).is_err());
+        assert!(corrupt_copy_exists(&path));
+    }
+
     fn pane(pane_id: &str, terminal_id: &str) -> PaneInfo {
+        pane_in_location(pane_id, terminal_id, "workspace-a", "tab-a")
+    }
+
+    fn pane_in_location(
+        pane_id: &str,
+        terminal_id: &str,
+        workspace_id: &str,
+        tab_id: &str,
+    ) -> PaneInfo {
         PaneInfo {
             pane_id: pane_id.to_string(),
             terminal_id: terminal_id.to_string(),
-            workspace_id: "workspace-a".to_string(),
-            tab_id: "tab-a".to_string(),
+            workspace_id: workspace_id.to_string(),
+            tab_id: tab_id.to_string(),
             focused: false,
             cwd: None,
             foreground_cwd: None,

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -1,3 +1,4 @@
+mod agent_pins;
 mod notes;
 mod session;
 mod web_bridge;

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -43,6 +43,7 @@ use herdr_compat::protocol::{
     PROTOCOL_VERSION,
 };
 
+use crate::agent_pins::{AgentPinsError, AgentPinsListResponse, AgentPinsManager};
 use crate::notes::{
     AttachNoteRequest, CreateNoteRequest, NoteResponse, NotesError, NotesListQuery,
     NotesListResponse, NotesManager, RevisionRequest, UpdateNoteRequest,
@@ -86,6 +87,7 @@ struct BridgeState {
     request_policy: RequestPolicy,
     terminal_sessions: Arc<Mutex<HashMap<String, SharedTerminalSession>>>,
     selected_pane_id: Arc<Mutex<Option<String>>>,
+    agent_pins: Arc<AgentPinsManager>,
     notes: Arc<NotesManager>,
     ui_event_tx: tokio::sync::broadcast::Sender<String>,
     activity_tx: tokio::sync::broadcast::Sender<ActivityMessage>,
@@ -127,7 +129,13 @@ struct SnapshotTabInfo {
 #[derive(Debug, Serialize)]
 struct Capabilities {
     commands: &'static [&'static str],
+    agent_pins: AgentPinsCapability,
     notes: NotesCapability,
+}
+
+#[derive(Debug, Serialize)]
+struct AgentPinsCapability {
+    version: u32,
 }
 
 #[derive(Debug, Serialize)]
@@ -585,6 +593,16 @@ impl From<NotesError> for BridgeError {
     }
 }
 
+impl From<AgentPinsError> for BridgeError {
+    fn from(err: AgentPinsError) -> Self {
+        match err {
+            AgentPinsError::BadRequest(message) => Self::BadRequest(message),
+            AgentPinsError::Io(err) => Self::Io(err),
+            AgentPinsError::Store(message) => Self::Protocol(message),
+        }
+    }
+}
+
 impl IntoResponse for UploadError {
     fn into_response(self) -> Response {
         let (status, body) = match self {
@@ -777,6 +795,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         );
     }
     ensure_upload_dir(&options.upload_dir)?;
+    let agent_pins = Arc::new(AgentPinsManager::new()?);
     let notes = Arc::new(NotesManager::new()?);
     let request_policy = RequestPolicy {
         bind_host: options.host.clone(),
@@ -797,12 +816,26 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         request_policy: request_policy.clone(),
         terminal_sessions: Arc::new(Mutex::new(HashMap::new())),
         selected_pane_id: Arc::new(Mutex::new(None)),
+        agent_pins,
         notes,
         ui_event_tx: tokio::sync::broadcast::channel(256).0,
         activity_tx: tokio::sync::broadcast::channel(512).0,
         upload_dir: options.upload_dir.clone(),
     };
     spawn_agent_activity_watcher(state.clone());
+    let agent_pins_routes = Router::new()
+        .route(
+            "/api/agent-pins",
+            get(agent_pins_list_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/agent-pins/{pane_id}/pin",
+            post(agent_pins_pin_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/agent-pins/{pane_id}/unpin",
+            post(agent_pins_unpin_handler).options(preflight_handler),
+        );
     let notes_routes = Router::new()
         .route(
             "/api/notes",
@@ -836,6 +869,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         )
         .layer(DefaultBodyLimit::max(MAX_NOTES_REQUEST_BYTES));
     let app = Router::new()
+        .merge(agent_pins_routes)
         .merge(notes_routes)
         .route(
             "/api/snapshot",
@@ -1854,8 +1888,55 @@ async fn capabilities_handler(
     ensure_allowed_request(&headers, &state.request_policy)?;
     Ok(Json(Capabilities {
         commands: ALLOWED_COMMANDS,
+        agent_pins: AgentPinsCapability { version: 1 },
         notes: NotesCapability { version: 1 },
     }))
+}
+
+async fn agent_pins_list_handler(
+    State(state): State<BridgeState>,
+    headers: HeaderMap,
+) -> Result<Json<AgentPinsListResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    Ok(Json(
+        run_agent_pins_task(state, move |state| {
+            let panes = current_panes(&state.api)?;
+            Ok(state.agent_pins.list(&panes)?)
+        })
+        .await?,
+    ))
+}
+
+async fn agent_pins_pin_handler(
+    State(state): State<BridgeState>,
+    AxumPath(pane_id): AxumPath<String>,
+    headers: HeaderMap,
+) -> Result<Json<AgentPinsListResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let event_pane_id = pane_id.clone();
+    let response = run_agent_pins_task(state.clone(), move |state| {
+        let panes = current_panes(&state.api)?;
+        Ok(state.agent_pins.pin(&pane_id, &panes)?)
+    })
+    .await?;
+    broadcast_agent_pins_changed(&state, Some(&event_pane_id));
+    Ok(Json(response))
+}
+
+async fn agent_pins_unpin_handler(
+    State(state): State<BridgeState>,
+    AxumPath(pane_id): AxumPath<String>,
+    headers: HeaderMap,
+) -> Result<Json<AgentPinsListResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let event_pane_id = pane_id.clone();
+    let response = run_agent_pins_task(state.clone(), move |state| {
+        let panes = current_panes(&state.api)?;
+        Ok(state.agent_pins.unpin(&pane_id, &panes)?)
+    })
+    .await?;
+    broadcast_agent_pins_changed(&state, Some(&event_pane_id));
+    Ok(Json(response))
 }
 
 async fn notes_list_handler(
@@ -1984,6 +2065,16 @@ async fn notes_delete_handler(
     Ok(Json(note))
 }
 
+async fn run_agent_pins_task<T, F>(state: BridgeState, task: F) -> Result<T, BridgeError>
+where
+    T: Send + 'static,
+    F: FnOnce(BridgeState) -> Result<T, BridgeError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(move || task(state))
+        .await
+        .map_err(|err| BridgeError::Protocol(err.to_string()))?
+}
+
 async fn run_notes_task<T, F>(state: BridgeState, task: F) -> Result<T, BridgeError>
 where
     T: Send + 'static,
@@ -1992,6 +2083,16 @@ where
     tokio::task::spawn_blocking(move || task(state))
         .await
         .map_err(|err| BridgeError::Protocol(err.to_string()))?
+}
+
+fn broadcast_agent_pins_changed(state: &BridgeState, pane_id: Option<&str>) {
+    let mut payload = serde_json::json!({
+        "type": "herdr_web.agent_pins_changed",
+    });
+    if let Some(pane_id) = pane_id {
+        payload["pane_id"] = serde_json::json!(pane_id);
+    }
+    let _ = state.ui_event_tx.send(payload.to_string());
 }
 
 fn broadcast_notes_changed(state: &BridgeState, note_id: Option<&str>, revision: Option<u64>) {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -6,6 +6,7 @@ import {
   buildVisibleScopedWorkspaces,
   buildVisibleTabEntries,
   isInFlightNoteSaveVisible,
+  menuItems,
   nextVisibleAgentPaneEntry,
   nextVisibleTabEntry,
   resolveInitialSelectedBridgeId,
@@ -202,6 +203,82 @@ describe("App multi-bridge helpers", () => {
         (item) => `${item.bridgeId}:${item.pane.pane_id}`,
       ),
     ).toEqual(["bridge-b:pane-b", "bridge-a:pane-a"]);
+  });
+
+  it("promotes pinned agents within their current group", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1)],
+      [
+        pane("pane-a", "workspace-a", "tab-a", "idle"),
+        pane("pane-b", "workspace-a", "tab-a", "idle"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+
+    expect(
+      buildVisibleAgentPaneEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "workspace",
+        "workspace",
+        new Set(["bridge-a:pane-b"]),
+      ).map((item) => item.pane.pane_id),
+    ).toEqual(["pane-b", "pane-a"]);
+  });
+
+  it("filters agents to pinned rows without reordering groups", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1), workspace("workspace-b", 2)],
+      [
+        pane("pane-a", "workspace-a", "tab-a", "idle"),
+        pane("pane-b", "workspace-b", "tab-b", "idle"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+
+    expect(
+      buildVisibleAgentPaneEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "workspace",
+        "workspace",
+        new Set(["bridge-a:pane-a", "bridge-a:pane-b"]),
+        true,
+      ).map((item) => `${item.workspace?.workspace_id}:${item.pane.pane_id}`),
+    ).toEqual(["workspace-a:pane-a", "workspace-b:pane-b"]);
+  });
+
+  it("shows pin actions even when pane commands are not ready", () => {
+    expect(menuItems("pane", false, false, true, false)).toEqual([
+      { key: "pin", label: "Pin pane" },
+    ]);
+    expect(menuItems("pane", false, false, true, true)).toEqual([
+      { key: "unpin", label: "Unpin pane" },
+    ]);
+    expect(menuItems("pane", false, false, true, false, "agent")).toEqual([
+      { key: "pin", label: "Pin agent" },
+    ]);
+    expect(menuItems("pane", false, false, true, true, "agent")).toEqual([
+      { key: "unpin", label: "Unpin agent" },
+    ]);
   });
 
   it("builds visible tab entries across hosts for all-host shortcut navigation", () => {
@@ -628,6 +705,36 @@ function bridgeSnapshot(workspaceId: string, tabId: string, paneInfo: PaneInfo):
     workspaces: [workspaceInfo],
     tabs: [tabInfo],
     panes: [paneInfo],
+    layouts: [],
+  };
+}
+
+function multiPaneSnapshot(workspaces: WorkspaceInfo[], panes: PaneInfo[]): Snapshot {
+  const tabsById = new Map<string, TabInfo>();
+  for (const paneInfo of panes) {
+    if (tabsById.has(paneInfo.tab_id)) {
+      continue;
+    }
+    tabsById.set(paneInfo.tab_id, {
+      tab_id: paneInfo.tab_id,
+      workspace_id: paneInfo.workspace_id,
+      number: tabsById.size + 1,
+      label: paneInfo.tab_id,
+      focused: false,
+      pane_count: panes.filter((item) => item.tab_id === paneInfo.tab_id).length,
+      agent_status: paneInfo.agent_status,
+    });
+  }
+  return {
+    workspaces: workspaces.map((workspaceInfo) => ({
+      ...workspaceInfo,
+      pane_count: panes.filter((item) => item.workspace_id === workspaceInfo.workspace_id).length,
+      tab_count: [...tabsById.values()].filter(
+        (tabInfo) => tabInfo.workspace_id === workspaceInfo.workspace_id,
+      ).length,
+    })),
+    tabs: [...tabsById.values()],
+    panes,
     layouts: [],
   };
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1526,6 +1526,20 @@ export function App() {
     () => snapshot?.panes.find((pane) => pane.pane_id === resolvedPaneId) ?? null,
     [snapshot, resolvedPaneId],
   );
+  const selectedPanePinsSupported = Boolean(
+    selectedRuntime?.canConnect &&
+      selectedRuntime.capabilityState === "ready" &&
+      selectedPane &&
+      supportsAgentPins(selectedRuntime.capabilities),
+  );
+  const selectedPanePinned =
+    selectedRuntime && selectedPane
+      ? isAgentPinned(pinnedAgentKeys, selectedRuntime.id, selectedPane.pane_id)
+      : false;
+  const selectedPanePinTarget = selectedPane && isAgentPane(selectedPane) ? "agent" : "pane";
+  const selectedPanePinTitle = selectedPanePinned
+    ? `Unpin ${selectedPanePinTarget}`
+    : `Pin ${selectedPanePinTarget}`;
   const selectedNotesState =
     selectedRuntime && notesStates[selectedRuntime.id]?.connectionKey === selectedRuntime.connectionKey
       ? notesStates[selectedRuntime.id]
@@ -3042,6 +3056,21 @@ export function App() {
               onClick={openNotesPanel}
             >
               <StickyNote size={18} />
+            </button>
+          ) : null}
+          {selectedPane && selectedRuntime && selectedPanePinsSupported ? (
+            <button
+              className="icon-btn stage-pin-button"
+              type="button"
+              aria-label={selectedPanePinTitle}
+              title={selectedPanePinTitle}
+              aria-pressed={selectedPanePinned}
+              data-on={selectedPanePinned}
+              onClick={() =>
+                void toggleAgentPin(selectedRuntime.id, selectedPane.pane_id, selectedPanePinned)
+              }
+            >
+              <Pin size={16} />
             </button>
           ) : null}
           {selectedPane ? (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1526,11 +1526,17 @@ export function App() {
     () => snapshot?.panes.find((pane) => pane.pane_id === resolvedPaneId) ?? null,
     [snapshot, resolvedPaneId],
   );
+  const selectedAgentPinsState =
+    selectedRuntime &&
+    agentPinsStates[selectedRuntime.id]?.connectionKey === selectedRuntime.connectionKey
+      ? agentPinsStates[selectedRuntime.id]
+      : null;
   const selectedPanePinsSupported = Boolean(
     selectedRuntime?.canConnect &&
       selectedRuntime.capabilityState === "ready" &&
       selectedPane &&
-      supportsAgentPins(selectedRuntime.capabilities),
+      supportsAgentPins(selectedRuntime.capabilities) &&
+      selectedAgentPinsState?.response,
   );
   const selectedPanePinned =
     selectedRuntime && selectedPane

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5175,7 +5175,7 @@ function Switcher({
                 ) : null}
                 {sidebarView === "agents" && agentPinsSupported ? (
                   <button
-                    className="sec-add"
+                    className="sec-add sec-add-pin"
                     type="button"
                     aria-label="Show pinned agents only"
                     title="Pinned only"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -960,6 +960,10 @@ export function App() {
     () => buildAgentPinKeySet(bridgeViews, agentPinsStates),
     [agentPinsStates, bridgeViews],
   );
+  const effectiveAgentPinnedOnly =
+    visibleHostBridgeViews(bridgeViews, selectedBridgeId, hostScope).some((view) =>
+      supportsAgentPins(view.runtime.capabilities),
+    ) && agentPinnedOnly;
   const selectedRuntime = useMemo(
     () =>
       selectedBridgeId
@@ -2196,7 +2200,7 @@ export function App() {
           agentGroup,
           agentSort,
           pinnedAgentKeys,
-          agentPinnedOnly,
+          effectiveAgentPinnedOnly,
         );
         if (agentEntries.length === 0) {
           return;
@@ -2263,7 +2267,7 @@ export function App() {
   }, [
     activeSpace,
     activeWorkspacesByBridgeId,
-    agentPinnedOnly,
+    effectiveAgentPinnedOnly,
     agentGroup,
     agentSort,
     bridgeViews,
@@ -4620,6 +4624,7 @@ function Switcher({
   const agentPinsSupported = hostBridgeViews.some((view) =>
     supportsAgentPins(view.runtime.capabilities),
   );
+  const effectiveAgentPinnedOnly = agentPinsSupported && agentPinnedOnly;
   const notesLoading = notesEnabled && hostBridgeViews.some(
     (view) => notesStates[view.runtime.id]?.loadState === "loading",
   );
@@ -4646,9 +4651,16 @@ function Switcher({
       "none",
       agentSort,
       pinnedAgentKeys,
-      agentPinnedOnly,
+      effectiveAgentPinnedOnly,
     );
-  }, [agentPinnedOnly, agentSort, bridgeViews, hostScope, pinnedAgentKeys, scopedWorkspaces]);
+  }, [
+    effectiveAgentPinnedOnly,
+    agentSort,
+    bridgeViews,
+    hostScope,
+    pinnedAgentKeys,
+    scopedWorkspaces,
+  ]);
 
   const agentGroups = useMemo(() => {
     if (agentGroup === "none") {
@@ -5209,8 +5221,10 @@ function Switcher({
               ) : sidebarView === "agents" ? (
                 agentPanes.length === 0 && disconnectedBridgeViews.length === 0 ? (
                   <div className="empty">
-                    <strong>{agentPinnedOnly ? "No pinned agents" : "No detected agents"}</strong>
-                    <span>{agentPinnedOnly ? "" : "Open the Tabs view for plain panes."}</span>
+                    <strong>
+                      {effectiveAgentPinnedOnly ? "No pinned agents" : "No detected agents"}
+                    </strong>
+                    <span>{effectiveAgentPinnedOnly ? "" : "Open the Tabs view for plain panes."}</span>
                   </div>
                 ) : (
                   <>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import {
   Link2,
   MoreVertical,
   PanelLeft,
+  Pin,
   Plus,
   RefreshCw,
   RotateCcw,
@@ -37,6 +38,15 @@ import type {
 import { Capacitor } from "@capacitor/core";
 import { Preferences } from "@capacitor/preferences";
 import { AgentIcon, agentIconKind } from "./AgentIcon";
+import {
+  agentPinKey,
+  agentPinKeys,
+  fetchAgentPins,
+  pinAgent,
+  supportsAgentPins,
+  unpinAgent,
+} from "./agentPins";
+import type { AgentPinsListResponse } from "./agentPins";
 import { applyActivityMessage, parseActivityEventData, replayActivityMessages } from "./activity";
 import type { ActivityLogEntry } from "./activity";
 import { BackendSettingsDialog } from "./BackendSettingsDialog";
@@ -178,6 +188,12 @@ type BridgeNotesState = {
   loadState: LoadState;
   error: string | null;
 };
+type BridgeAgentPinsState = {
+  connectionKey: string;
+  response: AgentPinsListResponse | null;
+  loadState: LoadState;
+  error: string | null;
+};
 export type BridgeConnectionRef = {
   connectionKey: string;
   snapshot: Snapshot | null;
@@ -195,6 +211,7 @@ export type ScopedAgentPane = {
   workspace?: WorkspaceInfo;
   tabNumber?: number;
   tabLabel?: string;
+  pinned?: boolean;
 };
 type ScopedWorkspace = {
   bridgeId: BridgeId;
@@ -254,6 +271,7 @@ type MenuState = {
   x: number;
   y: number;
   clearable?: boolean;
+  pinLabel?: "agent" | "pane";
 };
 type DialogState = {
   mode: "rename" | "close";
@@ -269,6 +287,7 @@ type DisplayPrefs = {
   sidebarView: SidebarView;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
+  agentPinnedOnly: boolean;
   sidebarWidth: number;
   notesPanelWidth: number;
   notesListPaneWidth: number;
@@ -322,6 +341,7 @@ function readDisplayPrefs(): DisplayPrefs {
     sidebarView: "agents",
     agentSort: "attention",
     agentGroup: "none",
+    agentPinnedOnly: false,
     sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
     notesPanelWidth: DEFAULT_NOTES_PANEL_WIDTH,
     notesListPaneWidth: DEFAULT_NOTES_LIST_PANE_WIDTH,
@@ -417,6 +437,10 @@ function parseDisplayPrefsValue(
       parsed.agentGroup === "hostWorkspace"
         ? parsed.agentGroup
         : fallback.agentGroup,
+    agentPinnedOnly:
+      typeof parsed.agentPinnedOnly === "boolean"
+        ? parsed.agentPinnedOnly
+        : fallback.agentPinnedOnly,
     sidebarWidth,
     notesPanelWidth,
     notesListPaneWidth:
@@ -527,6 +551,10 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
         parsed.agentGroup === "hostWorkspace"
           ? parsed.agentGroup
           : fallback.agentGroup,
+      agentPinnedOnly:
+        typeof parsed.agentPinnedOnly === "boolean"
+          ? parsed.agentPinnedOnly
+          : fallback.agentPinnedOnly,
       sidebarWidth,
       notesPanelWidth,
       notesListPaneWidth:
@@ -714,6 +742,7 @@ export function App() {
   const legacySelectionPrefs = useMemo(readLegacyDisplaySelectionPrefs, []);
   const [displayPrefsLoaded, setDisplayPrefsLoaded] = useState(() => !isNativeApp());
   const [connectionStates, setConnectionStates] = useState<Record<string, BridgeConnectionState>>({});
+  const [agentPinsStates, setAgentPinsStates] = useState<Record<string, BridgeAgentPinsState>>({});
   const [notesStates, setNotesStates] = useState<Record<string, BridgeNotesState>>({});
   const [selectedBridgeId, setSelectedBridgeId] = useState<BridgeId | null>(
     initialPrefs.selectedBridgeId,
@@ -741,6 +770,7 @@ export function App() {
   const [sidebarView, setSidebarView] = useState<SidebarView>(initialPrefs.sidebarView);
   const [agentSort, setAgentSort] = useState<AgentSort>(initialPrefs.agentSort);
   const [agentGroup, setAgentGroup] = useState<AgentGroup>(initialPrefs.agentGroup);
+  const [agentPinnedOnly, setAgentPinnedOnly] = useState(initialPrefs.agentPinnedOnly);
   const [sidebarWidth, setSidebarWidth] = useState(initialPrefs.sidebarWidth);
   const [notesPanelWidth, setNotesPanelWidth] = useState(initialPrefs.notesPanelWidth);
   const [notesListPaneWidth, setNotesListPaneWidth] = useState(initialPrefs.notesListPaneWidth);
@@ -840,6 +870,7 @@ export function App() {
       setSidebarView(prefs.sidebarView);
       setAgentSort(prefs.agentSort);
       setAgentGroup(prefs.agentGroup);
+      setAgentPinnedOnly(prefs.agentPinnedOnly);
       setSidebarWidth(prefs.sidebarWidth);
       setNotesPanelWidth(prefs.notesPanelWidth);
       setNotesListPaneWidth(prefs.notesListPaneWidth);
@@ -925,6 +956,10 @@ export function App() {
       }),
     [bridge.enabledRuntimes, connectionStates],
   );
+  const pinnedAgentKeys = useMemo(
+    () => buildAgentPinKeySet(bridgeViews, agentPinsStates),
+    [agentPinsStates, bridgeViews],
+  );
   const selectedRuntime = useMemo(
     () =>
       selectedBridgeId
@@ -980,7 +1015,28 @@ export function App() {
   );
   const menuSupportedCommands = menuCommandsReady ? (menuRuntime?.capabilities?.commands ?? []) : [];
   const menuPaneMoveSupported = menuSupportedCommands.includes("pane.move");
-  const activeMenuItems = menu ? menuItems(menu.kind, menuPaneMoveSupported, menuCommandsReady) : [];
+  const menuAgentPinsSupported = Boolean(
+    menu &&
+      menu.kind === "pane" &&
+      menu.pinLabel &&
+      menuRuntime?.canConnect &&
+      menuRuntime.capabilityState === "ready" &&
+      supportsAgentPins(menuRuntime.capabilities),
+  );
+  const menuPinLabel = menu?.pinLabel ?? "pane";
+  const menuPanePinned = menu
+    ? isAgentPinned(pinnedAgentKeys, menu.bridgeId, menu.id)
+    : false;
+  const activeMenuItems = menu
+    ? menuItems(
+        menu.kind,
+        menuPaneMoveSupported,
+        menuCommandsReady,
+        menuAgentPinsSupported,
+        menuPanePinned,
+        menuPinLabel,
+      )
+    : [];
 
   useEffect(() => {
     if (menu && activeMenuItems.length === 0) {
@@ -1149,6 +1205,7 @@ export function App() {
       sidebarView,
       agentSort,
       agentGroup,
+      agentPinnedOnly,
       sidebarWidth,
       notesPanelWidth,
       notesListPaneWidth,
@@ -1182,6 +1239,7 @@ export function App() {
     sidebarView,
     agentSort,
     agentGroup,
+    agentPinnedOnly,
     sidebarWidth,
     notesPanelWidth,
     notesListPaneWidth,
@@ -1406,6 +1464,18 @@ export function App() {
       }
       return changed ? next : current;
     });
+    setAgentPinsStates((current) => {
+      let changed = false;
+      const next: Record<string, BridgeAgentPinsState> = {};
+      for (const [bridgeId, state] of Object.entries(current)) {
+        if (activeBridgeIds.has(bridgeId)) {
+          next[bridgeId] = state;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
   }, [bridge.enabledRuntimes]);
 
   useEffect(() => {
@@ -1496,6 +1566,7 @@ export function App() {
         label: paneTitle(selectedPane),
         x,
         y,
+        pinLabel: isAgentPane(selectedPane) ? "agent" : "pane",
       });
     }
   });
@@ -2124,6 +2195,8 @@ export function App() {
           hostScope,
           agentGroup,
           agentSort,
+          pinnedAgentKeys,
+          agentPinnedOnly,
         );
         if (agentEntries.length === 0) {
           return;
@@ -2190,6 +2263,7 @@ export function App() {
   }, [
     activeSpace,
     activeWorkspacesByBridgeId,
+    agentPinnedOnly,
     agentGroup,
     agentSort,
     bridgeViews,
@@ -2200,6 +2274,7 @@ export function App() {
     launchTarget,
     menu,
     paneFocusSupported,
+    pinnedAgentKeys,
     scope,
     selectedPane,
     selectedRuntime,
@@ -2271,6 +2346,97 @@ export function App() {
       return null;
     }
   }
+
+  async function refreshBridgeAgentPins(runtime: BridgeRuntime, setLoading: boolean) {
+    ensureBridgeConnectionRef(connectionRefs, runtime);
+    const requestConnectionKey = runtime.connectionKey;
+    const isCurrentConnection = () =>
+      isConnectionResultCurrent(
+        connectionRefs.current[runtime.id]?.connectionKey ?? "",
+        requestConnectionKey,
+      );
+    if (
+      !runtime.canConnect ||
+      runtime.capabilityState !== "ready" ||
+      !supportsAgentPins(runtime.capabilities)
+    ) {
+      setAgentPinsStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response: null,
+          loadState: "ready",
+          error: null,
+        },
+      }));
+      return null;
+    }
+    if (setLoading) {
+      setAgentPinsStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response:
+            current[runtime.id]?.connectionKey === requestConnectionKey
+              ? current[runtime.id]?.response ?? null
+              : null,
+          loadState: "loading",
+          error: null,
+        },
+      }));
+    }
+    try {
+      const response = await fetchAgentPins(runtime.httpUrl);
+      setAgentPinsStates((current) => {
+        if (!isCurrentConnection()) {
+          return current;
+        }
+        return {
+          ...current,
+          [runtime.id]: {
+            connectionKey: requestConnectionKey,
+            response,
+            loadState: "ready",
+            error: null,
+          },
+        };
+      });
+      return response;
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : "Agent pins unavailable";
+      if (!isCurrentConnection()) {
+        return null;
+      }
+      setAgentPinsStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response:
+            current[runtime.id]?.connectionKey === requestConnectionKey
+              ? current[runtime.id]?.response ?? null
+              : null,
+          loadState: "error",
+          error: message,
+        },
+      }));
+      return null;
+    }
+  }
+
+  const refreshAgentPinsForBridge = (bridgeId: BridgeId) => {
+    const runtime = bridge.getRuntime(bridgeId);
+    if (runtime) {
+      void refreshBridgeAgentPins(runtime, false);
+    }
+  };
+
+  useEffect(() => {
+    for (const runtime of bridge.enabledRuntimes) {
+      if (runtime.capabilityState === "ready" && supportsAgentPins(runtime.capabilities)) {
+        void refreshBridgeAgentPins(runtime, true);
+      }
+    }
+  }, [bridge.enabledRuntimes]);
 
   async function refreshBridgeNotes(runtime: BridgeRuntime, setLoading: boolean) {
     ensureBridgeConnectionRef(connectionRefs, runtime);
@@ -2459,6 +2625,37 @@ export function App() {
     }
   }
 
+  async function toggleAgentPin(bridgeId: BridgeId, paneId: string, pinned: boolean) {
+    const runtime = bridge.getRuntime(bridgeId);
+    if (
+      !runtime ||
+      !runtime.canConnect ||
+      runtime.capabilityState !== "ready" ||
+      !supportsAgentPins(runtime.capabilities)
+    ) {
+      setError("Agent pins are unavailable");
+      return;
+    }
+    const requestConnectionKey = runtime.connectionKey;
+    try {
+      const response = pinned
+        ? await unpinAgent(runtime.httpUrl, paneId)
+        : await pinAgent(runtime.httpUrl, paneId);
+      setAgentPinsStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response,
+          loadState: "ready",
+          error: null,
+        },
+      }));
+      setError(null);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not update agent pin");
+    }
+  }
+
   const onMenuPick = (key: string) => {
     if (!menu) {
       return;
@@ -2478,6 +2675,10 @@ export function App() {
         current[bridgeId] === id ? current : { ...current, [bridgeId]: id },
       );
       setLaunchTarget({ mode: "tab", workspaceId: id, bridgeId });
+    } else if (key === "pin" && kind === "pane") {
+      void toggleAgentPin(bridgeId, id, false);
+    } else if (key === "unpin" && kind === "pane") {
+      void toggleAgentPin(bridgeId, id, true);
     } else if (key === "move_new_tab" && kind === "pane") {
       const pane = connectionRefs.current[bridgeId]?.snapshot?.panes.find(
         (item) => item.pane_id === id,
@@ -2620,6 +2821,7 @@ export function App() {
           connectionRefs={connectionRefs}
           setConnectionStates={setConnectionStates}
           onPaneSelection={rememberPaneSelection}
+          onAgentPinsChanged={refreshAgentPinsForBridge}
           onNotesChanged={refreshNotesForBridge}
         />
       ))}
@@ -2641,6 +2843,8 @@ export function App() {
           notesStates={notesStates}
           visibleNotes={visibleNotes}
           selectedNote={selectedScopedNote}
+          pinnedAgentKeys={pinnedAgentKeys}
+          agentPinnedOnly={agentPinnedOnly}
           agentSort={agentSort}
           agentGroup={agentGroup}
           activeSpace={activeSpace}
@@ -2651,6 +2855,7 @@ export function App() {
           onSidebarView={setSidebarView}
           onSelectNote={selectNote}
           onCreateNote={() => void createDetachedBridgeNote()}
+          onAgentPinnedOnly={setAgentPinnedOnly}
           onAgentSort={setAgentSort}
           onAgentGroup={setAgentGroup}
           onSelectBridge={setSelectedBridgeId}
@@ -2679,8 +2884,8 @@ export function App() {
               ? setMenu({ kind, bridgeId: selectedRuntime.id, id, label, x, y, clearable })
               : undefined
           }
-          onScopedMenu={(kind, bridgeId, id, label, x, y, clearable) =>
-            setMenu({ kind, bridgeId, id, label, x, y, clearable })
+          onScopedMenu={(kind, bridgeId, id, label, x, y, clearable, pinLabel) =>
+            setMenu({ kind, bridgeId, id, label, x, y, clearable, pinLabel })
           }
         />
         <div
@@ -3168,16 +3373,19 @@ export function BridgeConnectionController({
   connectionRefs,
   setConnectionStates,
   onPaneSelection,
+  onAgentPinsChanged,
   onNotesChanged,
 }: {
   runtime: BridgeRuntime;
   connectionRefs: MutableRefObject<Record<string, BridgeConnectionRef>>;
   setConnectionStates: Dispatch<SetStateAction<Record<string, BridgeConnectionState>>>;
   onPaneSelection: (bridgeId: BridgeId, paneId: string, workspaceId?: string) => void;
+  onAgentPinsChanged: (bridgeId: BridgeId) => void;
   onNotesChanged: (bridgeId: BridgeId) => void;
 }) {
   const httpUrlRef = useRef(runtime.httpUrl);
   const wsUrlRef = useRef(runtime.wsUrl);
+  const onAgentPinsChangedRef = useRef(onAgentPinsChanged);
   const onNotesChangedRef = useRef(onNotesChanged);
   const refreshOffsetRef = useRef(stableBridgeRefreshOffsetMs(runtime.id));
 
@@ -3187,8 +3395,9 @@ export function BridgeConnectionController({
   }, [runtime.httpUrl, runtime.wsUrl]);
 
   useEffect(() => {
+    onAgentPinsChangedRef.current = onAgentPinsChanged;
     onNotesChangedRef.current = onNotesChanged;
-  }, [onNotesChanged]);
+  }, [onAgentPinsChanged, onNotesChanged]);
 
   useEffect(() => {
     let disposed = false;
@@ -3345,6 +3554,10 @@ export function BridgeConnectionController({
         onNotesChangedRef.current(runtime.id);
         return;
       }
+      if (isAgentPinsChangedEvent(event)) {
+        onAgentPinsChangedRef.current(runtime.id);
+        return;
+      }
       refresh();
     });
 
@@ -3437,6 +3650,46 @@ export function activeWorkspaceForBridgeView(
   );
 }
 
+const EMPTY_AGENT_PIN_KEYS = new Set<string>();
+
+export function isAgentPinned(
+  pinnedAgentKeys: ReadonlySet<string>,
+  bridgeId: BridgeId,
+  paneId: string,
+) {
+  return pinnedAgentKeys.has(agentPinKey(bridgeId, paneId));
+}
+
+export function buildAgentPinKeySet(
+  bridgeViews: BridgeConnectionView[],
+  agentPinsStates: Record<string, BridgeAgentPinsState>,
+) {
+  const keys = new Set<string>();
+  for (const view of bridgeViews) {
+    const state = agentPinsStates[view.runtime.id];
+    if (!state || state.connectionKey !== view.runtime.connectionKey) {
+      continue;
+    }
+    for (const key of agentPinKeys(view.runtime.id, state.response)) {
+      keys.add(key);
+    }
+  }
+  return keys;
+}
+
+function sortedAgentEntriesWithinGroup(entries: ScopedAgentPane[]) {
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => {
+      const pinned = Number(b.entry.pinned === true) - Number(a.entry.pinned === true);
+      if (pinned !== 0) {
+        return pinned;
+      }
+      return a.index - b.index;
+    })
+    .map(({ entry }) => entry);
+}
+
 export function buildVisibleScopedWorkspaces(
   bridgeViews: BridgeConnectionView[],
   selectedBridgeId: BridgeId | null,
@@ -3483,8 +3736,10 @@ export function buildVisibleAgentPaneEntries(
   hostScope: HostScope,
   agentGroup: AgentGroup,
   agentSort: AgentSort,
+  pinnedAgentKeys: ReadonlySet<string> = EMPTY_AGENT_PIN_KEYS,
+  pinnedOnly = false,
 ) {
-  const agentPanes = sortScopedAgentPanes(
+  const sortedAgentPanes = sortScopedAgentPanes(
     scopedWorkspaces.flatMap((entry) => {
       const sorted = sortAgentPanes(
         entry.snapshot.panes.filter(
@@ -3505,16 +3760,23 @@ export function buildVisibleAgentPaneEntries(
           workspace: entry.workspace,
           tabNumber: tab?.number,
           tabLabel: tab ? displayTabLabel(tab, entry.snapshot.panes) : undefined,
+          pinned: isAgentPinned(pinnedAgentKeys, entry.bridgeId, pane.pane_id),
         };
       });
     }),
     agentSort,
   );
+  const agentPanes = pinnedOnly
+    ? sortedAgentPanes.filter((entry) => entry.pinned)
+    : sortedAgentEntriesWithinGroup(sortedAgentPanes);
   if (agentGroup === "none") {
     return agentPanes;
   }
 
-  const groups = buildScopedAgentGroups(agentPanes, agentGroup, hostScope);
+  const groups = buildScopedAgentGroups(agentPanes, agentGroup, hostScope).map((group) => ({
+    ...group,
+    panes: sortedAgentEntriesWithinGroup(group.panes),
+  }));
   if (agentGroup === "hostWorkspace" && hostScope === "all") {
     return bridgeViews.flatMap((view) =>
       groups.filter((group) => group.bridgeId === view.runtime.id).flatMap((group) => group.panes),
@@ -4231,6 +4493,8 @@ function Switcher({
   notesStates,
   visibleNotes,
   selectedNote,
+  pinnedAgentKeys,
+  agentPinnedOnly,
   agentSort,
   agentGroup,
   activeSpace,
@@ -4241,6 +4505,7 @@ function Switcher({
   onSidebarView,
   onSelectNote,
   onCreateNote,
+  onAgentPinnedOnly,
   onAgentSort,
   onAgentGroup,
   onSelectBridge,
@@ -4271,6 +4536,8 @@ function Switcher({
   notesStates: Record<string, BridgeNotesState>;
   visibleNotes: ScopedNoteEntry[];
   selectedNote: ScopedNoteEntry | null;
+  pinnedAgentKeys: ReadonlySet<string>;
+  agentPinnedOnly: boolean;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
   activeSpace: WorkspaceInfo | null;
@@ -4281,6 +4548,7 @@ function Switcher({
   onSidebarView: (view: SidebarView) => void;
   onSelectNote: (bridgeId: BridgeId, noteId: string) => void;
   onCreateNote: () => void;
+  onAgentPinnedOnly: (pinnedOnly: boolean) => void;
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
   onSelectBridge: (bridgeId: BridgeId) => void;
@@ -4308,6 +4576,7 @@ function Switcher({
     x: number,
     y: number,
     clearable?: boolean,
+    pinLabel?: "agent" | "pane",
   ) => void;
 }) {
   const [optionsMenu, setOptionsMenu] = useState<{ x: number; y: number } | null>(null);
@@ -4348,6 +4617,9 @@ function Switcher({
       : [];
   const notesSupported =
     notesEnabled && hostBridgeViews.some((view) => supportsNotes(view.runtime.capabilities));
+  const agentPinsSupported = hostBridgeViews.some((view) =>
+    supportsAgentPins(view.runtime.capabilities),
+  );
   const notesLoading = notesEnabled && hostBridgeViews.some(
     (view) => notesStates[view.runtime.id]?.loadState === "loading",
   );
@@ -4373,8 +4645,10 @@ function Switcher({
       hostScope,
       "none",
       agentSort,
+      pinnedAgentKeys,
+      agentPinnedOnly,
     );
-  }, [agentSort, bridgeViews, hostScope, scopedWorkspaces]);
+  }, [agentPinnedOnly, agentSort, bridgeViews, hostScope, pinnedAgentKeys, scopedWorkspaces]);
 
   const agentGroups = useMemo(() => {
     if (agentGroup === "none") {
@@ -4463,7 +4737,16 @@ function Switcher({
                 active={group.bridgeId === selectedBridgeId && pane.pane_id === selectedPane?.pane_id}
                 onSelect={() => onSelectPane(group.bridgeId, pane)}
                 onMenu={(x, y) =>
-                  onScopedMenu("pane", group.bridgeId, pane.pane_id, paneTitle(pane), x, y)
+                  onScopedMenu(
+                    "pane",
+                    group.bridgeId,
+                    pane.pane_id,
+                    paneTitle(pane),
+                    x,
+                    y,
+                    undefined,
+                    "pane",
+                  )
                 }
               />
             ))}
@@ -4532,6 +4815,7 @@ function Switcher({
             workspace={entry.workspace}
             tabLabel={entry.tabLabel}
             bridgeLabel={showAgentRowBridgeLabel ? entry.bridgeLabel : undefined}
+            pinned={entry.pinned === true}
             active={
               entry.bridgeId === selectedBridgeId &&
               entry.pane.pane_id === selectedPane?.pane_id
@@ -4545,6 +4829,8 @@ function Switcher({
                 paneTitle(entry.pane),
                 x,
                 y,
+                undefined,
+                "agent",
               )
             }
           />
@@ -4887,6 +5173,19 @@ function Switcher({
                     <Plus size={14} />
                   </button>
                 ) : null}
+                {sidebarView === "agents" && agentPinsSupported ? (
+                  <button
+                    className="sec-add"
+                    type="button"
+                    aria-label="Show pinned agents only"
+                    title="Pinned only"
+                    aria-pressed={agentPinnedOnly}
+                    data-on={agentPinnedOnly}
+                    onClick={() => onAgentPinnedOnly(!agentPinnedOnly)}
+                  >
+                    <Pin size={13} />
+                  </button>
+                ) : null}
                 {showOptionsControl ? (
                   <button
                     className="sec-add"
@@ -4910,8 +5209,8 @@ function Switcher({
               ) : sidebarView === "agents" ? (
                 agentPanes.length === 0 && disconnectedBridgeViews.length === 0 ? (
                   <div className="empty">
-                    <strong>No detected agents</strong>
-                    <span>Open the Tabs view for plain panes.</span>
+                    <strong>{agentPinnedOnly ? "No pinned agents" : "No detected agents"}</strong>
+                    <span>{agentPinnedOnly ? "" : "Open the Tabs view for plain panes."}</span>
                   </div>
                 ) : (
                   <>
@@ -4926,6 +5225,7 @@ function Switcher({
                             workspace={entry.workspace}
                             tabLabel={entry.tabLabel}
                             bridgeLabel={showAgentRowBridgeLabel ? entry.bridgeLabel : undefined}
+                            pinned={entry.pinned === true}
                             active={
                               entry.bridgeId === selectedBridgeId &&
                               entry.pane.pane_id === selectedPane?.pane_id
@@ -4939,6 +5239,8 @@ function Switcher({
                                 paneTitle(entry.pane),
                                 x,
                                 y,
+                                undefined,
+                                "agent",
                               )
                             }
                           />
@@ -5977,6 +6279,7 @@ function AgentRow({
   workspace,
   tabLabel,
   bridgeLabel,
+  pinned,
   active,
   index,
   onSelect,
@@ -5986,6 +6289,7 @@ function AgentRow({
   workspace?: WorkspaceInfo;
   tabLabel?: string;
   bridgeLabel?: string;
+  pinned: boolean;
   active: boolean;
   index: number;
   onSelect: () => void;
@@ -6006,6 +6310,9 @@ function AgentRow({
       <span className="pane-body">
         <span className="pane-name agent-title">
           {iconKind ? <AgentIcon kind={iconKind} /> : null}
+          {pinned ? (
+            <Pin className="agent-pin-indicator" size={10} aria-label="Pinned" />
+          ) : null}
           <span className="agent-title-text">{agentTitle(pane)}</span>
         </span>
         <span className="pane-meta mono">{agentSubtitle(pane, workspace, tabLabel, bridgeLabel)}</span>
@@ -6265,11 +6572,18 @@ function SplitGlyph() {
   );
 }
 
-function menuItems(kind: MenuKind, paneMoveSupported: boolean, commandsReady: boolean): MenuItem[] {
-  if (!commandsReady) {
-    return [];
-  }
+export function menuItems(
+  kind: MenuKind,
+  paneMoveSupported: boolean,
+  commandsReady: boolean,
+  agentPinsSupported = false,
+  panePinned = false,
+  pinLabel: "agent" | "pane" = "pane",
+): MenuItem[] {
   if (kind === "space") {
+    if (!commandsReady) {
+      return [];
+    }
     return [
       { key: "rename", label: "Rename" },
       { key: "newtab", label: "New tab" },
@@ -6277,14 +6591,26 @@ function menuItems(kind: MenuKind, paneMoveSupported: boolean, commandsReady: bo
     ];
   }
   if (kind === "tab") {
+    if (!commandsReady) {
+      return [];
+    }
     return [
       { key: "rename", label: "Rename" },
       { key: "close", label: "Close tab", danger: true },
     ];
   }
-  const paneItems: MenuItem[] = [
-    { key: "rename", label: "Rename" },
-  ];
+  const paneItems: MenuItem[] = [];
+  if (agentPinsSupported) {
+    const target = pinLabel === "agent" ? "agent" : "pane";
+    paneItems.push({
+      key: panePinned ? "unpin" : "pin",
+      label: panePinned ? `Unpin ${target}` : `Pin ${target}`,
+    });
+  }
+  if (!commandsReady) {
+    return paneItems;
+  }
+  paneItems.push({ key: "rename", label: "Rename" });
   if (paneMoveSupported) {
     paneItems.push(
       { key: "move_new_tab", label: "Move to new tab" },
@@ -6455,6 +6781,18 @@ function isNotesChangedEvent(event: MessageEvent) {
   try {
     const parsed = JSON.parse(event.data) as { type?: unknown };
     return parsed.type === "herdr_web.notes_changed";
+  } catch {
+    return false;
+  }
+}
+
+function isAgentPinsChangedEvent(event: MessageEvent) {
+  if (typeof event.data !== "string") {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(event.data) as { type?: unknown };
+    return parsed.type === "herdr_web.agent_pins_changed";
   } catch {
     return false;
   }

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -514,6 +514,7 @@ function createConnectionHarness({
           connectionRefs={connectionRefs}
           setConnectionStates={setConnectionStates}
           onPaneSelection={onPaneSelection}
+          onAgentPinsChanged={() => undefined}
           onNotesChanged={onNotesChanged}
         />,
       );

--- a/web/src/agentPins.test.ts
+++ b/web/src/agentPins.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AgentPinsApiError,
+  agentPinKey,
+  agentPinKeys,
+  pinAgent,
+  supportsAgentPins,
+} from "./agentPins";
+
+describe("agent pin helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("checks the bridge agent pins capability", () => {
+    expect(supportsAgentPins({ commands: [], agent_pins: { version: 1 } })).toBe(true);
+    expect(supportsAgentPins({ commands: [] })).toBe(false);
+    expect(supportsAgentPins(null)).toBe(false);
+  });
+
+  it("builds scoped pin keys", () => {
+    expect(agentPinKey("bridge-a", "pane-a")).toBe("bridge-a:pane-a");
+    expect(
+      [...agentPinKeys("bridge-a", {
+        session_key: "session:default",
+        pins: [
+          {
+            pane_id: "pane-a",
+            terminal_id: "terminal-a",
+            workspace_id: "workspace-a",
+            tab_id: "tab-a",
+            created_at: "100",
+            context: {},
+          },
+        ],
+      })],
+    ).toEqual(["bridge-a:pane-a"]);
+  });
+
+  it("preserves HTTP status for pin errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ error: "pane not found: pane-a" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(pinAgent((path) => `http://bridge${path}`, "pane-a")).rejects.toMatchObject({
+      name: "AgentPinsApiError",
+      status: 400,
+      message: "pane not found: pane-a",
+    });
+
+    expect(new AgentPinsApiError("bad", 400).status).toBe(400);
+  });
+});

--- a/web/src/agentPins.ts
+++ b/web/src/agentPins.ts
@@ -1,0 +1,88 @@
+import { fetchWithTimeout } from "./fetchWithTimeout";
+import type { BridgeCapabilities } from "./bridge";
+
+export type AgentPinContext = {
+  pane_label?: string;
+  pane_title?: string;
+  agent?: string;
+  display_agent?: string;
+  cwd?: string;
+  foreground_cwd?: string;
+};
+
+export type AgentPin = {
+  pane_id: string;
+  terminal_id: string;
+  workspace_id: string;
+  tab_id: string;
+  created_at: string;
+  context: AgentPinContext;
+};
+
+export type AgentPinsListResponse = {
+  session_key: string;
+  pins: AgentPin[];
+};
+
+export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
+
+export class AgentPinsApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "AgentPinsApiError";
+    this.status = status;
+  }
+}
+
+export function supportsAgentPins(capabilities: BridgeCapabilities | null | undefined) {
+  return capabilities?.agent_pins?.version === 1;
+}
+
+export async function fetchAgentPins(
+  httpUrl: BridgeHttpUrl,
+): Promise<AgentPinsListResponse> {
+  const response = await fetchWithTimeout(httpUrl("/api/agent-pins"));
+  return parseAgentPinsResponse(response);
+}
+
+export function pinAgent(httpUrl: BridgeHttpUrl, paneId: string) {
+  return sendAgentPinMutation(httpUrl, `/api/agent-pins/${encodeURIComponent(paneId)}/pin`);
+}
+
+export function unpinAgent(httpUrl: BridgeHttpUrl, paneId: string) {
+  return sendAgentPinMutation(httpUrl, `/api/agent-pins/${encodeURIComponent(paneId)}/unpin`);
+}
+
+export function agentPinKey(bridgeId: string, paneId: string) {
+  return `${bridgeId}:${paneId}`;
+}
+
+export function agentPinKeys(bridgeId: string, response: AgentPinsListResponse | null | undefined) {
+  return new Set((response?.pins ?? []).map((pin) => agentPinKey(bridgeId, pin.pane_id)));
+}
+
+async function sendAgentPinMutation(httpUrl: BridgeHttpUrl, path: string) {
+  const response = await fetchWithTimeout(httpUrl(path), { method: "POST" });
+  return parseAgentPinsResponse(response);
+}
+
+async function parseAgentPinsResponse(response: Response) {
+  if (!response.ok) {
+    throw await agentPinsApiError(response);
+  }
+  return (await response.json()) as AgentPinsListResponse;
+}
+
+async function agentPinsApiError(response: Response) {
+  try {
+    const parsed = (await response.json()) as { error?: unknown };
+    if (typeof parsed.error === "string" && parsed.error.trim()) {
+      return new AgentPinsApiError(parsed.error, response.status);
+    }
+  } catch {
+    // Fall through to the status-based error.
+  }
+  return new AgentPinsApiError(`agent pins failed: ${response.status}`, response.status);
+}

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -320,6 +320,7 @@ describe("capabilities", () => {
         bridge_version: "1.2.3",
         web_compat: 1,
         min_android_app_compat: 2,
+        agent_pins: { version: 1 },
         notes: { version: 1 },
       }),
     ).toEqual({
@@ -327,6 +328,7 @@ describe("capabilities", () => {
       bridge_version: "1.2.3",
       web_compat: 1,
       min_android_app_compat: 2,
+      agent_pins: { version: 1 },
       notes: { version: 1 },
     });
   });

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -36,6 +36,9 @@ export type BridgeMode = "same-origin" | "configured";
 
 export type BridgeCapabilities = {
   commands: string[];
+  agent_pins?: {
+    version: 1;
+  };
   notes?: {
     version: 1;
   };
@@ -1061,6 +1064,10 @@ export function parseCapabilities(value: unknown): BridgeCapabilities {
     web_compat: typeof value.web_compat === "number" ? value.web_compat : undefined,
     min_android_app_compat:
       typeof value.min_android_app_compat === "number" ? value.min_android_app_compat : undefined,
+    agent_pins:
+      isRecord(value.agent_pins) && value.agent_pins.version === 1
+        ? { version: 1 }
+        : undefined,
     notes:
       isRecord(value.notes) && value.notes.version === 1
         ? { version: 1 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2059,6 +2059,10 @@ button {
   background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
+.sec-add-pin svg {
+  transform: translateX(-1px);
+}
+
 .tab-head {
   display: inline-flex;
   align-items: center;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -940,6 +940,12 @@ button {
   white-space: nowrap;
 }
 
+.stage-pin-button[data-on="true"] {
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 11%, transparent);
+}
+
 .badge {
   display: inline-flex;
   align-items: center;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -700,6 +700,13 @@ button {
   color: var(--subtext1);
 }
 
+.agent-pin-indicator {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  color: var(--overlay1);
+}
+
 .agent-icon-claude {
   color: #d97757;
 }
@@ -2044,6 +2051,12 @@ button {
   border-color: var(--surface1);
   color: var(--text);
   background: var(--surface0);
+}
+
+.sec-add[data-on="true"] {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .tab-head {


### PR DESCRIPTION
## Summary
- add bridge-backed pane/agent pins with capability-gated REST endpoints and UI event refreshes
- sort pinned agents first within their current group and add a pinned-only sidebar toggle
- expose contextual pin/unpin menu labels for agent and pane rows, with a small pinned indicator
- keep pins stable across pane moves and add store diagnostics/bounding

## Verification
- npm run check
- $keel-local iterative-review with Claude: clean follow-up review
- built and deployed on srv/pc; APK built on pc and copied to downloads
