### PR TITLE
Add sidebar pane note action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /vendor/herdr-compat/target/
 /dist-packages/
 .specs/
+.scratch/
 *.log
 *.swp
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 - Extended the pinned-only sidebar toggle to the Tabs view so pinned panes can be found outside the
   Agents view.
+- New notes now open in Edit mode with the title selected, so the default title can be replaced
+  immediately.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added an `Add note` action to pane and agent sidebar context menus, creating a new note attached
+  to the target pane and opening it in the notes editor.
 - Added bridge-tracked agent status transition activity with an Agents view sort option for
   `Last status change`, using semantic status changes rather than terminal output activity.
   [PR #23](https://github.com/kcosr/herdr-web/pull/23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@
 
 - Extended the pinned-only sidebar toggle to the Tabs view so pinned panes can be found outside the
   Agents view.
-- New notes now open in Edit mode with the title selected, so the default title can be replaced
-  immediately.
+- Pane context menu `Add note` now opens a quick-create dialog with a focused title and optional body
+  instead of switching to the notes panel.
+- Notes created from the notes panel now open in Edit mode with the title selected, so the default
+  title can be replaced immediately.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added an `Add note` action to pane and agent sidebar context menus, creating a new note attached
   to the target pane and opening it in the notes editor.
+  [PR #24](https://github.com/kcosr/herdr-web/pull/24)
 - Added bridge-tracked agent status transition activity with an Agents view sort option for
   `Last status change`, using semantic status changes rather than terminal output activity.
   [PR #23](https://github.com/kcosr/herdr-web/pull/23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 ### Fixed
 
+- Prevented sidebar row labels and terminal tab labels from being text-selected during long-press
+  context-menu gestures.
 - Added Mobile settings for an expanding terminal command input and Enter-as-newline
   editing, allowing long prompts to wrap and remain viewable while preserving send-on-Enter
   by default. [PR #21](https://github.com/kcosr/herdr-web/pull/21)

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildVisibleAgentPaneEntries,
   buildVisibleScopedNotes,
+  canAddNoteFromPaneMenu,
+  mergeCreatedPaneNoteList,
+  mergePendingPaneNotesIntoList,
   noteDraftStorageKey,
   buildVisibleScopedWorkspaces,
   buildVisibleTabEntries,
@@ -10,6 +13,8 @@ import {
   nextVisibleAgentPaneEntry,
   nextVisibleTabEntry,
   resolveInitialSelectedBridgeId,
+  resolveCreatedPaneNoteForTarget,
+  paneNoteListContains,
   shouldBlockDirtyNoteAutosave,
   shouldCollapseHostScope,
   shouldShowLastStatusChangeSort,
@@ -24,6 +29,7 @@ import {
   isConnectionResultCurrent,
 } from "./connectionState";
 import type { AgentStatus, PaneInfo, Snapshot, TabInfo, WorkspaceInfo } from "./types";
+import { notesForPane } from "./notes";
 import type { PaneNote } from "./notes";
 
 describe("App connection guards", () => {
@@ -425,6 +431,143 @@ describe("App multi-bridge helpers", () => {
     expect(menuItems("pane", false, false, true, true, "agent")).toEqual([
       { key: "unpin", label: "Unpin agent" },
     ]);
+  });
+
+  it("shows add-note actions only for eligible pane menus", () => {
+    expect(menuItems("pane", false, false, false, false, "pane", true)).toEqual([
+      { key: "add_note", label: "Add note" },
+    ]);
+    expect(menuItems("pane", false, false, true, false, "agent", true)).toEqual([
+      { key: "pin", label: "Pin agent" },
+      { key: "add_note", label: "Add note" },
+    ]);
+    expect(menuItems("space", false, false, false, false, "pane", true)).toEqual([]);
+    expect(menuItems("tab", false, false, false, false, "pane", true)).toEqual([]);
+  });
+
+  it("requires a current note-capable pane before showing add-note", () => {
+    const eligible = {
+      kind: "pane" as const,
+      notesEnabled: true,
+      runtimeCanConnect: true,
+      capabilityState: "ready" as const,
+      notesSupported: true,
+      runtimeConnectionKey: "configured:one",
+      stateConnectionKey: "configured:one",
+      paneExists: true,
+    };
+
+    expect(canAddNoteFromPaneMenu(eligible)).toBe(true);
+    expect(canAddNoteFromPaneMenu({ ...eligible, kind: "tab" })).toBe(false);
+    expect(canAddNoteFromPaneMenu({ ...eligible, notesEnabled: false })).toBe(false);
+    expect(canAddNoteFromPaneMenu({ ...eligible, runtimeCanConnect: false })).toBe(false);
+    expect(canAddNoteFromPaneMenu({ ...eligible, capabilityState: "probing" })).toBe(false);
+    expect(canAddNoteFromPaneMenu({ ...eligible, notesSupported: false })).toBe(false);
+    expect(
+      canAddNoteFromPaneMenu({ ...eligible, stateConnectionKey: "configured:two" }),
+    ).toBe(false);
+    expect(canAddNoteFromPaneMenu({ ...eligible, paneExists: false })).toBe(false);
+  });
+
+  it("normalizes created notes so they are visible as pane notes", () => {
+    const targetPane = pane("pane-a", "workspace-a", "tab-a");
+    const rawNote: PaneNote = {
+      ...note("new", "workspace-b", "unresolved"),
+      attachment: null,
+      link_state: "detached",
+      updated_at: "300",
+    };
+    const olderPaneNote = {
+      ...resolveCreatedPaneNoteForTarget(note("older", "workspace-a", "linked"), targetPane),
+      updated_at: "100",
+    };
+    const staleServerNote = {
+      ...rawNote,
+      title: "Server title",
+      updated_at: "400",
+    };
+
+    const resolved = resolveCreatedPaneNoteForTarget(rawNote, targetPane);
+    const merged = mergeCreatedPaneNoteList([olderPaneNote], rawNote, targetPane);
+    const mergedWithServerCopy = mergeCreatedPaneNoteList([staleServerNote, olderPaneNote], rawNote, targetPane);
+
+    expect(resolved.link_state).toBe("linked");
+    expect(resolved.attachment?.pane_id).toBe(targetPane.pane_id);
+    expect(resolved.resolved_pane?.pane_id).toBe(targetPane.pane_id);
+    expect(paneNoteListContains([resolved], targetPane, rawNote.note_id)).toBe(true);
+    expect(paneNoteListContains([rawNote], targetPane, rawNote.note_id)).toBe(false);
+    expect(notesForPane(merged, targetPane.pane_id).map((item) => item.note_id)).toEqual([
+      "new",
+      "older",
+    ]);
+    expect(notesForPane(mergedWithServerCopy, targetPane.pane_id)[0]).toMatchObject({
+      note_id: "new",
+      title: "Server title",
+    });
+  });
+
+  it("keeps pending created pane notes through lagging refreshes", () => {
+    const targetPane = pane("pane-a", "workspace-a", "tab-a");
+    const rawNote: PaneNote = {
+      ...note("new", "workspace-b", "unresolved"),
+      attachment: null,
+      link_state: "detached",
+      updated_at: "300",
+    };
+    const olderPaneNote = {
+      ...resolveCreatedPaneNoteForTarget(note("older", "workspace-a", "linked"), targetPane),
+      updated_at: "100",
+    };
+    const serverLinkedNote = resolveCreatedPaneNoteForTarget(rawNote, targetPane);
+    const serverDetachedNote = {
+      ...rawNote,
+      updated_at: "500",
+    };
+    const serverUnresolvedNote = {
+      ...rawNote,
+      link_state: "unresolved" as const,
+      updated_at: "450",
+    };
+
+    const firstLaggingRefresh = mergePendingPaneNotesIntoList([], [
+      { note: rawNote, pane: targetPane },
+    ]);
+    const secondLaggingRefresh = mergePendingPaneNotesIntoList([olderPaneNote], firstLaggingRefresh.pending);
+    const serverDetachedRefresh = mergePendingPaneNotesIntoList(
+      [serverDetachedNote, olderPaneNote],
+      firstLaggingRefresh.pending,
+    );
+    const serverUnresolvedRefresh = mergePendingPaneNotesIntoList(
+      [serverUnresolvedNote, olderPaneNote],
+      firstLaggingRefresh.pending,
+    );
+    const serverCaughtUpRefresh = mergePendingPaneNotesIntoList(
+      [serverLinkedNote, olderPaneNote],
+      secondLaggingRefresh.pending,
+    );
+
+    expect(notesForPane(firstLaggingRefresh.notes, targetPane.pane_id).map((item) => item.note_id)).toEqual([
+      "new",
+    ]);
+    expect(firstLaggingRefresh.pending).toHaveLength(1);
+    expect(notesForPane(secondLaggingRefresh.notes, targetPane.pane_id).map((item) => item.note_id)).toEqual([
+      "new",
+      "older",
+    ]);
+    expect(secondLaggingRefresh.pending).toHaveLength(1);
+    expect(notesForPane(serverDetachedRefresh.notes, targetPane.pane_id).map((item) => item.note_id)).toEqual([
+      "older",
+    ]);
+    expect(serverDetachedRefresh.pending).toHaveLength(0);
+    expect(notesForPane(serverUnresolvedRefresh.notes, targetPane.pane_id).map((item) => item.note_id)).toEqual([
+      "older",
+    ]);
+    expect(serverUnresolvedRefresh.pending).toHaveLength(0);
+    expect(notesForPane(serverCaughtUpRefresh.notes, targetPane.pane_id).map((item) => item.note_id)).toEqual([
+      "new",
+      "older",
+    ]);
+    expect(serverCaughtUpRefresh.pending).toHaveLength(0);
   });
 
   it("builds visible tab entries across hosts for all-host shortcut navigation", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,7 @@ import {
 import type {
   CSSProperties,
   Dispatch,
+  FormEvent as ReactFormEvent,
   KeyboardEvent as ReactKeyboardEvent,
   MutableRefObject,
   SetStateAction,
@@ -204,6 +205,9 @@ type PendingCreatedPaneNoteTarget = {
 };
 type PendingCreatedPaneNote = PendingCreatedPaneNoteTarget & {
   connectionKey: string;
+};
+type QuickPaneNoteTarget = ScopedPaneRef & {
+  label: string;
 };
 type BridgeAgentPinsState = {
   connectionKey: string;
@@ -784,6 +788,8 @@ export function App() {
   const [mobileNotesScreen, setMobileNotesScreen] = useState<MobileNotesScreen>("list");
   const [notesIncludeArchived, setNotesIncludeArchived] = useState(false);
   const [notesIncludeDeleted, setNotesIncludeDeleted] = useState(false);
+  const [quickPaneNoteTarget, setQuickPaneNoteTarget] = useState<QuickPaneNoteTarget | null>(null);
+  const [quickPaneNoteCreating, setQuickPaneNoteCreating] = useState(false);
   const [selectedPaneRefState, setSelectedPaneRefState] = useState<ScopedPaneRef | null>(
     initialPrefs.selectedPane,
   );
@@ -2066,7 +2072,7 @@ export function App() {
     };
   };
 
-  const createNoteForPaneTarget = async (bridgeId: BridgeId, paneId: string) => {
+  const openQuickPaneNoteDialog = (bridgeId: BridgeId, paneId: string, label: string) => {
     if (!notesEnabled) {
       setError("Notes are disabled in settings");
       return;
@@ -2081,51 +2087,89 @@ export function App() {
       setError("Notes are not available for this bridge");
       return;
     }
-    const requestConnectionKey = runtime.connectionKey;
-    const isCurrentConnection = () => {
-      const currentRuntime = bridge.getRuntime(bridgeId);
-      return Boolean(
-        notesEnabledRef.current &&
-          currentRuntime?.connectionKey === requestConnectionKey &&
-          isConnectionResultCurrent(
-            connectionRefs.current[bridgeId]?.connectionKey ?? "",
-            requestConnectionKey,
-          ),
-      );
-    };
     const bridgeSnapshot = snapshotForBridge(bridgeId);
     const targetPane = bridgeSnapshot?.panes.find((pane) => pane.pane_id === paneId) ?? null;
     if (!targetPane) {
       setError("Pane not found");
       return;
     }
+    setQuickPaneNoteTarget({
+      bridgeId,
+      paneId,
+      label: label || paneTitle(targetPane),
+    });
+    setError(null);
+  };
 
-    openPane(bridgeId, targetPane);
-    setNotesPanelOpen(true);
-    if (isCompactLayout) {
-      setMobileNotesScreen("editor");
+  const createQuickPaneNote = async (title: string, body: string) => {
+    const target = quickPaneNoteTarget;
+    if (!target) {
+      return;
     }
-
+    if (!notesEnabled) {
+      setError("Notes are disabled in settings");
+      return;
+    }
+    const runtime = bridge.getRuntime(target.bridgeId);
+    if (
+      !runtime ||
+      !runtime.canConnect ||
+      runtime.capabilityState !== "ready" ||
+      !supportsNotes(runtime.capabilities)
+    ) {
+      setError("Notes are not available for this bridge");
+      return;
+    }
+    const bridgeSnapshot = snapshotForBridge(target.bridgeId);
+    const targetPane = bridgeSnapshot?.panes.find((pane) => pane.pane_id === target.paneId) ?? null;
+    if (!targetPane) {
+      setError("Pane not found");
+      return;
+    }
+    const requestConnectionKey = runtime.connectionKey;
+    const isCurrentConnection = () => {
+      const currentRuntime = bridge.getRuntime(target.bridgeId);
+      return Boolean(
+        notesEnabledRef.current &&
+          currentRuntime?.connectionKey === requestConnectionKey &&
+          isConnectionResultCurrent(
+            connectionRefs.current[target.bridgeId]?.connectionKey ?? "",
+            requestConnectionKey,
+          ),
+      );
+    };
+    setQuickPaneNoteCreating(true);
     try {
       const note = await createNote(runtime.httpUrl, {
-        title: "Untitled note",
-        body: "",
+        title,
+        body,
         paneId: targetPane.pane_id,
       });
-      const response = await refreshBridgeNotes(runtime, false);
-      if (!isCurrentConnection()) {
+      setQuickPaneNoteTarget((current) =>
+        current?.bridgeId === target.bridgeId && current.paneId === target.paneId ? null : current,
+      );
+      try {
+        const response = await refreshBridgeNotes(runtime, false);
+        if (!isCurrentConnection()) {
+          return;
+        }
+        if (!response || !noteListContainsId(response.notes, note.note_id)) {
+          mergeCreatedPaneNote(target.bridgeId, requestConnectionKey, note, targetPane, Boolean(response));
+        }
+      } catch (caught) {
+        if (isCurrentConnection()) {
+          const detail = caught instanceof Error ? caught.message : "unknown refresh error";
+          setError(`Note created, but notes did not refresh: ${detail}`);
+        }
         return;
       }
-      if (!response || !noteListContainsId(response.notes, note.note_id)) {
-        mergeCreatedPaneNote(bridgeId, requestConnectionKey, note, targetPane, Boolean(response));
-      }
-      setSelectedNoteRef({ bridgeId, noteId: note.note_id });
-      requestNoteTitleFocus(bridgeId, note.note_id);
       setError(null);
     } catch (caught) {
       if (isCurrentConnection()) {
         setError(caught instanceof Error ? caught.message : "Could not create note");
       }
+    } finally {
+      setQuickPaneNoteCreating(false);
     }
   };
 
@@ -3048,7 +3092,7 @@ export function App() {
     } else if (key === "unpin" && kind === "pane") {
       void toggleAgentPin(bridgeId, id, true);
     } else if (key === "add_note" && kind === "pane") {
-      void createNoteForPaneTarget(bridgeId, id);
+      openQuickPaneNoteDialog(bridgeId, id, label);
     } else if (key === "move_new_tab" && kind === "pane") {
       const pane = connectionRefs.current[bridgeId]?.snapshot?.panes.find(
         (item) => item.pane_id === id,
@@ -3656,6 +3700,19 @@ export function App() {
           busy={busy}
           onCancel={() => setDialog(null)}
           onConfirm={confirmClose}
+        />
+      ) : null}
+
+      {quickPaneNoteTarget ? (
+        <QuickPaneNoteDialog
+          targetLabel={quickPaneNoteTarget.label}
+          busy={quickPaneNoteCreating}
+          onCancel={() => {
+            if (!quickPaneNoteCreating) {
+              setQuickPaneNoteTarget(null);
+            }
+          }}
+          onSubmit={(title, body) => void createQuickPaneNote(title, body)}
         />
       ) : null}
 
@@ -5883,6 +5940,163 @@ function SidebarOptionsMenu({
           </label>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+export function QuickPaneNoteDialog({
+  targetLabel,
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  targetLabel: string;
+  busy?: boolean;
+  onCancel: () => void;
+  onSubmit: (title: string, body: string) => void;
+}) {
+  const [title, setTitle] = useState("Untitled note");
+  const [bodyExpanded, setBodyExpanded] = useState(false);
+  const [body, setBody] = useState("");
+  const dialogRef = useRef<HTMLFormElement | null>(null);
+  const titleInputRef = useRef<HTMLInputElement | null>(null);
+  const bodyInputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    titleInputRef.current?.focus();
+    titleInputRef.current?.select();
+  }, []);
+
+  useEffect(() => {
+    if (bodyExpanded) {
+      bodyInputRef.current?.focus();
+    }
+  }, [bodyExpanded]);
+
+  useEffect(() => {
+    return addNativeBackHandler(() => {
+      if (!busy) {
+        onCancel();
+      }
+      return true;
+    });
+  }, [busy, onCancel]);
+
+  const cancel = () => {
+    if (!busy) {
+      onCancel();
+    }
+  };
+
+  const submit = (event: ReactFormEvent) => {
+    event.preventDefault();
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle || busy) {
+      return;
+    }
+    onSubmit(trimmedTitle, bodyExpanded ? body : "");
+  };
+  const trapDialogFocus = (event: ReactKeyboardEvent<HTMLFormElement>) => {
+    if (event.key !== "Tab") {
+      return;
+    }
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        "button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex='-1'])",
+      ),
+    );
+    if (focusable.length === 0) {
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  return (
+    <div className="overlay-root">
+      <button
+        className="overlay-scrim"
+        type="button"
+        aria-label="Cancel"
+        disabled={busy}
+        onClick={cancel}
+      />
+      <form
+        ref={dialogRef}
+        className="modal quick-note-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add note"
+        onSubmit={submit}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            cancel();
+            return;
+          }
+          trapDialogFocus(event);
+        }}
+      >
+        <div className="modal-title">Add note</div>
+        <div className="modal-message quick-note-target">Attached to {targetLabel}</div>
+        <label className="field-label">
+          <span>Title</span>
+          <input
+            ref={titleInputRef}
+            className="field"
+            value={title}
+            placeholder="Untitled note"
+            spellCheck={false}
+            autoComplete="off"
+            disabled={busy}
+            onChange={(event) => setTitle(event.currentTarget.value)}
+          />
+        </label>
+        {bodyExpanded ? (
+          <label className="field-label">
+            <span>Body</span>
+            <textarea
+              ref={bodyInputRef}
+              className="field quick-note-body"
+              value={body}
+              placeholder="Write a note"
+              disabled={busy}
+              rows={5}
+              onChange={(event) => setBody(event.currentTarget.value)}
+            />
+          </label>
+        ) : (
+          <button
+            className="btn quick-note-expand"
+            type="button"
+            disabled={busy}
+            aria-expanded="false"
+            onClick={() => setBodyExpanded(true)}
+          >
+            Add body
+          </button>
+        )}
+        <div className="modal-actions">
+          <button type="button" className="btn" disabled={busy} onClick={cancel}>
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary" disabled={busy || !title.trim()}>
+            Create
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -171,6 +171,9 @@ type ScopedNoteRef = {
   bridgeId: BridgeId;
   noteId: string;
 };
+type ScopedNoteTitleFocusRequest = ScopedNoteRef & {
+  token: number;
+};
 type MobileNotesScreen = "list" | "editor";
 type ScopedWorkspaceRef = {
   bridgeId: BridgeId;
@@ -773,6 +776,8 @@ export function App() {
     initialPrefs.selectedBridgeId,
   );
   const [selectedNoteRef, setSelectedNoteRef] = useState<ScopedNoteRef | null>(null);
+  const [noteTitleFocusRequest, setNoteTitleFocusRequest] =
+    useState<ScopedNoteTitleFocusRequest | null>(null);
   const [notesPanelOpen, setNotesPanelOpen] = useState(
     initialPrefs.notesEnabled && initialPrefs.notesPanelOpen,
   );
@@ -1840,6 +1845,16 @@ export function App() {
   };
 
   const requestTerminalFocus = () => setTerminalFocusToken((token) => token + 1);
+  const requestNoteTitleFocus = (bridgeId: BridgeId, noteId: string) => {
+    setNoteTitleFocusRequest((current) => ({
+      bridgeId,
+      noteId,
+      token: (current?.token ?? 0) + 1,
+    }));
+  };
+  const clearNoteTitleFocusRequest = useCallback((request: ScopedNoteTitleFocusRequest) => {
+    setNoteTitleFocusRequest((current) => (current?.token === request.token ? null : current));
+  }, []);
 
   const snapshotForBridge = (bridgeId: BridgeId) => {
     const runtime = bridge.getRuntime(bridgeId);
@@ -1958,6 +1973,7 @@ export function App() {
         paneId: selectedPane.pane_id,
       });
       setSelectedNoteRef({ bridgeId: selectedRuntime.id, noteId: note.note_id });
+      requestNoteTitleFocus(selectedRuntime.id, note.note_id);
       if (isCompactLayout) {
         setMobileNotesScreen("editor");
       }
@@ -1984,6 +2000,7 @@ export function App() {
         body: "",
       });
       setSelectedNoteRef({ bridgeId: runtime.id, noteId: note.note_id });
+      requestNoteTitleFocus(runtime.id, note.note_id);
       if (isCompactLayout) {
         setMobileNotesScreen("editor");
       }
@@ -2103,6 +2120,7 @@ export function App() {
         mergeCreatedPaneNote(bridgeId, requestConnectionKey, note, targetPane, Boolean(response));
       }
       setSelectedNoteRef({ bridgeId, noteId: note.note_id });
+      requestNoteTitleFocus(bridgeId, note.note_id);
       setError(null);
     } catch (caught) {
       if (isCurrentConnection()) {
@@ -3486,6 +3504,8 @@ export function App() {
           mobileScreen={mobileNotesScreen}
           selectedEntry={selectedScopedNote}
           selectedBridgeId={selectedRuntime?.id ?? null}
+          titleFocusRequest={noteTitleFocusRequest}
+          onTitleFocusRequestHandled={clearNoteTitleFocusRequest}
           selectedPane={selectedPane}
           selectedPaneNotes={selectedRuntime ? selectedPaneNotes.map((note) => ({
             bridgeId: selectedRuntime.id,
@@ -5872,6 +5892,8 @@ function NotesSurface({
   mobileScreen,
   selectedEntry,
   selectedBridgeId,
+  titleFocusRequest,
+  onTitleFocusRequestHandled,
   selectedPane,
   selectedPaneNotes,
   visibleNotes,
@@ -5908,6 +5930,8 @@ function NotesSurface({
   mobileScreen: MobileNotesScreen;
   selectedEntry: ScopedNoteEntry | null;
   selectedBridgeId: BridgeId | null;
+  titleFocusRequest: ScopedNoteTitleFocusRequest | null;
+  onTitleFocusRequestHandled: (request: ScopedNoteTitleFocusRequest) => void;
   selectedPane: PaneInfo | null;
   selectedPaneNotes: ScopedNoteEntry[];
   visibleNotes: ScopedNoteEntry[];
@@ -6130,6 +6154,8 @@ function NotesSurface({
           entry={selectedEntry}
           currentBridgeId={selectedBridgeId}
           currentPaneId={selectedPane?.pane_id ?? null}
+          titleFocusRequest={titleFocusRequest}
+          onTitleFocusRequestHandled={onTitleFocusRequestHandled}
           canAttachToCurrentPane={canAttachToCurrentPane}
           showCurrentPaneViewAction={compact}
           onSave={onSaveNote}
@@ -6175,6 +6201,8 @@ export function NoteEditor({
   entry,
   currentBridgeId,
   currentPaneId,
+  titleFocusRequest = null,
+  onTitleFocusRequestHandled,
   canAttachToCurrentPane,
   showCurrentPaneViewAction = false,
   onSave,
@@ -6188,6 +6216,8 @@ export function NoteEditor({
   entry: ScopedNoteEntry | null;
   currentBridgeId: BridgeId | null;
   currentPaneId: string | null;
+  titleFocusRequest?: ScopedNoteTitleFocusRequest | null;
+  onTitleFocusRequestHandled?: (request: ScopedNoteTitleFocusRequest) => void;
   canAttachToCurrentPane: boolean;
   showCurrentPaneViewAction?: boolean;
   onSave: (
@@ -6216,10 +6246,13 @@ export function NoteEditor({
   const loadedNoteIdentityRef = useRef("");
   const saveBlockedRef = useRef(false);
   const noteSaveInFlightRef = useRef<NoteSaveInFlight | null>(null);
+  const titleInputRef = useRef<HTMLInputElement | null>(null);
   const entryRef = useRef(entry);
   const onSaveRef = useRef(onSave);
   const noteIdentity = entry ? noteDraftStorageKey(entry) : "";
   const noteKey = entry ? `${entry.bridgeId}:${entry.note.note_id}:${entry.note.revision}` : "";
+  const currentEntryBridgeId = entry?.bridgeId ?? null;
+  const currentEntryNoteId = entry?.note.note_id ?? null;
   const serverTitle = entry?.note.title ?? "";
   const serverBody = entry?.note.body ?? "";
   const serverRevision = entry?.note.revision ?? 0;
@@ -6232,10 +6265,10 @@ export function NoteEditor({
     onSaveRef.current = onSave;
   }, [onSave]);
 
-  const setEditorMode = (mode: NoteEditorMode) => {
+  const setEditorMode = useCallback((mode: NoteEditorMode) => {
     setEditorModeState(mode);
     writeNoteEditorMode(mode);
-  };
+  }, []);
 
   useEffect(() => {
     if (!entry) {
@@ -6326,6 +6359,37 @@ export function NoteEditor({
       clearNoteDraft(entry);
     }
   }, [baseRevision, body, dirty, entry, noteIdentity, noteKey, title]);
+
+  useEffect(() => {
+    if (
+      !currentEntryBridgeId ||
+      !currentEntryNoteId ||
+      !titleFocusRequest ||
+      titleFocusRequest.bridgeId !== currentEntryBridgeId ||
+      titleFocusRequest.noteId !== currentEntryNoteId
+    ) {
+      return;
+    }
+    setEditorMode("edit");
+    const handledRequest = titleFocusRequest;
+    const focusTimer = window.setTimeout(() => {
+      const titleInput = titleInputRef.current;
+      if (!titleInput || titleInput.disabled) {
+        onTitleFocusRequestHandled?.(handledRequest);
+        return;
+      }
+      titleInput.focus();
+      titleInput.select();
+      onTitleFocusRequestHandled?.(handledRequest);
+    }, 0);
+    return () => window.clearTimeout(focusTimer);
+  }, [
+    currentEntryBridgeId,
+    currentEntryNoteId,
+    onTitleFocusRequestHandled,
+    setEditorMode,
+    titleFocusRequest,
+  ]);
 
   useEffect(() => {
     if (!entry) {
@@ -6585,6 +6649,7 @@ export function NoteEditor({
         </div>
       ) : null}
       <input
+        ref={titleInputRef}
         className="note-title-input"
         value={title}
         onChange={(event) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -108,7 +108,7 @@ import {
   supportsNotes,
   updateNote,
 } from "./notes";
-import type { NotesListResponse, PaneNote } from "./notes";
+import type { NoteAttachment, NotesListResponse, PaneNote } from "./notes";
 import { ActionMenu, ConfirmDialog, RenameDialog, useLongPress } from "./overlays";
 import type { MenuItem } from "./overlays";
 import { createSnapshotRefreshController } from "./refreshCoordinator";
@@ -194,6 +194,13 @@ type BridgeNotesState = {
   response: NotesListResponse | null;
   loadState: LoadState;
   error: string | null;
+};
+type PendingCreatedPaneNoteTarget = {
+  note: PaneNote;
+  pane: PaneInfo;
+};
+type PendingCreatedPaneNote = PendingCreatedPaneNoteTarget & {
+  connectionKey: string;
 };
 type BridgeAgentPinsState = {
   connectionKey: string;
@@ -796,6 +803,7 @@ export function App() {
     initialPrefs.notesListPaneCollapsed,
   );
   const notesEnabledRef = useRef(initialPrefs.notesEnabled);
+  const pendingCreatedPaneNotesRef = useRef<Record<string, PendingCreatedPaneNote[]>>({});
   const [notesEnabled, setNotesEnabledState] = useState(initialPrefs.notesEnabled);
   const setNotesEnabled = useCallback((enabled: boolean) => {
     notesEnabledRef.current = enabled;
@@ -1049,6 +1057,20 @@ export function App() {
       menuRuntime.capabilityState === "ready" &&
       supportsAgentPins(menuRuntime.capabilities),
   );
+  const menuNotesSupported = canAddNoteFromPaneMenu({
+    kind: menu?.kind ?? "space",
+    notesEnabled,
+    runtimeCanConnect: menuRuntime?.canConnect === true,
+    capabilityState: menuRuntime?.capabilityState ?? "idle",
+    notesSupported: supportsNotes(menuRuntime?.capabilities),
+    runtimeConnectionKey: menuRuntime?.connectionKey ?? "",
+    stateConnectionKey: menuConnectionState?.connectionKey ?? null,
+    paneExists: Boolean(
+      menu &&
+        menu.kind === "pane" &&
+        menuConnectionState?.snapshot?.panes.some((pane) => pane.pane_id === menu.id),
+    ),
+  });
   const menuPinLabel = menu?.pinLabel ?? "pane";
   const menuPanePinned = menu
     ? isAgentPinned(pinnedAgentKeys, menu.bridgeId, menu.id)
@@ -1061,6 +1083,7 @@ export function App() {
         menuAgentPinsSupported,
         menuPanePinned,
         menuPinLabel,
+        menuNotesSupported,
       )
     : [];
 
@@ -1326,6 +1349,7 @@ export function App() {
     setNotesPanelOpen(false);
     setSelectedNoteRef(null);
     setNotesStates({});
+    pendingCreatedPaneNotesRef.current = {};
     if (sidebarView === "notes") {
       setSidebarView("agents");
     }
@@ -1460,6 +1484,19 @@ export function App() {
 
   useEffect(() => {
     const activeBridgeIds = new Set(bridge.enabledRuntimes.map((runtime) => runtime.id));
+    const activeConnectionKeysByBridgeId = new Map(
+      bridge.enabledRuntimes.map((runtime) => [runtime.id, runtime.connectionKey]),
+    );
+
+    for (const [bridgeId, entries] of Object.entries(pendingCreatedPaneNotesRef.current)) {
+      const activeConnectionKey = activeConnectionKeysByBridgeId.get(bridgeId);
+      const nextEntries = entries.filter((entry) => entry.connectionKey === activeConnectionKey);
+      if (nextEntries.length > 0) {
+        pendingCreatedPaneNotesRef.current[bridgeId] = nextEntries;
+      } else {
+        delete pendingCreatedPaneNotesRef.current[bridgeId];
+      }
+    }
 
     for (const bridgeId of Object.keys(connectionRefs.current)) {
       if (!activeBridgeIds.has(bridgeId)) {
@@ -1955,6 +1992,157 @@ export function App() {
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Could not create note");
     }
+  };
+
+  const setPendingCreatedPaneNotesForConnection = (
+    bridgeId: BridgeId,
+    connectionKey: string,
+    entries: readonly PendingCreatedPaneNoteTarget[],
+  ) => {
+    const current = pendingCreatedPaneNotesRef.current[bridgeId] ?? [];
+    const next = [
+      ...current.filter((entry) => entry.connectionKey !== connectionKey),
+      ...entries.map((entry) => ({ ...entry, connectionKey })),
+    ].slice(-MAX_PENDING_CREATED_PANE_NOTES);
+    if (next.length > 0) {
+      pendingCreatedPaneNotesRef.current[bridgeId] = next;
+    } else {
+      delete pendingCreatedPaneNotesRef.current[bridgeId];
+    }
+  };
+
+  const rememberPendingCreatedPaneNote = (
+    bridgeId: BridgeId,
+    connectionKey: string,
+    note: PaneNote,
+    pane: PaneInfo,
+  ) => {
+    const current = pendingCreatedPaneNotesRef.current[bridgeId] ?? [];
+    setPendingCreatedPaneNotesForConnection(
+      bridgeId,
+      connectionKey,
+      [
+        ...current.filter(
+          (entry) => entry.connectionKey === connectionKey && entry.note.note_id !== note.note_id,
+        ),
+        { note, pane },
+      ],
+    );
+  };
+
+  const mergePendingCreatedPaneNotesForResponse = (
+    bridgeId: BridgeId,
+    connectionKey: string,
+    response: NotesListResponse,
+  ) => {
+    const pending = (pendingCreatedPaneNotesRef.current[bridgeId] ?? []).filter(
+      (entry) => entry.connectionKey === connectionKey,
+    );
+    if (pending.length === 0) {
+      return response;
+    }
+    const merged = mergePendingPaneNotesIntoList(response.notes, pending);
+    setPendingCreatedPaneNotesForConnection(bridgeId, connectionKey, merged.pending);
+    return {
+      ...response,
+      notes: merged.notes,
+    };
+  };
+
+  const createNoteForPaneTarget = async (bridgeId: BridgeId, paneId: string) => {
+    if (!notesEnabled) {
+      setError("Notes are disabled in settings");
+      return;
+    }
+    const runtime = bridge.getRuntime(bridgeId);
+    if (
+      !runtime ||
+      !runtime.canConnect ||
+      runtime.capabilityState !== "ready" ||
+      !supportsNotes(runtime.capabilities)
+    ) {
+      setError("Notes are not available for this bridge");
+      return;
+    }
+    const requestConnectionKey = runtime.connectionKey;
+    const isCurrentConnection = () => {
+      const currentRuntime = bridge.getRuntime(bridgeId);
+      return Boolean(
+        notesEnabledRef.current &&
+          currentRuntime?.connectionKey === requestConnectionKey &&
+          isConnectionResultCurrent(
+            connectionRefs.current[bridgeId]?.connectionKey ?? "",
+            requestConnectionKey,
+          ),
+      );
+    };
+    const bridgeSnapshot = snapshotForBridge(bridgeId);
+    const targetPane = bridgeSnapshot?.panes.find((pane) => pane.pane_id === paneId) ?? null;
+    if (!targetPane) {
+      setError("Pane not found");
+      return;
+    }
+
+    openPane(bridgeId, targetPane);
+    setNotesPanelOpen(true);
+    if (isCompactLayout) {
+      setMobileNotesScreen("editor");
+    }
+
+    try {
+      const note = await createNote(runtime.httpUrl, {
+        title: "Untitled note",
+        body: "",
+        paneId: targetPane.pane_id,
+      });
+      const response = await refreshBridgeNotes(runtime, false);
+      if (!isCurrentConnection()) {
+        return;
+      }
+      if (!response || !noteListContainsId(response.notes, note.note_id)) {
+        mergeCreatedPaneNote(bridgeId, requestConnectionKey, note, targetPane, Boolean(response));
+      }
+      setSelectedNoteRef({ bridgeId, noteId: note.note_id });
+      setError(null);
+    } catch (caught) {
+      if (isCurrentConnection()) {
+        setError(caught instanceof Error ? caught.message : "Could not create note");
+      }
+    }
+  };
+
+  const mergeCreatedPaneNote = (
+    bridgeId: BridgeId,
+    connectionKey: string,
+    note: PaneNote,
+    pane: PaneInfo,
+    refreshSucceeded: boolean,
+  ) => {
+    rememberPendingCreatedPaneNote(bridgeId, connectionKey, note, pane);
+    setNotesStates((current) => {
+      const state = current[bridgeId];
+      if (state && state.connectionKey !== connectionKey) {
+        return current;
+      }
+      const response = state?.response ?? {
+        store_id: `${bridgeId}:optimistic`,
+        session_key: note.session_key,
+        notes: [],
+      };
+      const notes = mergeCreatedPaneNoteList(response.notes, note, pane);
+      return {
+        ...current,
+        [bridgeId]: {
+          connectionKey,
+          response: {
+            ...response,
+            notes,
+          },
+          loadState: refreshSucceeded ? "ready" : (state?.loadState ?? "ready"),
+          error: refreshSucceeded ? null : (state?.error ?? null),
+        },
+      };
+    });
   };
 
   const saveScopedNote = async (
@@ -2640,6 +2828,14 @@ export function App() {
       if (!notesEnabledRef.current) {
         return null;
       }
+      if (!isCurrentConnection()) {
+        return null;
+      }
+      const effectiveResponse = mergePendingCreatedPaneNotesForResponse(
+        runtime.id,
+        requestConnectionKey,
+        response,
+      );
       setNotesStates((current) => {
         if (!isCurrentConnection()) {
           return current;
@@ -2648,13 +2844,13 @@ export function App() {
           ...current,
           [runtime.id]: {
             connectionKey: requestConnectionKey,
-            response,
+            response: effectiveResponse,
             loadState: "ready",
             error: null,
           },
         };
       });
-      return response;
+      return effectiveResponse;
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : "Notes unavailable";
       if (!notesEnabledRef.current) {
@@ -2833,6 +3029,8 @@ export function App() {
       void toggleAgentPin(bridgeId, id, false);
     } else if (key === "unpin" && kind === "pane") {
       void toggleAgentPin(bridgeId, id, true);
+    } else if (key === "add_note" && kind === "pane") {
+      void createNoteForPaneTarget(bridgeId, id);
     } else if (key === "move_new_tab" && kind === "pane") {
       const pane = connectionRefs.current[bridgeId]?.snapshot?.panes.find(
         (item) => item.pane_id === id,
@@ -3514,6 +3712,7 @@ export function App() {
 
 const SNAPSHOT_REFRESH_INTERVAL_MS = 10000;
 const NOTES_REFRESH_INTERVAL_MS = 15000;
+const MAX_PENDING_CREATED_PANE_NOTES = 32;
 const NOTE_DRAFT_STORAGE_PREFIX = "herdr-web:note-draft:v1:";
 const NOTE_EDITOR_MODE_STORAGE_KEY = "herdr-web:note-editor-mode:v1";
 
@@ -6817,6 +7016,105 @@ export function shouldShowLastStatusChangeSort(
   return agentActivitySupported || agentSort === "lastStatusChange";
 }
 
+export function canAddNoteFromPaneMenu({
+  kind,
+  notesEnabled,
+  runtimeCanConnect,
+  capabilityState,
+  notesSupported,
+  runtimeConnectionKey,
+  stateConnectionKey,
+  paneExists,
+}: {
+  kind: MenuKind;
+  notesEnabled: boolean;
+  runtimeCanConnect: boolean;
+  capabilityState: BridgeRuntime["capabilityState"];
+  notesSupported: boolean;
+  runtimeConnectionKey: string | null | undefined;
+  stateConnectionKey: string | null | undefined;
+  paneExists: boolean;
+}) {
+  return Boolean(
+    kind === "pane" &&
+      notesEnabled &&
+      runtimeCanConnect &&
+      capabilityState === "ready" &&
+      notesSupported &&
+      runtimeConnectionKey &&
+      stateConnectionKey === runtimeConnectionKey &&
+      paneExists,
+  );
+}
+
+export function paneNoteListContains(
+  notes: readonly PaneNote[],
+  pane: PaneInfo,
+  noteId: string,
+) {
+  return notesForPane(notes, pane.pane_id).some((note) => note.note_id === noteId);
+}
+
+function noteListContainsId(notes: readonly PaneNote[], noteId: string) {
+  return notes.some((note) => note.note_id === noteId);
+}
+
+export function mergeCreatedPaneNoteList(
+  notes: readonly PaneNote[],
+  note: PaneNote,
+  pane: PaneInfo,
+) {
+  const sourceNote = notes.find((item) => item.note_id === note.note_id) ?? note;
+  const linkedNote = resolveCreatedPaneNoteForTarget(sourceNote, pane);
+  return [linkedNote, ...notes.filter((item) => item.note_id !== linkedNote.note_id)].sort(
+    compareNotes,
+  );
+}
+
+export function mergePendingPaneNotesIntoList(
+  notes: readonly PaneNote[],
+  pending: readonly PendingCreatedPaneNoteTarget[],
+) {
+  let mergedNotes = [...notes];
+  const remaining: PendingCreatedPaneNoteTarget[] = [];
+  for (const entry of pending) {
+    // Once the server returns the note id, its current link state is authoritative.
+    if (noteListContainsId(mergedNotes, entry.note.note_id)) {
+      continue;
+    }
+    mergedNotes = mergeCreatedPaneNoteList(mergedNotes, entry.note, entry.pane);
+    remaining.push(entry);
+  }
+  return {
+    notes: mergedNotes,
+    pending: remaining,
+  };
+}
+
+export function resolveCreatedPaneNoteForTarget(note: PaneNote, pane: PaneInfo): PaneNote {
+  const existingAttachment = note.attachment?.type === "pane" ? note.attachment : null;
+  const attachment: NoteAttachment = {
+    type: "pane",
+    pane_id: pane.pane_id,
+    workspace_id: pane.workspace_id,
+    tab_id: pane.tab_id,
+    terminal_id: pane.terminal_id,
+    pane_revision: pane.revision,
+    captured_at: existingAttachment?.captured_at ?? note.created_at,
+    context: existingAttachment?.context ?? {},
+  };
+  if (existingAttachment?.observed_generation) {
+    attachment.observed_generation = existingAttachment.observed_generation;
+  }
+  return {
+    ...note,
+    attachment,
+    attachment_history: note.attachment_history ?? [],
+    link_state: "linked",
+    resolved_pane: pane,
+  };
+}
+
 function compareLastStatusTransition(a: ScopedAgentPane, b: ScopedAgentPane) {
   // Values are bridge-observed wall-clock times. Across hosts, clock skew can
   // affect exact ordering, so existing bridge/workspace fallback order remains
@@ -6887,6 +7185,7 @@ export function menuItems(
   agentPinsSupported = false,
   panePinned = false,
   pinLabel: "agent" | "pane" = "pane",
+  notesSupported = false,
 ): MenuItem[] {
   if (kind === "space") {
     if (!commandsReady) {
@@ -6914,6 +7213,9 @@ export function menuItems(
       key: panePinned ? "unpin" : "pin",
       label: panePinned ? `Unpin ${target}` : `Pin ${target}`,
     });
+  }
+  if (notesSupported) {
+    paneItems.push({ key: "add_note", label: "Add note" });
   }
   if (!commandsReady) {
     return paneItems;

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -4,7 +4,12 @@
 import { act, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BridgeConnectionController, NoteEditor, noteDraftStorageKey } from "./App";
+import {
+  BridgeConnectionController,
+  NoteEditor,
+  QuickPaneNoteDialog,
+  noteDraftStorageKey,
+} from "./App";
 import type { BridgeConnectionRef, BridgeConnectionState, ScopedNoteEntry } from "./App";
 import type { BridgeRuntime } from "./bridge";
 
@@ -65,6 +70,57 @@ describe("BridgeConnectionController sockets", () => {
 
     expect(FakeWebSocket.instances).toHaveLength(3);
     expect(FakeWebSocket.instances.filter((socket) => socket.closed)).toHaveLength(0);
+  });
+});
+
+describe("QuickPaneNoteDialog", () => {
+  it("selects the title and submits an optional body", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    const onSubmit = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <QuickPaneNoteDialog
+          targetLabel="Pinned Indicator"
+          onCancel={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+    });
+
+    const titleInput = container.querySelector<HTMLInputElement>("input.field");
+    if (!titleInput) {
+      throw new Error("missing quick note title input");
+    }
+    expect(document.activeElement).toBe(titleInput);
+    expect(titleInput.selectionStart).toBe(0);
+    expect(titleInput.selectionEnd).toBe(titleInput.value.length);
+    const createButton = buttonByText(container, "Create");
+
+    await act(async () => {
+      createButton.click();
+    });
+    expect(onSubmit).toHaveBeenLastCalledWith("Untitled note", "");
+
+    await act(async () => {
+      buttonByText(container, "Add body").click();
+    });
+    const bodyInput = container.querySelector<HTMLTextAreaElement>(".quick-note-body");
+    if (!bodyInput) {
+      throw new Error("missing quick note body input");
+    }
+    expect(document.activeElement).toBe(bodyInput);
+    await act(async () => {
+      setNativeValue(bodyInput, "Follow-up details");
+      bodyInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      buttonByText(container, "Create").click();
+    });
+    expect(onSubmit).toHaveBeenLastCalledWith("Untitled note", "Follow-up details");
   });
 });
 

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -261,6 +261,38 @@ describe("NoteEditor actions", () => {
     expect(container.querySelector(".note-body-preview strong")?.textContent).toBe("bold");
   });
 
+  it("forces edit mode and selects the title for note title focus requests", async () => {
+    localStorage.setItem("herdr-web:note-editor-mode:v1", "preview");
+    const onSave = vi.fn(() => Promise.resolve(2));
+    const { container, render } = createEditorHarness(onSave);
+
+    await render(
+      noteEntry({
+        noteId: "note-new",
+        revision: 1,
+        title: "Untitled note",
+        body: "",
+      }),
+      {
+        titleFocusRequest: {
+          bridgeId: "bridge-a",
+          noteId: "note-new",
+          token: 1,
+        },
+      },
+    );
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+
+    const titleInput = noteTitleInput(container);
+    expect(noteBodyInput(container).value).toBe("");
+    expect(document.activeElement).toBe(titleInput);
+    expect(titleInput.selectionStart).toBe(0);
+    expect(titleInput.selectionEnd).toBe(titleInput.value.length);
+    expect(localStorage.getItem("herdr-web:note-editor-mode:v1")).toBe("edit");
+  });
+
   it("escapes raw HTML, blocks remote images, and restricts markdown links", async () => {
     const onSave = vi.fn(() => Promise.resolve(6));
     const { container, render } = createEditorHarness(onSave);
@@ -344,6 +376,11 @@ function createEditorHarness(
     entry: ScopedNoteEntry,
     options: {
       showCurrentPaneViewAction?: boolean;
+      titleFocusRequest?: {
+        bridgeId: string;
+        noteId: string;
+        token: number;
+      };
       onSave?: (
         entry: ScopedNoteEntry,
         title: string,
@@ -358,6 +395,7 @@ function createEditorHarness(
           entry={entry}
           currentBridgeId="bridge-a"
           currentPaneId="pane-a"
+          titleFocusRequest={options.titleFocusRequest}
           canAttachToCurrentPane
           showCurrentPaneViewAction={options.showCurrentPaneViewAction}
           onSave={options.onSave ?? onSave}
@@ -462,6 +500,14 @@ function noteBodyInput(container: HTMLElement) {
   const input = container.querySelector<HTMLTextAreaElement>(".note-body-input");
   if (!input) {
     throw new Error("missing note body input");
+  }
+  return input;
+}
+
+function noteTitleInput(container: HTMLElement) {
+  const input = container.querySelector<HTMLInputElement>(".note-title-input");
+  if (!input) {
+    throw new Error("missing note title input");
   }
   return input;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2265,6 +2265,26 @@ button {
   color: var(--subtext0);
 }
 
+.quick-note-modal {
+  width: min(420px, 100%);
+}
+
+.quick-note-target {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.quick-note-expand {
+  align-self: flex-start;
+}
+
+.quick-note-body {
+  min-height: 112px;
+  resize: vertical;
+  line-height: 1.45;
+}
+
 .launch-modal {
   width: min(420px, 100%);
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -507,6 +507,15 @@ button {
   transition: background 120ms ease, border-color 120ms ease;
 }
 
+.space-row,
+.pane-row,
+.tab-head,
+.tabbar-tab {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 .space-row:hover {
   background: var(--row-hover);
 }


### PR DESCRIPTION
## Summary
- add an Add note action to eligible pane and agent sidebar context menus
- create notes against the row pane/bridge, switch to that pane, and open the notes editor
- preserve newly created notes through lagging notes refreshes until the server returns the note id

## Verification
- npm run check
- subagent code review
- keel iterative-review workflow clean after follow-up cycles
