### PR TITLE
Add agent status transition sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added bridge-tracked agent status transition activity with an Agents view sort option for
   `Last status change`, using semantic status changes rather than terminal output activity.
+  [PR #23](https://github.com/kcosr/herdr-web/pull/23)
 - Added server-side agent pins with pinned-first agent ordering, a pinned-only sidebar toggle, and
   a selected-pane header toggle plus a small pinned indicator on pinned agent rows.
   [PR #22](https://github.com/kcosr/herdr-web/pull/22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 
 ### Changed
 
+- Extended the pinned-only sidebar toggle to the Tabs view so pinned panes can be found outside the
+  Agents view.
+
 ### Fixed
 
 - Added Mobile settings for an expanding terminal command input and Enter-as-newline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added bridge-tracked agent status transition activity with an Agents view sort option for
+  `Last status change`, using semantic status changes rather than terminal output activity.
 - Added server-side agent pins with pinned-first agent ordering, a pinned-only sidebar toggle, and
   a selected-pane header toggle plus a small pinned indicator on pinned agent rows.
   [PR #22](https://github.com/kcosr/herdr-web/pull/22)

--- a/bridge/src/agent_activity.rs
+++ b/bridge/src/agent_activity.rs
@@ -1,0 +1,522 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use herdr_compat::api::schema::{AgentStatus, PaneInfo};
+use serde::Serialize;
+
+const STARTUP_ACTIVITY_BASELINE_GRACE_MS: u128 = 1_000;
+
+pub struct AgentActivityManager {
+    session_key: String,
+    tracker: Mutex<AgentActivityTracker>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentActivityListResponse {
+    pub session_key: String,
+    pub records: Vec<AgentActivityRecordResponse>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentActivityRecordResponse {
+    pub pane_id: String,
+    pub terminal_id: String,
+    pub workspace_id: String,
+    pub tab_id: String,
+    pub agent_status: AgentStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_status_transition_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PaneKey {
+    pane_id: String,
+    terminal_id: String,
+}
+
+#[derive(Debug, Clone)]
+struct PaneIdentity {
+    key: PaneKey,
+}
+
+#[derive(Debug, Clone)]
+struct AgentActivityRecord {
+    pane_id: String,
+    terminal_id: String,
+    workspace_id: String,
+    tab_id: String,
+    agent_status: AgentStatus,
+    last_status_transition_at: Option<u128>,
+    last_seen_at: u128,
+}
+
+#[derive(Debug, Default)]
+struct AgentActivityTracker {
+    records: HashMap<PaneKey, AgentActivityRecord>,
+    pane_index: HashMap<String, PaneIdentity>,
+    startup_baseline_until_ms: Option<u128>,
+}
+
+impl AgentActivityManager {
+    pub fn new() -> Self {
+        Self {
+            session_key: session_key(),
+            tracker: Mutex::new(AgentActivityTracker::default()),
+        }
+    }
+
+    pub fn observe_snapshot(&self, panes: &[PaneInfo]) -> bool {
+        self.tracker
+            .lock()
+            .expect("agent activity tracker lock poisoned")
+            .observe_snapshot(panes, now_ms())
+    }
+
+    pub fn observe_status_event(&self, pane_id: &str, agent_status: AgentStatus) -> bool {
+        self.tracker
+            .lock()
+            .expect("agent activity tracker lock poisoned")
+            .observe_status_event(pane_id, agent_status, now_ms())
+    }
+
+    pub fn list(&self, panes: &[PaneInfo]) -> AgentActivityListResponse {
+        let records = self
+            .tracker
+            .lock()
+            .expect("agent activity tracker lock poisoned")
+            .list(panes);
+        AgentActivityListResponse {
+            session_key: self.session_key.clone(),
+            records,
+        }
+    }
+}
+
+impl AgentActivityTracker {
+    fn observe_snapshot(&mut self, panes: &[PaneInfo], now: u128) -> bool {
+        if panes.is_empty() {
+            return false;
+        }
+        if self.startup_baseline_until_ms.is_none() {
+            self.startup_baseline_until_ms = Some(now + STARTUP_ACTIVITY_BASELINE_GRACE_MS);
+        }
+        let in_startup_baseline = self
+            .startup_baseline_until_ms
+            .is_some_and(|baseline_until| now <= baseline_until);
+        self.pane_index = pane_index(panes);
+
+        let mut changed = false;
+        let mut open_keys = HashSet::new();
+        for pane in panes {
+            let key = pane_key(pane);
+            open_keys.insert(key.clone());
+            let already_tracked = self.records.contains_key(&key);
+            if !already_tracked && !is_agent_like(pane) {
+                continue;
+            }
+            match self.records.get_mut(&key) {
+                Some(record) => {
+                    record.workspace_id = pane.workspace_id.clone();
+                    record.tab_id = pane.tab_id.clone();
+                    record.last_seen_at = now;
+                    if record.agent_status != pane.agent_status {
+                        record.agent_status = pane.agent_status;
+                        record.last_status_transition_at = Some(now);
+                        changed = true;
+                    }
+                }
+                None => {
+                    let last_status_transition_at = (!in_startup_baseline
+                        && pane.agent_status != AgentStatus::Unknown)
+                        .then_some(now);
+                    if last_status_transition_at.is_some() {
+                        changed = true;
+                    }
+                    self.records.insert(
+                        key,
+                        AgentActivityRecord {
+                            pane_id: pane.pane_id.clone(),
+                            terminal_id: pane.terminal_id.clone(),
+                            workspace_id: pane.workspace_id.clone(),
+                            tab_id: pane.tab_id.clone(),
+                            agent_status: pane.agent_status,
+                            last_status_transition_at,
+                            last_seen_at: now,
+                        },
+                    );
+                }
+            }
+        }
+
+        self.records.retain(|_, record| {
+            let keep = open_keys.contains(&PaneKey {
+                pane_id: record.pane_id.clone(),
+                terminal_id: record.terminal_id.clone(),
+            });
+            if !keep && record.last_status_transition_at.is_some() {
+                changed = true;
+            }
+            keep
+        });
+        changed
+    }
+
+    fn observe_status_event(
+        &mut self,
+        pane_id: &str,
+        agent_status: AgentStatus,
+        now: u128,
+    ) -> bool {
+        let Some(identity) = self.pane_index.get(pane_id).cloned() else {
+            return false;
+        };
+        match self.records.get_mut(&identity.key) {
+            Some(record) => {
+                record.last_seen_at = now;
+                if record.agent_status == agent_status {
+                    return false;
+                }
+                record.agent_status = agent_status;
+                record.last_status_transition_at = Some(now);
+                true
+            }
+            None => {
+                if agent_status == AgentStatus::Unknown {
+                    return false;
+                }
+                let key = identity.key;
+                let terminal_id = key.terminal_id.clone();
+                self.records.insert(
+                    key,
+                    AgentActivityRecord {
+                        pane_id: pane_id.to_string(),
+                        terminal_id,
+                        workspace_id: String::new(),
+                        tab_id: String::new(),
+                        agent_status,
+                        last_status_transition_at: Some(now),
+                        last_seen_at: now,
+                    },
+                );
+                true
+            }
+        }
+    }
+
+    fn list(&self, panes: &[PaneInfo]) -> Vec<AgentActivityRecordResponse> {
+        let mut records = panes
+            .iter()
+            .filter_map(|pane| {
+                let record = self.records.get(&pane_key(pane))?;
+                Some(AgentActivityRecordResponse {
+                    pane_id: pane.pane_id.clone(),
+                    terminal_id: pane.terminal_id.clone(),
+                    workspace_id: pane.workspace_id.clone(),
+                    tab_id: pane.tab_id.clone(),
+                    agent_status: record.agent_status,
+                    last_status_transition_at: record.last_status_transition_at.map(ms_string),
+                })
+            })
+            .collect::<Vec<_>>();
+        records.sort_by(|a, b| {
+            a.pane_id
+                .cmp(&b.pane_id)
+                .then_with(|| a.terminal_id.cmp(&b.terminal_id))
+        });
+        records
+    }
+}
+
+fn pane_index(panes: &[PaneInfo]) -> HashMap<String, PaneIdentity> {
+    panes
+        .iter()
+        .map(|pane| {
+            (
+                pane.pane_id.clone(),
+                PaneIdentity {
+                    key: pane_key(pane),
+                },
+            )
+        })
+        .collect()
+}
+
+fn pane_key(pane: &PaneInfo) -> PaneKey {
+    PaneKey {
+        pane_id: pane.pane_id.clone(),
+        terminal_id: pane.terminal_id.clone(),
+    }
+}
+
+fn is_agent_like(pane: &PaneInfo) -> bool {
+    pane.agent.is_some()
+        || pane.display_agent.is_some()
+        || pane.custom_status.is_some()
+        || pane.title.is_some()
+        || pane.agent_status != AgentStatus::Unknown
+}
+
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn ms_string(value: u128) -> String {
+    value.to_string()
+}
+
+fn session_key() -> String {
+    if let Some(name) = crate::session::active_name() {
+        return format!("session:{name}");
+    }
+    if let Ok(path) = std::env::var(herdr_compat::api::SOCKET_PATH_ENV_VAR) {
+        if !path.is_empty() && !crate::session::explicit_session_requested() {
+            let canonical = fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(path));
+            return format!("socket:{:016x}", stable_path_hash(&canonical));
+        }
+    }
+    "default".to_string()
+}
+
+fn stable_path_hash(path: &std::path::Path) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    path.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn empty_first_snapshot_does_not_establish_baseline() {
+        let mut tracker = AgentActivityTracker::default();
+
+        assert!(!tracker.observe_snapshot(&[], 100));
+        assert!(!tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Working)], 200));
+
+        let records = tracker.list(&[agent_pane("pane-1", AgentStatus::Working)]);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].last_status_transition_at, None);
+    }
+
+    #[test]
+    fn new_active_pane_after_baseline_gets_transition_timestamp() {
+        let mut tracker = AgentActivityTracker::default();
+        assert!(!tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Idle)], 100));
+
+        assert!(tracker.observe_snapshot(
+            &[
+                agent_pane("pane-1", AgentStatus::Idle),
+                agent_pane("pane-2", AgentStatus::Working),
+            ],
+            1_200,
+        ));
+
+        let records = tracker.list(&[
+            agent_pane("pane-1", AgentStatus::Idle),
+            agent_pane("pane-2", AgentStatus::Working),
+        ]);
+        let pane_two = records
+            .iter()
+            .find(|record| record.pane_id == "pane-2")
+            .unwrap();
+        assert_eq!(pane_two.last_status_transition_at.as_deref(), Some("1200"));
+    }
+
+    #[test]
+    fn panes_observed_during_startup_grace_seed_without_timestamp() {
+        let mut tracker = AgentActivityTracker::default();
+        assert!(!tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Idle)], 100));
+
+        assert!(!tracker.observe_snapshot(
+            &[
+                agent_pane("pane-1", AgentStatus::Idle),
+                agent_pane("pane-2", AgentStatus::Working),
+            ],
+            500,
+        ));
+
+        let records = tracker.list(&[
+            agent_pane("pane-1", AgentStatus::Idle),
+            agent_pane("pane-2", AgentStatus::Working),
+        ]);
+        assert!(records
+            .iter()
+            .all(|record| record.last_status_transition_at.is_none()));
+    }
+
+    #[test]
+    fn status_transition_updates_timestamp_once() {
+        let mut tracker = AgentActivityTracker::default();
+        tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Idle)], 100);
+
+        assert!(tracker.observe_status_event("pane-1", AgentStatus::Working, 200));
+        assert!(!tracker.observe_status_event("pane-1", AgentStatus::Working, 300));
+
+        let records = tracker.list(&[agent_pane("pane-1", AgentStatus::Working)]);
+        assert_eq!(records[0].last_status_transition_at.as_deref(), Some("200"));
+    }
+
+    #[test]
+    fn snapshot_reconciliation_detects_missed_status_transition() {
+        let mut tracker = AgentActivityTracker::default();
+        tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Idle)], 100);
+
+        assert!(tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Blocked)], 200));
+
+        let records = tracker.list(&[agent_pane("pane-1", AgentStatus::Blocked)]);
+        assert_eq!(records[0].last_status_transition_at.as_deref(), Some("200"));
+    }
+
+    #[test]
+    fn ordinary_unknown_panes_are_not_tracked() {
+        let mut tracker = AgentActivityTracker::default();
+
+        assert!(!tracker.observe_snapshot(&[ordinary_pane("pane-1")], 100));
+
+        assert!(tracker.list(&[ordinary_pane("pane-1")]).is_empty());
+    }
+
+    #[test]
+    fn tracked_pane_transitioning_to_unknown_remains_visible() {
+        let mut tracker = AgentActivityTracker::default();
+        tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Working)], 100);
+
+        assert!(tracker.observe_status_event("pane-1", AgentStatus::Unknown, 1_200));
+
+        let mut pane = ordinary_pane("pane-1");
+        pane.agent_status = AgentStatus::Unknown;
+        let records = tracker.list(&[pane]);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].agent_status, AgentStatus::Unknown);
+        assert_eq!(
+            records[0].last_status_transition_at.as_deref(),
+            Some("1200")
+        );
+    }
+
+    #[test]
+    fn pane_moves_update_location_without_transition() {
+        let mut tracker = AgentActivityTracker::default();
+        tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Idle)], 100);
+        let mut moved = agent_pane("pane-1", AgentStatus::Idle);
+        moved.workspace_id = "workspace-b".to_string();
+        moved.tab_id = "tab-b".to_string();
+
+        assert!(!tracker.observe_snapshot(&[moved.clone()], 200));
+
+        let records = tracker.list(&[moved]);
+        assert_eq!(records[0].workspace_id, "workspace-b");
+        assert_eq!(records[0].tab_id, "tab-b");
+        assert_eq!(records[0].last_status_transition_at, None);
+    }
+
+    #[test]
+    fn transient_empty_snapshot_preserves_records() {
+        let mut tracker = AgentActivityTracker::default();
+        tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Idle)], 100);
+        assert!(tracker.observe_status_event("pane-1", AgentStatus::Working, 1_200));
+
+        assert!(!tracker.observe_snapshot(&[], 1_300));
+        assert!(!tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Working)], 1_400));
+
+        let records = tracker.list(&[agent_pane("pane-1", AgentStatus::Working)]);
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].last_status_transition_at.as_deref(),
+            Some("1200")
+        );
+    }
+
+    #[test]
+    fn reused_pane_id_does_not_inherit_terminal_activity() {
+        let mut tracker = AgentActivityTracker::default();
+        tracker.observe_snapshot(&[agent_pane("pane-1", AgentStatus::Idle)], 100);
+        tracker.observe_status_event("pane-1", AgentStatus::Working, 200);
+        let mut replacement = agent_pane("pane-1", AgentStatus::Working);
+        replacement.terminal_id = "terminal-new".to_string();
+
+        assert!(tracker.observe_snapshot(&[replacement.clone()], 1_500));
+
+        let records = tracker.list(&[replacement]);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].terminal_id, "terminal-new");
+        assert_eq!(
+            records[0].last_status_transition_at.as_deref(),
+            Some("1500")
+        );
+    }
+
+    #[test]
+    fn many_open_panes_are_not_rotated_or_restamped() {
+        let mut tracker = AgentActivityTracker::default();
+        let panes = (0..150)
+            .map(|index| agent_pane(&format!("pane-{index:03}"), AgentStatus::Working))
+            .collect::<Vec<_>>();
+
+        assert!(!tracker.observe_snapshot(&panes, 100));
+        assert!(!tracker.observe_snapshot(&panes, 1_500));
+
+        let records = tracker.list(&panes);
+        assert_eq!(records.len(), 150);
+        assert!(records
+            .iter()
+            .all(|record| record.last_status_transition_at.is_none()));
+    }
+
+    fn agent_pane(pane_id: &str, status: AgentStatus) -> PaneInfo {
+        let mut pane = pane_in_location(
+            pane_id,
+            &format!("terminal-{pane_id}"),
+            "workspace-a",
+            "tab-a",
+        );
+        pane.agent = Some("codex".to_string());
+        pane.display_agent = Some("Codex".to_string());
+        pane.agent_status = status;
+        pane
+    }
+
+    fn ordinary_pane(pane_id: &str) -> PaneInfo {
+        pane_in_location(
+            pane_id,
+            &format!("terminal-{pane_id}"),
+            "workspace-a",
+            "tab-a",
+        )
+    }
+
+    fn pane_in_location(
+        pane_id: &str,
+        terminal_id: &str,
+        workspace_id: &str,
+        tab_id: &str,
+    ) -> PaneInfo {
+        PaneInfo {
+            pane_id: pane_id.to_string(),
+            terminal_id: terminal_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            tab_id: tab_id.to_string(),
+            focused: false,
+            cwd: None,
+            foreground_cwd: None,
+            label: None,
+            agent: None,
+            agent_session: None,
+            title: None,
+            display_agent: None,
+            agent_status: AgentStatus::Unknown,
+            custom_status: None,
+            state_labels: HashMap::new(),
+            revision: 1,
+        }
+    }
+}

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -1,3 +1,4 @@
+mod agent_activity;
 mod agent_pins;
 mod notes;
 mod session;

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -43,6 +43,7 @@ use herdr_compat::protocol::{
     PROTOCOL_VERSION,
 };
 
+use crate::agent_activity::{AgentActivityListResponse, AgentActivityManager};
 use crate::agent_pins::{AgentPinsError, AgentPinsListResponse, AgentPinsManager};
 use crate::notes::{
     AttachNoteRequest, CreateNoteRequest, NoteResponse, NotesError, NotesListQuery,
@@ -87,6 +88,7 @@ struct BridgeState {
     request_policy: RequestPolicy,
     terminal_sessions: Arc<Mutex<HashMap<String, SharedTerminalSession>>>,
     selected_pane_id: Arc<Mutex<Option<String>>>,
+    agent_activity: Arc<AgentActivityManager>,
     agent_pins: Arc<AgentPinsManager>,
     notes: Arc<NotesManager>,
     ui_event_tx: tokio::sync::broadcast::Sender<String>,
@@ -129,8 +131,14 @@ struct SnapshotTabInfo {
 #[derive(Debug, Serialize)]
 struct Capabilities {
     commands: &'static [&'static str],
+    agent_activity: AgentActivityCapability,
     agent_pins: AgentPinsCapability,
     notes: NotesCapability,
+}
+
+#[derive(Debug, Serialize)]
+struct AgentActivityCapability {
+    version: u32,
 }
 
 #[derive(Debug, Serialize)]
@@ -795,6 +803,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         );
     }
     ensure_upload_dir(&options.upload_dir)?;
+    let agent_activity = Arc::new(AgentActivityManager::new());
     let agent_pins = Arc::new(AgentPinsManager::new()?);
     let notes = Arc::new(NotesManager::new()?);
     let request_policy = RequestPolicy {
@@ -816,6 +825,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         request_policy: request_policy.clone(),
         terminal_sessions: Arc::new(Mutex::new(HashMap::new())),
         selected_pane_id: Arc::new(Mutex::new(None)),
+        agent_activity,
         agent_pins,
         notes,
         ui_event_tx: tokio::sync::broadcast::channel(256).0,
@@ -823,6 +833,10 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         upload_dir: options.upload_dir.clone(),
     };
     spawn_agent_activity_watcher(state.clone());
+    let agent_activity_routes = Router::new().route(
+        "/api/agent-activity",
+        get(agent_activity_list_handler).options(preflight_handler),
+    );
     let agent_pins_routes = Router::new()
         .route(
             "/api/agent-pins",
@@ -869,6 +883,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         )
         .layer(DefaultBodyLimit::max(MAX_NOTES_REQUEST_BYTES));
     let app = Router::new()
+        .merge(agent_activity_routes)
         .merge(agent_pins_routes)
         .merge(notes_routes)
         .route(
@@ -1833,6 +1848,7 @@ async fn snapshot_handler(
         }
     };
     let panes = current_panes(&state.api)?;
+    observe_agent_activity_snapshot(&state, &panes);
     let notes = state.notes.clone();
     let note_panes = panes.clone();
     match tokio::task::spawn_blocking(move || notes.observe_panes(&note_panes))
@@ -1888,9 +1904,20 @@ async fn capabilities_handler(
     ensure_allowed_request(&headers, &state.request_policy)?;
     Ok(Json(Capabilities {
         commands: ALLOWED_COMMANDS,
+        agent_activity: AgentActivityCapability { version: 1 },
         agent_pins: AgentPinsCapability { version: 1 },
         notes: NotesCapability { version: 1 },
     }))
+}
+
+async fn agent_activity_list_handler(
+    State(state): State<BridgeState>,
+    headers: HeaderMap,
+) -> Result<Json<AgentActivityListResponse>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let panes = current_panes(&state.api)?;
+    observe_agent_activity_snapshot(&state, &panes);
+    Ok(Json(state.agent_activity.list(&panes)))
 }
 
 async fn agent_pins_list_handler(
@@ -2095,6 +2122,13 @@ fn broadcast_agent_pins_changed(state: &BridgeState, pane_id: Option<&str>) {
     let _ = state.ui_event_tx.send(payload.to_string());
 }
 
+fn broadcast_agent_activity_changed(state: &BridgeState) {
+    let payload = serde_json::json!({
+        "type": "herdr_web.agent_activity_changed",
+    });
+    let _ = state.ui_event_tx.send(payload.to_string());
+}
+
 fn broadcast_notes_changed(state: &BridgeState, note_id: Option<&str>, revision: Option<u64>) {
     let mut payload = serde_json::json!({
         "type": "herdr_web.notes_changed",
@@ -2106,6 +2140,12 @@ fn broadcast_notes_changed(state: &BridgeState, note_id: Option<&str>, revision:
         payload["revision"] = serde_json::json!(revision);
     }
     let _ = state.ui_event_tx.send(payload.to_string());
+}
+
+fn observe_agent_activity_snapshot(state: &BridgeState, panes: &[PaneInfo]) {
+    if state.agent_activity.observe_snapshot(panes) {
+        broadcast_agent_activity_changed(state);
+    }
 }
 
 fn current_panes(api: &ApiClient) -> Result<Vec<PaneInfo>, BridgeError> {
@@ -2718,6 +2758,7 @@ fn run_agent_activity_subscription(
 ) -> Result<(), BridgeError> {
     drain_resubscribe_signals(resubscribe_rx);
     let panes = current_panes(&state.api)?;
+    observe_agent_activity_snapshot(state, &panes);
     let pane_ids = sorted_pane_ids(&panes);
     if pane_ids.is_empty() {
         wait_for_resubscribe_signal(resubscribe_rx)?;
@@ -2741,7 +2782,9 @@ fn run_agent_activity_subscription(
 
     loop {
         if drain_resubscribe_signals(resubscribe_rx) {
-            if !activity_resubscribe_needed(&pane_ids, &current_panes(&state.api)?) {
+            let next_panes = current_panes(&state.api)?;
+            observe_agent_activity_snapshot(state, &next_panes);
+            if !activity_resubscribe_needed(&pane_ids, &next_panes) {
                 continue;
             }
             return Ok(());
@@ -2749,6 +2792,19 @@ fn run_agent_activity_subscription(
         match stream.next_value() {
             Ok(Some(value)) => {
                 if let Some(message) = activity_message_from_subscription_value(value) {
+                    if let ActivityMessage::PaneAgentStatusChanged {
+                        pane_id,
+                        agent_status,
+                        ..
+                    } = &message
+                    {
+                        if state
+                            .agent_activity
+                            .observe_status_event(pane_id, *agent_status)
+                        {
+                            broadcast_agent_activity_changed(state);
+                        }
+                    }
                     let _ = state.activity_tx.send(message);
                 }
             }

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -309,6 +309,40 @@ describe("App multi-bridge helpers", () => {
     ).toEqual(["bridge-a:tab-a", "bridge-b:tab-b"]);
   });
 
+  it("filters tab entries to pinned panes", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1)],
+      [
+        pane("pane-a", "workspace-a", "tab-a"),
+        pane("pane-b", "workspace-a", "tab-a"),
+        pane("pane-c", "workspace-a", "tab-b"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+
+    expect(
+      buildVisibleTabEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "none",
+        new Set(["bridge-a:pane-b"]),
+        true,
+      ).map((entry) => ({
+        tab: entry.tab.tab_id,
+        panes: entry.panes.map((item) => item.pane_id),
+      })),
+    ).toEqual([{ tab: "tab-a", panes: ["pane-b"] }]);
+  });
+
   it("navigates visible agent entries with fallback and wrap-around", () => {
     const bridgeViews = [
       bridgeView(

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -12,11 +12,13 @@ import {
   resolveInitialSelectedBridgeId,
   shouldBlockDirtyNoteAutosave,
   shouldCollapseHostScope,
+  shouldShowLastStatusChangeSort,
   sortScopedAgentPanes,
   stableBridgeRefreshOffsetMs,
 } from "./App";
 import type { BridgeConnectionView } from "./App";
 import type { BridgeRuntime } from "./bridge";
+import { agentActivityKey } from "./agentActivity";
 import {
   currentConnectionSnapshot,
   isConnectionResultCurrent,
@@ -233,6 +235,150 @@ describe("App multi-bridge helpers", () => {
         new Set(["bridge-a:pane-b"]),
       ).map((item) => item.pane.pane_id),
     ).toEqual(["pane-b", "pane-a"]);
+  });
+
+  it("sorts agents by last status change", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1)],
+      [
+        pane("pane-a", "workspace-a", "tab-a", "idle"),
+        pane("pane-b", "workspace-a", "tab-a", "idle"),
+        pane("pane-c", "workspace-a", "tab-a", "idle"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+    const activity = new Map([
+      [agentActivityKey("bridge-a", "pane-a", "pane-a-terminal"), 100],
+      [agentActivityKey("bridge-a", "pane-b", "pane-b-terminal"), 300],
+    ]);
+
+    expect(
+      buildVisibleAgentPaneEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "none",
+        "lastStatusChange",
+        new Set(),
+        false,
+        activity,
+      ).map((item) => item.pane.pane_id),
+    ).toEqual(["pane-b", "pane-a", "pane-c"]);
+  });
+
+  it("keeps pinned agents before last-status-change sorting", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1)],
+      [
+        pane("pane-a", "workspace-a", "tab-a", "idle"),
+        pane("pane-b", "workspace-a", "tab-a", "idle"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+    const activity = new Map([
+      [agentActivityKey("bridge-a", "pane-a", "pane-a-terminal"), 100],
+      [agentActivityKey("bridge-a", "pane-b", "pane-b-terminal"), 300],
+    ]);
+
+    expect(
+      buildVisibleAgentPaneEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "none",
+        "lastStatusChange",
+        new Set(["bridge-a:pane-a"]),
+        false,
+        activity,
+      ).map((item) => item.pane.pane_id),
+    ).toEqual(["pane-a", "pane-b"]);
+  });
+
+  it("does not reorder workspace groups for last status change", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1), workspace("workspace-b", 2)],
+      [
+        pane("pane-a", "workspace-a", "tab-a", "idle"),
+        pane("pane-b", "workspace-b", "tab-b", "idle"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+    const activity = new Map([
+      [agentActivityKey("bridge-a", "pane-a", "pane-a-terminal"), 100],
+      [agentActivityKey("bridge-a", "pane-b", "pane-b-terminal"), 500],
+    ]);
+
+    expect(
+      buildVisibleAgentPaneEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "workspace",
+        "lastStatusChange",
+        new Set(),
+        false,
+        activity,
+      ).map((item) => `${item.workspace?.workspace_id}:${item.pane.pane_id}`),
+    ).toEqual(["workspace-a:pane-a", "workspace-b:pane-b"]);
+  });
+
+  it("gates the last-status sort option on capability or persisted selection", () => {
+    expect(shouldShowLastStatusChangeSort(true, "attention")).toBe(true);
+    expect(shouldShowLastStatusChangeSort(false, "attention")).toBe(false);
+    expect(shouldShowLastStatusChangeSort(false, "lastStatusChange")).toBe(true);
+  });
+
+  it("keeps existing sort row order stable across agent grouping modes and host scopes", () => {
+    const bridgeViews = agentParityBridgeViews();
+
+    for (const hostScope of ["selected", "all"] as const) {
+      const scopedWorkspaces = buildVisibleScopedWorkspaces(
+        bridgeViews,
+        "bridge-a",
+        hostScope,
+        "all",
+        null,
+        {},
+      );
+      for (const sort of ["attention", "status", "workspace"] as const) {
+        const expected = visibleAgentPaneOrder(
+          scopedWorkspaces,
+          bridgeViews,
+          hostScope,
+          "none",
+          sort,
+        );
+        for (const group of ["none", "host", "workspace", "hostWorkspace"] as const) {
+          expect(
+            visibleAgentPaneOrder(scopedWorkspaces, bridgeViews, hostScope, group, sort),
+          ).toEqual(expected);
+        }
+      }
+    }
   });
 
   it("filters agents to pinned rows without reordering groups", () => {
@@ -700,6 +846,40 @@ function bridgeView(bridgeId: string, snapshot: Snapshot): BridgeConnectionView 
     snapshot,
     loadState: "ready",
   };
+}
+
+function agentParityBridgeViews(): BridgeConnectionView[] {
+  return [
+    bridgeView(
+      "bridge-a",
+      multiPaneSnapshot(
+        [workspace("workspace-a", 1), workspace("workspace-b", 2)],
+        [
+          pane("pane-a", "workspace-a", "tab-a", "blocked"),
+          pane("pane-b", "workspace-b", "tab-b", "working"),
+        ],
+      ),
+    ),
+    bridgeView(
+      "bridge-b",
+      multiPaneSnapshot(
+        [workspace("workspace-a", 1)],
+        [pane("pane-c", "workspace-a", "tab-c", "idle")],
+      ),
+    ),
+  ];
+}
+
+function visibleAgentPaneOrder(
+  scopedWorkspaces: ReturnType<typeof buildVisibleScopedWorkspaces>,
+  bridgeViews: BridgeConnectionView[],
+  hostScope: "selected" | "all",
+  group: "none" | "host" | "workspace" | "hostWorkspace",
+  sort: "attention" | "status" | "workspace",
+) {
+  return buildVisibleAgentPaneEntries(scopedWorkspaces, bridgeViews, hostScope, group, sort).map(
+    (item) => `${item.bridgeId}:${item.pane.pane_id}`,
+  );
 }
 
 function bridgeRuntime(bridgeId: string): BridgeRuntime {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,6 +39,13 @@ import { Capacitor } from "@capacitor/core";
 import { Preferences } from "@capacitor/preferences";
 import { AgentIcon, agentIconKind } from "./AgentIcon";
 import {
+  agentActivityKey,
+  agentActivityTimestamps,
+  fetchAgentActivity,
+  supportsAgentActivity,
+} from "./agentActivity";
+import type { AgentActivityListResponse } from "./agentActivity";
+import {
   agentPinKey,
   agentPinKeys,
   fetchAgentPins,
@@ -153,7 +160,7 @@ type LoadState = "loading" | "ready" | "error";
 type Scope = "space" | "all";
 type HostScope = "selected" | "all";
 type SidebarView = "agents" | "tabs" | "notes";
-type AgentSort = "attention" | "status" | "workspace";
+type AgentSort = "attention" | "status" | "workspace" | "lastStatusChange";
 type AgentGroup = "none" | "host" | "workspace" | "hostWorkspace";
 type MenuKind = "space" | "tab" | "pane";
 type ScopedPaneRef = {
@@ -194,6 +201,12 @@ type BridgeAgentPinsState = {
   loadState: LoadState;
   error: string | null;
 };
+type BridgeAgentActivityState = {
+  connectionKey: string;
+  response: AgentActivityListResponse | null;
+  loadState: LoadState;
+  error: string | null;
+};
 export type BridgeConnectionRef = {
   connectionKey: string;
   snapshot: Snapshot | null;
@@ -212,6 +225,7 @@ export type ScopedAgentPane = {
   tabNumber?: number;
   tabLabel?: string;
   pinned?: boolean;
+  lastStatusTransitionAt?: number;
 };
 type ScopedWorkspace = {
   bridgeId: BridgeId;
@@ -427,7 +441,8 @@ function parseDisplayPrefsValue(
     agentSort:
       parsed.agentSort === "attention" ||
       parsed.agentSort === "status" ||
-      parsed.agentSort === "workspace"
+      parsed.agentSort === "workspace" ||
+      parsed.agentSort === "lastStatusChange"
         ? parsed.agentSort
         : fallback.agentSort,
     agentGroup:
@@ -541,7 +556,8 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
       agentSort:
         parsed.agentSort === "attention" ||
         parsed.agentSort === "status" ||
-        parsed.agentSort === "workspace"
+        parsed.agentSort === "workspace" ||
+        parsed.agentSort === "lastStatusChange"
           ? parsed.agentSort
           : fallback.agentSort,
       agentGroup:
@@ -742,6 +758,8 @@ export function App() {
   const legacySelectionPrefs = useMemo(readLegacyDisplaySelectionPrefs, []);
   const [displayPrefsLoaded, setDisplayPrefsLoaded] = useState(() => !isNativeApp());
   const [connectionStates, setConnectionStates] = useState<Record<string, BridgeConnectionState>>({});
+  const [agentActivityStates, setAgentActivityStates] =
+    useState<Record<string, BridgeAgentActivityState>>({});
   const [agentPinsStates, setAgentPinsStates] = useState<Record<string, BridgeAgentPinsState>>({});
   const [notesStates, setNotesStates] = useState<Record<string, BridgeNotesState>>({});
   const [selectedBridgeId, setSelectedBridgeId] = useState<BridgeId | null>(
@@ -959,6 +977,10 @@ export function App() {
   const pinnedAgentKeys = useMemo(
     () => buildAgentPinKeySet(bridgeViews, agentPinsStates),
     [agentPinsStates, bridgeViews],
+  );
+  const agentActivityTransitions = useMemo(
+    () => buildAgentActivityTransitionMap(bridgeViews, agentActivityStates),
+    [agentActivityStates, bridgeViews],
   );
   const effectiveAgentPinnedOnly =
     visibleHostBridgeViews(bridgeViews, selectedBridgeId, hostScope).some((view) =>
@@ -1447,6 +1469,18 @@ export function App() {
     setConnectionStates((current) => {
       let changed = false;
       const next: Record<string, BridgeConnectionState> = {};
+      for (const [bridgeId, state] of Object.entries(current)) {
+        if (activeBridgeIds.has(bridgeId)) {
+          next[bridgeId] = state;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+    setAgentActivityStates((current) => {
+      let changed = false;
+      const next: Record<string, BridgeAgentActivityState> = {};
       for (const [bridgeId, state] of Object.entries(current)) {
         if (activeBridgeIds.has(bridgeId)) {
           next[bridgeId] = state;
@@ -2221,6 +2255,7 @@ export function App() {
           agentSort,
           pinnedAgentKeys,
           effectiveAgentPinnedOnly,
+          agentActivityTransitions,
         );
         if (agentEntries.length === 0) {
           return;
@@ -2289,6 +2324,7 @@ export function App() {
   }, [
     activeSpace,
     activeWorkspacesByBridgeId,
+    agentActivityTransitions,
     effectiveAgentPinnedOnly,
     agentGroup,
     agentSort,
@@ -2373,6 +2409,97 @@ export function App() {
       return null;
     }
   }
+
+  async function refreshBridgeAgentActivity(runtime: BridgeRuntime, setLoading: boolean) {
+    ensureBridgeConnectionRef(connectionRefs, runtime);
+    const requestConnectionKey = runtime.connectionKey;
+    const isCurrentConnection = () =>
+      isConnectionResultCurrent(
+        connectionRefs.current[runtime.id]?.connectionKey ?? "",
+        requestConnectionKey,
+      );
+    if (
+      !runtime.canConnect ||
+      runtime.capabilityState !== "ready" ||
+      !supportsAgentActivity(runtime.capabilities)
+    ) {
+      setAgentActivityStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response: null,
+          loadState: "ready",
+          error: null,
+        },
+      }));
+      return null;
+    }
+    if (setLoading) {
+      setAgentActivityStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response:
+            current[runtime.id]?.connectionKey === requestConnectionKey
+              ? current[runtime.id]?.response ?? null
+              : null,
+          loadState: "loading",
+          error: null,
+        },
+      }));
+    }
+    try {
+      const response = await fetchAgentActivity(runtime.httpUrl);
+      setAgentActivityStates((current) => {
+        if (!isCurrentConnection()) {
+          return current;
+        }
+        return {
+          ...current,
+          [runtime.id]: {
+            connectionKey: requestConnectionKey,
+            response,
+            loadState: "ready",
+            error: null,
+          },
+        };
+      });
+      return response;
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : "Agent activity unavailable";
+      if (!isCurrentConnection()) {
+        return null;
+      }
+      setAgentActivityStates((current) => ({
+        ...current,
+        [runtime.id]: {
+          connectionKey: requestConnectionKey,
+          response:
+            current[runtime.id]?.connectionKey === requestConnectionKey
+              ? current[runtime.id]?.response ?? null
+              : null,
+          loadState: "error",
+          error: message,
+        },
+      }));
+      return null;
+    }
+  }
+
+  const refreshAgentActivityForBridge = (bridgeId: BridgeId) => {
+    const runtime = bridge.getRuntime(bridgeId);
+    if (runtime) {
+      void refreshBridgeAgentActivity(runtime, false);
+    }
+  };
+
+  useEffect(() => {
+    for (const runtime of bridge.enabledRuntimes) {
+      if (runtime.capabilityState === "ready" && supportsAgentActivity(runtime.capabilities)) {
+        void refreshBridgeAgentActivity(runtime, true);
+      }
+    }
+  }, [bridge.enabledRuntimes]);
 
   async function refreshBridgeAgentPins(runtime: BridgeRuntime, setLoading: boolean) {
     ensureBridgeConnectionRef(connectionRefs, runtime);
@@ -2848,6 +2975,7 @@ export function App() {
           connectionRefs={connectionRefs}
           setConnectionStates={setConnectionStates}
           onPaneSelection={rememberPaneSelection}
+          onAgentActivityChanged={refreshAgentActivityForBridge}
           onAgentPinsChanged={refreshAgentPinsForBridge}
           onNotesChanged={refreshNotesForBridge}
         />
@@ -2870,6 +2998,7 @@ export function App() {
           notesStates={notesStates}
           visibleNotes={visibleNotes}
           selectedNote={selectedScopedNote}
+          agentActivityTransitions={agentActivityTransitions}
           pinnedAgentKeys={pinnedAgentKeys}
           agentPinnedOnly={agentPinnedOnly}
           agentSort={agentSort}
@@ -3415,6 +3544,7 @@ export function BridgeConnectionController({
   connectionRefs,
   setConnectionStates,
   onPaneSelection,
+  onAgentActivityChanged,
   onAgentPinsChanged,
   onNotesChanged,
 }: {
@@ -3422,11 +3552,13 @@ export function BridgeConnectionController({
   connectionRefs: MutableRefObject<Record<string, BridgeConnectionRef>>;
   setConnectionStates: Dispatch<SetStateAction<Record<string, BridgeConnectionState>>>;
   onPaneSelection: (bridgeId: BridgeId, paneId: string, workspaceId?: string) => void;
+  onAgentActivityChanged: (bridgeId: BridgeId) => void;
   onAgentPinsChanged: (bridgeId: BridgeId) => void;
   onNotesChanged: (bridgeId: BridgeId) => void;
 }) {
   const httpUrlRef = useRef(runtime.httpUrl);
   const wsUrlRef = useRef(runtime.wsUrl);
+  const onAgentActivityChangedRef = useRef(onAgentActivityChanged);
   const onAgentPinsChangedRef = useRef(onAgentPinsChanged);
   const onNotesChangedRef = useRef(onNotesChanged);
   const refreshOffsetRef = useRef(stableBridgeRefreshOffsetMs(runtime.id));
@@ -3437,9 +3569,10 @@ export function BridgeConnectionController({
   }, [runtime.httpUrl, runtime.wsUrl]);
 
   useEffect(() => {
+    onAgentActivityChangedRef.current = onAgentActivityChanged;
     onAgentPinsChangedRef.current = onAgentPinsChanged;
     onNotesChangedRef.current = onNotesChanged;
-  }, [onAgentPinsChanged, onNotesChanged]);
+  }, [onAgentActivityChanged, onAgentPinsChanged, onNotesChanged]);
 
   useEffect(() => {
     let disposed = false;
@@ -3579,29 +3712,38 @@ export function BridgeConnectionController({
       },
       { onOpen: refresh },
     );
-    const uiEvents = openEventsSocket(wsUrlRef.current, "/ws/ui-events", (event) => {
-      if (!isCurrentConnection()) {
-        return;
-      }
-      const paneId = selectionPaneId(event);
-      if (paneId) {
-        const pane = connectionRefs.current[runtime.id]?.snapshot?.panes.find(
-          (item) => item.pane_id === paneId,
-        );
-        onPaneSelection(runtime.id, paneId, pane?.workspace_id);
+    const uiEvents = openEventsSocket(
+      wsUrlRef.current,
+      "/ws/ui-events",
+      (event) => {
+        if (!isCurrentConnection()) {
+          return;
+        }
+        const paneId = selectionPaneId(event);
+        if (paneId) {
+          const pane = connectionRefs.current[runtime.id]?.snapshot?.panes.find(
+            (item) => item.pane_id === paneId,
+          );
+          onPaneSelection(runtime.id, paneId, pane?.workspace_id);
+          refresh();
+          return;
+        }
+        if (isNotesChangedEvent(event)) {
+          onNotesChangedRef.current(runtime.id);
+          return;
+        }
+        if (isAgentActivityChangedEvent(event)) {
+          onAgentActivityChangedRef.current(runtime.id);
+          return;
+        }
+        if (isAgentPinsChangedEvent(event)) {
+          onAgentPinsChangedRef.current(runtime.id);
+          return;
+        }
         refresh();
-        return;
-      }
-      if (isNotesChangedEvent(event)) {
-        onNotesChangedRef.current(runtime.id);
-        return;
-      }
-      if (isAgentPinsChangedEvent(event)) {
-        onAgentPinsChangedRef.current(runtime.id);
-        return;
-      }
-      refresh();
-    });
+      },
+      { onOpen: () => onAgentActivityChangedRef.current(runtime.id) },
+    );
 
     return () => {
       disposed = true;
@@ -3693,6 +3835,7 @@ export function activeWorkspaceForBridgeView(
 }
 
 const EMPTY_AGENT_PIN_KEYS = new Set<string>();
+const EMPTY_AGENT_ACTIVITY_TRANSITIONS = new Map<string, number>();
 
 export function isAgentPinned(
   pinnedAgentKeys: ReadonlySet<string>,
@@ -3717,6 +3860,23 @@ export function buildAgentPinKeySet(
     }
   }
   return keys;
+}
+
+export function buildAgentActivityTransitionMap(
+  bridgeViews: BridgeConnectionView[],
+  agentActivityStates: Record<string, BridgeAgentActivityState>,
+) {
+  const transitions = new Map<string, number>();
+  for (const view of bridgeViews) {
+    const state = agentActivityStates[view.runtime.id];
+    if (!state || state.connectionKey !== view.runtime.connectionKey) {
+      continue;
+    }
+    for (const [key, value] of agentActivityTimestamps(view.runtime.id, state.response)) {
+      transitions.set(key, value);
+    }
+  }
+  return transitions;
 }
 
 function sortedAgentEntriesWithinGroup(entries: ScopedAgentPane[]) {
@@ -3780,14 +3940,15 @@ export function buildVisibleAgentPaneEntries(
   agentSort: AgentSort,
   pinnedAgentKeys: ReadonlySet<string> = EMPTY_AGENT_PIN_KEYS,
   pinnedOnly = false,
+  agentActivityTransitions: ReadonlyMap<string, number> = EMPTY_AGENT_ACTIVITY_TRANSITIONS,
 ) {
-  const sortedAgentPanes = sortScopedAgentPanes(
+  const buildRows = (sort: AgentSort) =>
     scopedWorkspaces.flatMap((entry) => {
       const sorted = sortAgentPanes(
         entry.snapshot.panes.filter(
           (pane) => pane.workspace_id === entry.workspace.workspace_id && isAgentPane(pane),
         ),
-        agentSort,
+        sort,
         entry.snapshot,
       );
       return sorted.map((pane) => {
@@ -3803,11 +3964,30 @@ export function buildVisibleAgentPaneEntries(
           tabNumber: tab?.number,
           tabLabel: tab ? displayTabLabel(tab, entry.snapshot.panes) : undefined,
           pinned: isAgentPinned(pinnedAgentKeys, entry.bridgeId, pane.pane_id),
+          lastStatusTransitionAt: agentActivityTransitions.get(
+            agentActivityKey(entry.bridgeId, pane.pane_id, pane.terminal_id),
+          ),
         };
       });
-    }),
-    agentSort,
-  );
+    });
+
+  if (agentSort === "lastStatusChange" && agentGroup !== "none") {
+    const agentPanes = pinnedOnly
+      ? buildRows("workspace").filter((entry) => entry.pinned)
+      : buildRows("workspace");
+    const groups = buildScopedAgentGroups(agentPanes, agentGroup, hostScope).map((group) => ({
+      ...group,
+      panes: sortedAgentEntriesWithinGroup(sortScopedAgentPanes(group.panes, agentSort)),
+    }));
+    if (agentGroup === "hostWorkspace" && hostScope === "all") {
+      return bridgeViews.flatMap((view) =>
+        groups.filter((group) => group.bridgeId === view.runtime.id).flatMap((group) => group.panes),
+      );
+    }
+    return groups.flatMap((group) => group.panes);
+  }
+
+  const sortedAgentPanes = sortScopedAgentPanes(buildRows(agentSort), agentSort);
   const agentPanes = pinnedOnly
     ? sortedAgentPanes.filter((entry) => entry.pinned)
     : sortedAgentEntriesWithinGroup(sortedAgentPanes);
@@ -4547,6 +4727,7 @@ function Switcher({
   notesStates,
   visibleNotes,
   selectedNote,
+  agentActivityTransitions,
   pinnedAgentKeys,
   agentPinnedOnly,
   agentSort,
@@ -4590,6 +4771,7 @@ function Switcher({
   notesStates: Record<string, BridgeNotesState>;
   visibleNotes: ScopedNoteEntry[];
   selectedNote: ScopedNoteEntry | null;
+  agentActivityTransitions: ReadonlyMap<string, number>;
   pinnedAgentKeys: ReadonlySet<string>;
   agentPinnedOnly: boolean;
   agentSort: AgentSort;
@@ -4674,6 +4856,10 @@ function Switcher({
   const agentPinsSupported = hostBridgeViews.some((view) =>
     supportsAgentPins(view.runtime.capabilities),
   );
+  const showLastStatusChangeSort = shouldShowLastStatusChangeSort(
+    hostBridgeViews.some((view) => supportsAgentActivity(view.runtime.capabilities)),
+    agentSort,
+  );
   const effectiveAgentPinnedOnly = agentPinsSupported && agentPinnedOnly;
   const notesLoading = notesEnabled && hostBridgeViews.some(
     (view) => notesStates[view.runtime.id]?.loadState === "loading",
@@ -4698,12 +4884,15 @@ function Switcher({
       scopedWorkspaces,
       bridgeViews,
       hostScope,
-      "none",
+      agentSort === "lastStatusChange" ? agentGroup : "none",
       agentSort,
       pinnedAgentKeys,
       effectiveAgentPinnedOnly,
+      agentActivityTransitions,
     );
   }, [
+    agentActivityTransitions,
+    agentGroup,
     effectiveAgentPinnedOnly,
     agentSort,
     bridgeViews,
@@ -5351,6 +5540,7 @@ function Switcher({
           showGroup={showGroupControl}
           agentSort={agentSort}
           agentGroup={agentGroup}
+          showLastStatusChangeSort={showLastStatusChangeSort}
           onAgentSort={onAgentSort}
           onAgentGroup={onAgentGroup}
           onClose={() => setOptionsMenu(null)}
@@ -5367,6 +5557,7 @@ function SidebarOptionsMenu({
   showGroup,
   agentSort,
   agentGroup,
+  showLastStatusChangeSort,
   onAgentSort,
   onAgentGroup,
   onClose,
@@ -5377,6 +5568,7 @@ function SidebarOptionsMenu({
   showGroup: boolean;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
+  showLastStatusChangeSort: boolean;
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
   onClose: () => void;
@@ -5450,6 +5642,9 @@ function SidebarOptionsMenu({
             >
               <option value="attention">Attention</option>
               <option value="status">Status</option>
+              {showLastStatusChangeSort ? (
+                <option value="lastStatusChange">Last status change</option>
+              ) : null}
               <option value="workspace">Workspace</option>
             </select>
           </label>
@@ -6584,6 +6779,11 @@ export function sortScopedAgentPanes(entries: ScopedAgentPane[], sort: AgentSort
       if (status !== 0) {
         return status;
       }
+    } else if (sort === "lastStatusChange") {
+      const activity = compareLastStatusTransition(a, b);
+      if (activity !== 0) {
+        return activity;
+      }
     }
 
     const bridge = a.bridgeIndex - b.bridgeIndex;
@@ -6608,6 +6808,30 @@ export function sortScopedAgentPanes(entries: ScopedAgentPane[], sort: AgentSort
       { numeric: true },
     );
   });
+}
+
+export function shouldShowLastStatusChangeSort(
+  agentActivitySupported: boolean,
+  agentSort: AgentSort,
+) {
+  return agentActivitySupported || agentSort === "lastStatusChange";
+}
+
+function compareLastStatusTransition(a: ScopedAgentPane, b: ScopedAgentPane) {
+  // Values are bridge-observed wall-clock times. Across hosts, clock skew can
+  // affect exact ordering, so existing bridge/workspace fallback order remains
+  // the deterministic tie and no-timestamp behavior.
+  const aTransition = a.lastStatusTransitionAt;
+  const bTransition = b.lastStatusTransitionAt;
+  const hasA = typeof aTransition === "number";
+  const hasB = typeof bTransition === "number";
+  if (hasA !== hasB) {
+    return hasA ? -1 : 1;
+  }
+  if (hasA && hasB && aTransition !== bTransition) {
+    return bTransition - aTransition;
+  }
+  return 0;
 }
 
 function agentTitle(pane: PaneInfo) {
@@ -6865,6 +7089,18 @@ function isNotesChangedEvent(event: MessageEvent) {
   try {
     const parsed = JSON.parse(event.data) as { type?: unknown };
     return parsed.type === "herdr_web.notes_changed";
+  } catch {
+    return false;
+  }
+}
+
+function isAgentActivityChangedEvent(event: MessageEvent) {
+  if (typeof event.data !== "string") {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(event.data) as { type?: unknown };
+    return parsed.type === "herdr_web.agent_activity_changed";
   } catch {
     return false;
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2257,6 +2257,8 @@ export function App() {
         bridgeViews,
         hostScope,
         agentGroup,
+        pinnedAgentKeys,
+        sidebarView === "tabs" && effectiveAgentPinnedOnly,
       );
       const tabs = tabEntries;
       if (tabs.length === 0) {
@@ -2300,6 +2302,7 @@ export function App() {
     paneFocusSupported,
     pinnedAgentKeys,
     scope,
+    sidebarView,
     selectedPane,
     selectedRuntime,
     selectedCommands,
@@ -3864,11 +3867,21 @@ export function buildScopedAgentGroups(
 
 export function buildVisibleTabWorkspaceGroups(
   scopedWorkspaces: ScopedWorkspace[],
+  pinnedAgentKeys: ReadonlySet<string> = EMPTY_AGENT_PIN_KEYS,
+  pinnedOnly = false,
 ): ScopedTabWorkspace[] {
   return scopedWorkspaces.map((entry) => ({
     ...entry,
     tabs: sortTabsForWorkspace(entry.snapshot.tabs, entry.workspace.workspace_id)
-      .map((tab) => ({ tab, panes: sortPanesForTab(entry.snapshot.panes, tab.tab_id) }))
+      .map((tab) => {
+        const panes = sortPanesForTab(entry.snapshot.panes, tab.tab_id);
+        return {
+          tab,
+          panes: pinnedOnly
+            ? panes.filter((pane) => isAgentPinned(pinnedAgentKeys, entry.bridgeId, pane.pane_id))
+            : panes,
+        };
+      })
       .filter((group) => group.panes.length > 0),
   }));
 }
@@ -3878,8 +3891,10 @@ export function buildVisibleTabEntries(
   bridgeViews: BridgeConnectionView[],
   hostScope: HostScope,
   agentGroup: AgentGroup,
+  pinnedAgentKeys: ReadonlySet<string> = EMPTY_AGENT_PIN_KEYS,
+  pinnedOnly = false,
 ): ScopedTabEntry[] {
-  const spaceGroups = buildVisibleTabWorkspaceGroups(scopedWorkspaces);
+  const spaceGroups = buildVisibleTabWorkspaceGroups(scopedWorkspaces, pinnedAgentKeys, pinnedOnly);
   const flattenGroup = (group: ScopedTabWorkspace): ScopedTabEntry[] =>
     group.tabs.map(({ tab, panes }) => ({ ...group, tab, panes }));
   if (agentGroup === "host" || (agentGroup === "hostWorkspace" && hostScope === "all")) {
@@ -4705,8 +4720,13 @@ function Switcher({
   }, [agentGroup, agentPanes, hostScope]);
 
   const spaceGroups = useMemo<ScopedTabWorkspace[]>(
-    () => buildVisibleTabWorkspaceGroups(scopedWorkspaces),
-    [scopedWorkspaces],
+    () =>
+      buildVisibleTabWorkspaceGroups(
+        scopedWorkspaces,
+        pinnedAgentKeys,
+        sidebarView === "tabs" && effectiveAgentPinnedOnly,
+      ),
+    [effectiveAgentPinnedOnly, pinnedAgentKeys, scopedWorkspaces, sidebarView],
   );
   const spaceCount = hostBridgeViews.reduce(
     (count, view) => count + (view.snapshot?.workspaces.length ?? 0),
@@ -4724,6 +4744,9 @@ function Switcher({
       selectedBridgeId,
   );
   const canCreateNoteFromHeader = notesViewActive && notesSupported;
+  const showPinnedOnlyControl =
+    (sidebarView === "agents" || sidebarView === "tabs") && agentPinsSupported;
+  const pinnedOnlyLabel = sidebarView === "tabs" ? "pinned panes" : "pinned agents";
 
   useEffect(() => {
     if (optionsMenu && !showOptionsControl) {
@@ -4781,6 +4804,7 @@ function Switcher({
                 key={`${group.bridgeId}:${pane.pane_id}`}
                 index={paneIndex++}
                 pane={pane}
+                pinned={isAgentPinned(pinnedAgentKeys, group.bridgeId, pane.pane_id)}
                 active={group.bridgeId === selectedBridgeId && pane.pane_id === selectedPane?.pane_id}
                 onSelect={() => onSelectPane(group.bridgeId, pane)}
                 onMenu={(x, y) =>
@@ -5220,11 +5244,11 @@ function Switcher({
                     <Plus size={14} />
                   </button>
                 ) : null}
-                {sidebarView === "agents" && agentPinsSupported ? (
+                {showPinnedOnlyControl ? (
                   <button
                     className="sec-add sec-add-pin"
                     type="button"
-                    aria-label="Show pinned agents only"
+                    aria-label={`Show ${pinnedOnlyLabel} only`}
                     title="Pinned only"
                     aria-pressed={agentPinnedOnly}
                     data-on={agentPinnedOnly}
@@ -5301,8 +5325,14 @@ function Switcher({
                   <>{renderDisconnectedBridgeRows()}</>
                 ) : (
                 <div className="empty">
-                  <strong>No panes</strong>
-                  <span>{scope === "space" ? "This space has no panes yet." : "No workspace has panes yet."}</span>
+                  <strong>{effectiveAgentPinnedOnly ? "No pinned panes" : "No panes"}</strong>
+                  <span>
+                    {effectiveAgentPinnedOnly
+                      ? ""
+                      : scope === "space"
+                        ? "This space has no panes yet."
+                        : "No workspace has panes yet."}
+                  </span>
                 </div>
                 )
               ) : (
@@ -6287,12 +6317,14 @@ function TabDivider({
 
 function PaneRow({
   pane,
+  pinned,
   active,
   index,
   onSelect,
   onMenu,
 }: {
   pane: PaneInfo;
+  pinned?: boolean;
   active: boolean;
   index: number;
   onSelect: () => void;
@@ -6318,6 +6350,9 @@ function PaneRow({
         <span className="pane-word" data-status={pane.agent_status}>
           {statusLabel(pane.agent_status)}
         </span>
+      ) : null}
+      {pinned ? (
+        <Pin className="agent-pin-indicator" size={10} aria-label="Pinned" />
       ) : null}
     </button>
   );

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -514,6 +514,7 @@ function createConnectionHarness({
           connectionRefs={connectionRefs}
           setConnectionStates={setConnectionStates}
           onPaneSelection={onPaneSelection}
+          onAgentActivityChanged={() => undefined}
           onAgentPinsChanged={() => undefined}
           onNotesChanged={onNotesChanged}
         />,

--- a/web/src/agentActivity.test.ts
+++ b/web/src/agentActivity.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentActivityKey,
+  agentActivityTimestamps,
+  parseAgentActivityListResponse,
+  supportsAgentActivity,
+} from "./agentActivity";
+
+describe("agent activity helpers", () => {
+  it("checks bridge support", () => {
+    expect(supportsAgentActivity({ commands: [], agent_activity: { version: 1 } })).toBe(true);
+    expect(supportsAgentActivity({ commands: [] })).toBe(false);
+    expect(supportsAgentActivity(null)).toBe(false);
+  });
+
+  it("parses records with optional transition timestamps", () => {
+    const response = parseAgentActivityListResponse({
+      session_key: "session-a",
+      records: [
+        {
+          pane_id: "pane-1",
+          terminal_id: "terminal-1",
+          workspace_id: "workspace-a",
+          tab_id: "tab-a",
+          agent_status: "working",
+          last_status_transition_at: "123",
+        },
+        {
+          pane_id: "pane-2",
+          terminal_id: "terminal-2",
+          workspace_id: "workspace-a",
+          tab_id: "tab-a",
+          agent_status: "idle",
+          last_status_transition_at: null,
+        },
+      ],
+    });
+
+    expect(response.records).toHaveLength(2);
+    expect(response.records[0].last_status_transition_at).toBe("123");
+    expect(response.records[1].last_status_transition_at).toBeUndefined();
+  });
+
+  it("rejects invalid timestamps and statuses", () => {
+    expect(() =>
+      parseAgentActivityListResponse({
+        session_key: "session-a",
+        records: [
+          {
+            pane_id: "pane-1",
+            terminal_id: "terminal-1",
+            workspace_id: "workspace-a",
+            tab_id: "tab-a",
+            agent_status: "busy",
+            last_status_transition_at: "123",
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(() =>
+      parseAgentActivityListResponse({
+        session_key: "session-a",
+        records: [
+          {
+            pane_id: "pane-1",
+            terminal_id: "terminal-1",
+            workspace_id: "workspace-a",
+            tab_id: "tab-a",
+            agent_status: "working",
+            last_status_transition_at: "12ms",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("keys timestamps by bridge pane and terminal", () => {
+    const timestamps = agentActivityTimestamps("bridge-a", {
+      session_key: "session-a",
+      records: [
+        {
+          pane_id: "pane-1",
+          terminal_id: "terminal-1",
+          workspace_id: "workspace-a",
+          tab_id: "tab-a",
+          agent_status: "working",
+          last_status_transition_at: "456",
+        },
+        {
+          pane_id: "pane-1",
+          terminal_id: "terminal-2",
+          workspace_id: "workspace-a",
+          tab_id: "tab-a",
+          agent_status: "working",
+        },
+      ],
+    });
+
+    expect(timestamps.get(agentActivityKey("bridge-a", "pane-1", "terminal-1"))).toBe(456);
+    expect(timestamps.has(agentActivityKey("bridge-a", "pane-1", "terminal-2"))).toBe(false);
+  });
+});

--- a/web/src/agentActivity.ts
+++ b/web/src/agentActivity.ts
@@ -1,0 +1,134 @@
+import { fetchWithTimeout } from "./fetchWithTimeout";
+import type { BridgeCapabilities } from "./bridge";
+import type { AgentStatus } from "./types";
+
+export type AgentActivityRecord = {
+  pane_id: string;
+  terminal_id: string;
+  workspace_id: string;
+  tab_id: string;
+  agent_status: AgentStatus;
+  last_status_transition_at?: string;
+};
+
+export type AgentActivityListResponse = {
+  session_key: string;
+  records: AgentActivityRecord[];
+};
+
+export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
+
+export class AgentActivityApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "AgentActivityApiError";
+    this.status = status;
+  }
+}
+
+const agentStatuses: AgentStatus[] = ["idle", "working", "blocked", "done", "unknown"];
+
+export function supportsAgentActivity(capabilities: BridgeCapabilities | null | undefined) {
+  return capabilities?.agent_activity?.version === 1;
+}
+
+export async function fetchAgentActivity(
+  httpUrl: BridgeHttpUrl,
+): Promise<AgentActivityListResponse> {
+  const response = await fetchWithTimeout(httpUrl("/api/agent-activity"));
+  return parseAgentActivityResponse(response);
+}
+
+export function agentActivityKey(bridgeId: string, paneId: string, terminalId: string) {
+  return `${bridgeId}:${paneId}:${terminalId}`;
+}
+
+export function agentActivityTimestamps(
+  bridgeId: string,
+  response: AgentActivityListResponse | null | undefined,
+) {
+  const timestamps = new Map<string, number>();
+  for (const record of response?.records ?? []) {
+    const timestamp = parseTransitionTimestamp(record.last_status_transition_at);
+    if (timestamp === null) {
+      continue;
+    }
+    timestamps.set(agentActivityKey(bridgeId, record.pane_id, record.terminal_id), timestamp);
+  }
+  return timestamps;
+}
+
+export function parseAgentActivityListResponse(value: unknown): AgentActivityListResponse {
+  if (!isRecord(value) || typeof value.session_key !== "string" || !Array.isArray(value.records)) {
+    throw new Error("agent activity response is invalid");
+  }
+  return {
+    session_key: value.session_key,
+    records: value.records.map(parseAgentActivityRecord),
+  };
+}
+
+function parseAgentActivityRecord(value: unknown): AgentActivityRecord {
+  if (
+    !isRecord(value) ||
+    typeof value.pane_id !== "string" ||
+    typeof value.terminal_id !== "string" ||
+    typeof value.workspace_id !== "string" ||
+    typeof value.tab_id !== "string" ||
+    !isAgentStatus(value.agent_status)
+  ) {
+    throw new Error("agent activity record is invalid");
+  }
+  const timestamp = parseTransitionTimestamp(value.last_status_transition_at);
+  return {
+    pane_id: value.pane_id,
+    terminal_id: value.terminal_id,
+    workspace_id: value.workspace_id,
+    tab_id: value.tab_id,
+    agent_status: value.agent_status,
+    ...(timestamp === null ? {} : { last_status_transition_at: String(timestamp) }),
+  };
+}
+
+function parseTransitionTimestamp(value: unknown) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    throw new Error("agent activity timestamp is invalid");
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error("agent activity timestamp is invalid");
+  }
+  return parsed;
+}
+
+async function parseAgentActivityResponse(response: Response) {
+  if (!response.ok) {
+    throw await agentActivityApiError(response);
+  }
+  return parseAgentActivityListResponse(await response.json());
+}
+
+async function agentActivityApiError(response: Response) {
+  try {
+    const parsed = (await response.json()) as { error?: unknown };
+    if (typeof parsed.error === "string" && parsed.error.trim()) {
+      return new AgentActivityApiError(parsed.error, response.status);
+    }
+  } catch {
+    // Fall through to the status-based error.
+  }
+  return new AgentActivityApiError(`agent activity failed: ${response.status}`, response.status);
+}
+
+function isAgentStatus(value: unknown): value is AgentStatus {
+  return typeof value === "string" && agentStatuses.includes(value as AgentStatus);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -320,6 +320,7 @@ describe("capabilities", () => {
         bridge_version: "1.2.3",
         web_compat: 1,
         min_android_app_compat: 2,
+        agent_activity: { version: 1 },
         agent_pins: { version: 1 },
         notes: { version: 1 },
       }),
@@ -328,6 +329,7 @@ describe("capabilities", () => {
       bridge_version: "1.2.3",
       web_compat: 1,
       min_android_app_compat: 2,
+      agent_activity: { version: 1 },
       agent_pins: { version: 1 },
       notes: { version: 1 },
     });

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -36,6 +36,9 @@ export type BridgeMode = "same-origin" | "configured";
 
 export type BridgeCapabilities = {
   commands: string[];
+  agent_activity?: {
+    version: 1;
+  };
   agent_pins?: {
     version: 1;
   };
@@ -1064,6 +1067,10 @@ export function parseCapabilities(value: unknown): BridgeCapabilities {
     web_compat: typeof value.web_compat === "number" ? value.web_compat : undefined,
     min_android_app_compat:
       typeof value.min_android_app_compat === "number" ? value.min_android_app_compat : undefined,
+    agent_activity:
+      isRecord(value.agent_activity) && value.agent_activity.version === 1
+        ? { version: 1 }
+        : undefined,
     agent_pins:
       isRecord(value.agent_pins) && value.agent_pins.version === 1
         ? { version: 1 }


### PR DESCRIPTION
## Summary
- add bridge-tracked agent activity records for semantic status transitions
- expose `/api/agent-activity` and capability metadata
- add Agents view `Last status change` sorting with startup/empty-snapshot safeguards

## Verification
- npm run check
