### PR TITLE
Repo-wide review: bug fixes, bridge hardening, and dedup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ This is a lightweight internal onboarding note for agents working in this repo.
 - Run `npm run lint:web` for ESLint.
 - Run `npm run test:web` for Vitest.
 - Run `npm run build:web` for the frontend production build.
-- Run `npm run bridge:test` for bridge unit tests when Zig is available.
+- Run `npm run bridge:test` for bridge unit tests when a Rust toolchain (cargo) is available.
 - Run `npm run check` before committing or releasing.
-- If Zig is missing, call out that bridge build/test verification could not run.
+- If cargo/Rust is missing, call out that bridge build/test verification could not run.
 
 ## Build And Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@
 
 ### Fixed
 
+- Kept the selected note open while no pane is selected, so notes no longer deselect mid-edit when
+  a bridge disconnects, has zero panes, or a notes refresh lands.
+- Made Escape in settings number fields discard the typed value instead of committing it, and stop
+  it from closing the whole settings dialog; out-of-range numbers now snap back to the clamped
+  value in the field.
+- Reordered Android hardware-back handling so open menus and dialogs close before the notes panel
+  underneath them.
+- Made Escape cancel the rename dialog from any focused control, not just the text input.
+- Extended long-press text-selection prevention to the stage header pane title.
+- Restored the intended drop shadow and muted URL color on the terminal selection sheet, which
+  referenced undefined CSS variables.
+- Validated agent-pins responses at the fetch boundary so a malformed bridge response degrades
+  gracefully instead of crashing the sidebar render.
 - Prevented sidebar row labels and terminal tab labels from being text-selected during long-press
   context-menu gestures.
 - Added Mobile settings for an expanding terminal command input and Enter-as-newline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 - Unified the `session_key` reported by `/api/agent-activity` with the notes and agent-pins
   endpoints (`session:default` and FNV-1a socket hashes instead of a divergent local format).
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Extended the pinned-only sidebar toggle to the Tabs view so pinned panes can be found outside the
   Agents view. [PR #23](https://github.com/kcosr/herdr-web/pull/23)
 - Notes created from the notes panel now open in Edit mode with the title selected, so the default
@@ -41,37 +42,53 @@
 
 - Made the bridge close and cleanly reattach terminal sockets that fall behind fast output instead
   of silently dropping frames and corrupting the rendered stream.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Moved the bridge's remaining blocking daemon round-trips (snapshot, selection, agent activity,
   rename-label lookups) off async worker threads, so a stalled daemon no longer freezes unrelated
   requests and terminal websockets.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Bounded the bridge's per-terminal input queue so a client sending faster than the pty drains no
   longer grows bridge memory without limit.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Fixed terminal session races where a client connecting while the previous one disconnected could
   be handed an already-detached session, and where the daemon handshake blocked all other terminal
   clients.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Stopped the bridge from silently tightening permissions on a pre-existing operator-supplied
   `--upload-dir`; only directories the bridge creates itself are set to 0700.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Applied the standard 120-byte label validation to `pane.rename` requests, matching every other
   rename/create command.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Stopped a cancelled terminal mount from leaking an orphaned renderer and duplicated canvas when
   the pane changes while the terminal module is still loading.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Made single-cell touch selections highlight correctly instead of silently storing a wrong
   scrollback row.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Preserved combining characters and multi-codepoint emoji when copying terminal text via touch
   selection.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Kept the selected note open while no pane is selected, so notes no longer deselect mid-edit when
   a bridge disconnects, has zero panes, or a notes refresh lands.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Made Escape in settings number fields discard the typed value instead of committing it, and stop
   it from closing the whole settings dialog; out-of-range numbers now snap back to the clamped
   value in the field.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Reordered Android hardware-back handling so open menus and dialogs close before the notes panel
   underneath them.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Made Escape cancel the rename dialog from any focused control, not just the text input.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Extended long-press text-selection prevention to the stage header pane title.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Restored the intended drop shadow and muted URL color on the terminal selection sheet, which
   referenced undefined CSS variables.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Validated agent-pins responses at the fetch boundary so a malformed bridge response degrades
   gracefully instead of crashing the sidebar render.
+  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Prevented sidebar row labels and terminal tab labels from being text-selected during long-press
   context-menu gestures.
 - Fixed notes editor selection and autosave edge cases so switching to panes without notes clears

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Extended the pinned-only sidebar toggle to the Tabs view so pinned panes can be found outside the
   Agents view. [PR #23](https://github.com/kcosr/herdr-web/pull/23)
 - Notes created from the notes panel now open in Edit mode with the title selected, so the default
-  title can be replaced immediately.
+  title can be replaced immediately. [PR #24](https://github.com/kcosr/herdr-web/pull/24)
 
 ### Fixed
 
@@ -90,7 +90,7 @@
   gracefully instead of crashing the sidebar render.
   [PR #25](https://github.com/kcosr/herdr-web/pull/25)
 - Prevented sidebar row labels and terminal tab labels from being text-selected during long-press
-  context-menu gestures.
+  context-menu gestures. [PR #24](https://github.com/kcosr/herdr-web/pull/24)
 - Fixed notes editor selection and autosave edge cases so switching to panes without notes clears
   the editor, deleting the selected note no longer shows a deleted note, and stale local save
   refreshes do not appear as external note changes. Also fixed mobile delete-dialog back handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 ### Changed
 
+- Unified the `session_key` reported by `/api/agent-activity` with the notes and agent-pins
+  endpoints (`session:default` and FNV-1a socket hashes instead of a divergent local format).
 - Extended the pinned-only sidebar toggle to the Tabs view so pinned panes can be found outside the
   Agents view. [PR #23](https://github.com/kcosr/herdr-web/pull/23)
 - Notes created from the notes panel now open in Edit mode with the title selected, so the default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@
 
 ### Added
 
-- Added an `Add note` action to pane and agent sidebar context menus, creating a new note attached
-  to the target pane and opening it in the notes editor.
+- Added an `Add note` action to pane and agent sidebar context menus, opening a quick-create
+  dialog with a focused title and optional body that attaches the new note to the target pane.
   [PR #24](https://github.com/kcosr/herdr-web/pull/24)
+- Added Mobile settings for an expanding terminal command input and Enter-as-newline
+  editing, allowing long prompts to wrap and remain viewable while preserving send-on-Enter
+  by default. [PR #21](https://github.com/kcosr/herdr-web/pull/21)
 - Added bridge-tracked agent status transition activity with an Agents view sort option for
   `Last status change`, using semantic status changes rather than terminal output activity.
   [PR #23](https://github.com/kcosr/herdr-web/pull/23)
@@ -28,9 +31,7 @@
 ### Changed
 
 - Extended the pinned-only sidebar toggle to the Tabs view so pinned panes can be found outside the
-  Agents view.
-- Pane context menu `Add note` now opens a quick-create dialog with a focused title and optional body
-  instead of switching to the notes panel.
+  Agents view. [PR #23](https://github.com/kcosr/herdr-web/pull/23)
 - Notes created from the notes panel now open in Edit mode with the title selected, so the default
   title can be replaced immediately.
 
@@ -71,9 +72,6 @@
   gracefully instead of crashing the sidebar render.
 - Prevented sidebar row labels and terminal tab labels from being text-selected during long-press
   context-menu gestures.
-- Added Mobile settings for an expanding terminal command input and Enter-as-newline
-  editing, allowing long prompts to wrap and remain viewable while preserving send-on-Enter
-  by default. [PR #21](https://github.com/kcosr/herdr-web/pull/21)
 - Fixed notes editor selection and autosave edge cases so switching to panes without notes clears
   the editor, deleting the selected note no longer shows a deleted note, and stale local save
   refreshes do not appear as external note changes. Also fixed mobile delete-dialog back handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@
 
 ### Fixed
 
+- Made the bridge close and cleanly reattach terminal sockets that fall behind fast output instead
+  of silently dropping frames and corrupting the rendered stream.
+- Moved the bridge's remaining blocking daemon round-trips (snapshot, selection, agent activity,
+  rename-label lookups) off async worker threads, so a stalled daemon no longer freezes unrelated
+  requests and terminal websockets.
+- Bounded the bridge's per-terminal input queue so a client sending faster than the pty drains no
+  longer grows bridge memory without limit.
+- Fixed terminal session races where a client connecting while the previous one disconnected could
+  be handed an already-detached session, and where the daemon handshake blocked all other terminal
+  clients.
+- Stopped the bridge from silently tightening permissions on a pre-existing operator-supplied
+  `--upload-dir`; only directories the bridge creates itself are set to 0700.
+- Applied the standard 120-byte label validation to `pane.rename` requests, matching every other
+  rename/create command.
 - Stopped a cancelled terminal mount from leaking an orphaned renderer and duplicated canvas when
   the pane changes while the terminal module is still loading.
 - Made single-cell touch selections highlight correctly instead of silently storing a wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
 
 ### Fixed
 
+- Stopped a cancelled terminal mount from leaking an orphaned renderer and duplicated canvas when
+  the pane changes while the terminal module is still loading.
+- Made single-cell touch selections highlight correctly instead of silently storing a wrong
+  scrollback row.
+- Preserved combining characters and multi-codepoint emoji when copying terminal text via touch
+  selection.
 - Kept the selected note open while no pane is selected, so notes no longer deselect mid-edit when
   a bridge disconnects, has zero panes, or a notes refresh lands.
 - Made Escape in settings number fields discard the typed value instead of committing it, and stop

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ for HTTP/cleartext behavior, Android SDK setup, and APK verification notes.
 Settings are grouped by area:
 
 - Bridge: same-origin and saved bridge profiles, reachability testing, and bridge enablement.
+- Features: client feature toggles such as Notes.
+- Display: top/bottom app padding and mobile terminal controls size.
 - Terminal: browser-to-bridge terminal input transport and input batching delay.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
 
@@ -255,6 +257,8 @@ The bridge exposes:
 - `POST /api/command`: allow-listed workspace/tab/pane commands
 - `POST /api/selection`: bridge-owned selected pane for syncing browser clients
 - `GET /api/notes` and `POST /api/notes...`: bridge-owned pane notes
+- `GET /api/agent-activity`: bridge-tracked agent status transition activity
+- `GET /api/agent-pins` and `POST /api/agent-pins/{pane_id}/pin|unpin`: bridge-owned agent pins
 - `POST /api/uploads`: save uploaded files into the configured upload directory
 - `GET /ws/activity`: bridge-owned pane activity deltas
 - `GET /ws/events`: Herdr structural events

--- a/bridge/src/agent_activity.rs
+++ b/bridge/src/agent_activity.rs
@@ -1,11 +1,11 @@
 use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use herdr_compat::api::schema::{AgentStatus, PaneInfo};
 use serde::Serialize;
+
+use crate::store_util::session_key;
 
 const STARTUP_ACTIVITY_BASELINE_GRACE_MS: u128 = 1_000;
 
@@ -268,26 +268,6 @@ fn now_ms() -> u128 {
 
 fn ms_string(value: u128) -> String {
     value.to_string()
-}
-
-fn session_key() -> String {
-    if let Some(name) = crate::session::active_name() {
-        return format!("session:{name}");
-    }
-    if let Ok(path) = std::env::var(herdr_compat::api::SOCKET_PATH_ENV_VAR) {
-        if !path.is_empty() && !crate::session::explicit_session_requested() {
-            let canonical = fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(path));
-            return format!("socket:{:016x}", stable_path_hash(&canonical));
-        }
-    }
-    "default".to_string()
-}
-
-fn stable_path_hash(path: &std::path::Path) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    path.hash(&mut hasher);
-    hasher.finish()
 }
 
 #[cfg(test)]

--- a/bridge/src/agent_pins.rs
+++ b/bridge/src/agent_pins.rs
@@ -1,11 +1,15 @@
 use std::collections::HashSet;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{self, ErrorKind, Write};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use herdr_compat::api::schema::PaneInfo;
 use serde::{Deserialize, Serialize};
+
+use crate::store_util::{
+    copy_corrupt_once, default_store_dir, ensure_private_dir, now_ms_string, session_key,
+    set_private_file_permissions, LockFile,
+};
 
 const AGENT_PINS_STORE_VERSION: u32 = 1;
 const MAX_AGENT_PIN_RECORDS: usize = 1_000;
@@ -313,176 +317,12 @@ fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<(), AgentPi
     Ok(())
 }
 
-fn copy_corrupt_once(path: &Path) {
-    if corrupt_copy_exists(path) {
-        return;
-    }
-    let Ok(bytes) = fs::read(path) else {
-        return;
-    };
-    let corrupt_path = path.with_extension(format!("{}.corrupt", now_ms_string()));
-    if fs::write(&corrupt_path, bytes).is_ok() {
-        let _ = set_private_file_permissions(&corrupt_path);
-    }
-}
-
-fn corrupt_copy_exists(path: &Path) -> bool {
-    let Some(parent) = path.parent() else {
-        return false;
-    };
-    let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
-        return false;
-    };
-    let Ok(entries) = fs::read_dir(parent) else {
-        return false;
-    };
-    let prefix = format!("{stem}.");
-    entries.flatten().any(|entry| {
-        entry
-            .path()
-            .file_name()
-            .and_then(|value| value.to_str())
-            .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".corrupt"))
-    })
-}
-
 fn default_agent_pins_dir() -> PathBuf {
-    if let Some(path) = non_empty_env_path("HERDR_WEB_AGENT_PINS_DIR") {
-        return path;
-    }
-    if let Some(data_home) = non_empty_env_path("XDG_DATA_HOME") {
-        return data_home.join("herdr-web").join("agent-pins");
-    }
-    if let Some(home) = non_empty_env_path("HOME") {
-        return home
-            .join(".local")
-            .join("share")
-            .join("herdr-web")
-            .join("agent-pins");
-    }
-    PathBuf::from("herdr-web-agent-pins")
-}
-
-fn non_empty_env_path(name: &str) -> Option<PathBuf> {
-    std::env::var_os(name)
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-}
-
-fn session_key() -> String {
-    if let Some(name) = crate::session::active_name() {
-        return format!("session:{name}");
-    }
-    if let Ok(path) = std::env::var(herdr_compat::api::SOCKET_PATH_ENV_VAR) {
-        if !path.is_empty() && !crate::session::explicit_session_requested() {
-            let canonical = fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(path));
-            return format!(
-                "socket:{:016x}",
-                stable_hash(canonical.to_string_lossy().as_ref())
-            );
-        }
-    }
-    "session:default".to_string()
-}
-
-fn stable_hash(value: &str) -> u64 {
-    let mut hash = 0xcbf29ce484222325u64;
-    for byte in value.as_bytes() {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x100000001b3);
-    }
-    hash
-}
-
-fn now_ms_string() -> String {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-        .to_string()
-}
-
-fn ensure_private_dir(path: &Path) -> io::Result<()> {
-    fs::create_dir_all(path)?;
-    set_private_dir_permissions(path)
-}
-
-#[cfg(unix)]
-fn set_private_dir_permissions(path: &Path) -> io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
-}
-
-#[cfg(not(unix))]
-fn set_private_dir_permissions(_path: &Path) -> io::Result<()> {
-    Ok(())
-}
-
-fn set_private_file_permissions(path: &Path) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-    }
-    Ok(())
-}
-
-struct LockFile {
-    file: File,
-}
-
-impl LockFile {
-    fn exclusive(path: &Path) -> io::Result<Self> {
-        if let Some(parent) = path.parent() {
-            ensure_private_dir(parent)?;
-        }
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(path)?;
-        set_private_file_permissions(path)?;
-        lock_file(&file)?;
-        Ok(Self { file })
-    }
-}
-
-impl Drop for LockFile {
-    fn drop(&mut self) {
-        let _ = unlock_file(&self.file);
-    }
-}
-
-#[cfg(unix)]
-fn lock_file(file: &File) -> io::Result<()> {
-    use std::os::fd::AsRawFd;
-    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-#[cfg(not(unix))]
-fn lock_file(_file: &File) -> io::Result<()> {
-    Ok(())
-}
-
-#[cfg(unix)]
-fn unlock_file(file: &File) -> io::Result<()> {
-    use std::os::fd::AsRawFd;
-    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-#[cfg(not(unix))]
-fn unlock_file(_file: &File) -> io::Result<()> {
-    Ok(())
+    default_store_dir(
+        "HERDR_WEB_AGENT_PINS_DIR",
+        "agent-pins",
+        "herdr-web-agent-pins",
+    )
 }
 
 #[cfg(test)]
@@ -491,6 +331,8 @@ mod tests {
     use std::collections::HashMap;
 
     use herdr_compat::api::schema::AgentStatus;
+
+    use crate::store_util::corrupt_copy_exists;
 
     #[test]
     fn list_returns_current_session_matching_open_pins() {

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -2,6 +2,7 @@ mod agent_activity;
 mod agent_pins;
 mod notes;
 mod session;
+mod store_util;
 mod web_bridge;
 mod workspace;
 

--- a/bridge/src/notes.rs
+++ b/bridge/src/notes.rs
@@ -1,11 +1,15 @@
 use std::collections::HashSet;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{self, ErrorKind, Write};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use herdr_compat::api::schema::PaneInfo;
 use serde::{Deserialize, Serialize};
+
+use crate::store_util::{
+    copy_corrupt_once, default_store_dir, ensure_private_dir, now_ms_string, session_key,
+    set_private_file_permissions, LockFile,
+};
 
 const NOTES_STORE_VERSION: u32 = 1;
 const OBSERVATION_STORE_VERSION: u32 = 1;
@@ -1002,175 +1006,8 @@ fn backup_existing_file(path: &Path) {
     }
 }
 
-fn copy_corrupt_once(path: &Path) {
-    if corrupt_copy_exists(path) {
-        return;
-    }
-    let Ok(bytes) = fs::read(path) else {
-        return;
-    };
-    let corrupt_path = path.with_extension(format!("{}.corrupt", now_ms_string()));
-    if fs::write(&corrupt_path, bytes).is_ok() {
-        let _ = set_private_file_permissions(&corrupt_path);
-    }
-}
-
-fn corrupt_copy_exists(path: &Path) -> bool {
-    let Some(parent) = path.parent() else {
-        return false;
-    };
-    let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
-        return false;
-    };
-    let Ok(entries) = fs::read_dir(parent) else {
-        return false;
-    };
-    let prefix = format!("{stem}.");
-    entries.flatten().any(|entry| {
-        entry
-            .file_name()
-            .to_str()
-            .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".corrupt"))
-    })
-}
-
 fn default_notes_dir() -> PathBuf {
-    if let Some(path) = non_empty_env_path("HERDR_WEB_NOTES_DIR") {
-        return path;
-    }
-    if let Some(data_home) = non_empty_env_path("XDG_DATA_HOME") {
-        return data_home.join("herdr-web").join("notes");
-    }
-    if let Some(home) = non_empty_env_path("HOME") {
-        return home
-            .join(".local")
-            .join("share")
-            .join("herdr-web")
-            .join("notes");
-    }
-    PathBuf::from("herdr-web-notes")
-}
-
-fn non_empty_env_path(name: &str) -> Option<PathBuf> {
-    std::env::var_os(name)
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-}
-
-fn session_key() -> String {
-    if let Some(name) = crate::session::active_name() {
-        return format!("session:{name}");
-    }
-    if let Ok(path) = std::env::var(herdr_compat::api::SOCKET_PATH_ENV_VAR) {
-        if !path.is_empty() && !crate::session::explicit_session_requested() {
-            let canonical = fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(path));
-            return format!(
-                "socket:{:016x}",
-                stable_hash(canonical.to_string_lossy().as_ref())
-            );
-        }
-    }
-    "session:default".to_string()
-}
-
-fn stable_hash(value: &str) -> u64 {
-    let mut hash = 0xcbf29ce484222325u64;
-    for byte in value.as_bytes() {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x100000001b3);
-    }
-    hash
-}
-
-fn now_ms_string() -> String {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-        .to_string()
-}
-
-fn ensure_private_dir(path: &Path) -> io::Result<()> {
-    fs::create_dir_all(path)?;
-    set_private_dir_permissions(path)
-}
-
-#[cfg(unix)]
-fn set_private_dir_permissions(path: &Path) -> io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
-}
-
-#[cfg(not(unix))]
-fn set_private_dir_permissions(_path: &Path) -> io::Result<()> {
-    Ok(())
-}
-
-fn set_private_file_permissions(path: &Path) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-    }
-    Ok(())
-}
-
-struct LockFile {
-    file: File,
-}
-
-impl LockFile {
-    fn exclusive(path: &Path) -> io::Result<Self> {
-        if let Some(parent) = path.parent() {
-            ensure_private_dir(parent)?;
-        }
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(path)?;
-        set_private_file_permissions(path)?;
-        lock_file(&file)?;
-        Ok(Self { file })
-    }
-}
-
-impl Drop for LockFile {
-    fn drop(&mut self) {
-        let _ = unlock_file(&self.file);
-    }
-}
-
-#[cfg(unix)]
-fn lock_file(file: &File) -> io::Result<()> {
-    use std::os::unix::io::AsRawFd;
-    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-#[cfg(unix)]
-fn unlock_file(file: &File) -> io::Result<()> {
-    use std::os::unix::io::AsRawFd;
-    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-#[cfg(not(unix))]
-fn lock_file(_file: &File) -> io::Result<()> {
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn unlock_file(_file: &File) -> io::Result<()> {
-    Ok(())
+    default_store_dir("HERDR_WEB_NOTES_DIR", "notes", "herdr-web-notes")
 }
 
 #[cfg(test)]

--- a/bridge/src/store_util.rs
+++ b/bridge/src/store_util.rs
@@ -1,0 +1,178 @@
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) fn default_store_dir(env_var: &str, subdir: &str, fallback: &str) -> PathBuf {
+    if let Some(path) = non_empty_env_path(env_var) {
+        return path;
+    }
+    if let Some(data_home) = non_empty_env_path("XDG_DATA_HOME") {
+        return data_home.join("herdr-web").join(subdir);
+    }
+    if let Some(home) = non_empty_env_path("HOME") {
+        return home
+            .join(".local")
+            .join("share")
+            .join("herdr-web")
+            .join(subdir);
+    }
+    PathBuf::from(fallback)
+}
+
+pub(crate) fn non_empty_env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+pub(crate) fn session_key() -> String {
+    if let Some(name) = crate::session::active_name() {
+        return format!("session:{name}");
+    }
+    if let Ok(path) = std::env::var(herdr_compat::api::SOCKET_PATH_ENV_VAR) {
+        if !path.is_empty() && !crate::session::explicit_session_requested() {
+            let canonical = fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(path));
+            return format!(
+                "socket:{:016x}",
+                stable_hash(canonical.to_string_lossy().as_ref())
+            );
+        }
+    }
+    "session:default".to_string()
+}
+
+pub(crate) fn stable_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+pub(crate) fn now_ms_string() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .to_string()
+}
+
+pub(crate) fn copy_corrupt_once(path: &Path) {
+    if corrupt_copy_exists(path) {
+        return;
+    }
+    let Ok(bytes) = fs::read(path) else {
+        return;
+    };
+    let corrupt_path = path.with_extension(format!("{}.corrupt", now_ms_string()));
+    if fs::write(&corrupt_path, bytes).is_ok() {
+        let _ = set_private_file_permissions(&corrupt_path);
+    }
+}
+
+pub(crate) fn corrupt_copy_exists(path: &Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    let Ok(entries) = fs::read_dir(parent) else {
+        return false;
+    };
+    let prefix = format!("{stem}.");
+    entries.flatten().any(|entry| {
+        entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".corrupt"))
+    })
+}
+
+pub(crate) fn ensure_private_dir(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    set_private_dir_permissions(path)
+}
+
+#[cfg(unix)]
+pub(crate) fn set_private_dir_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+pub(crate) fn set_private_dir_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+pub(crate) fn set_private_file_permissions(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+pub(crate) struct LockFile {
+    file: File,
+}
+
+impl LockFile {
+    pub(crate) fn exclusive(path: &Path) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            ensure_private_dir(parent)?;
+        }
+        // Lock files are flock-only coordination points; existing contents are
+        // never read, so keep them as-is instead of truncating.
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        set_private_file_permissions(path)?;
+        lock_file(&file)?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for LockFile {
+    fn drop(&mut self) {
+        let _ = unlock_file(&self.file);
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn lock_file(file: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn unlock_file(file: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn lock_file(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub(crate) fn unlock_file(_file: &File) -> io::Result<()> {
+    Ok(())
+}

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -1045,6 +1045,8 @@ fn default_upload_dir() -> PathBuf {
     PathBuf::from("herdr-web-uploads")
 }
 
+// Intentionally diverges from `store_util::non_empty_env_path`: upload dir
+// configuration trims whitespace and expands a leading `~`.
 fn non_empty_env_path(name: &str) -> Option<PathBuf> {
     let value = env::var(name).ok()?;
     let trimmed = value.trim();
@@ -1982,7 +1984,7 @@ async fn agent_pins_list_handler(
 ) -> Result<Json<AgentPinsListResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
     Ok(Json(
-        run_agent_pins_task(state, move |state| {
+        run_store_task(state, move |state| {
             let panes = current_panes(&state.api)?;
             Ok(state.agent_pins.list(&panes)?)
         })
@@ -1997,7 +1999,7 @@ async fn agent_pins_pin_handler(
 ) -> Result<Json<AgentPinsListResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
     let event_pane_id = pane_id.clone();
-    let response = run_agent_pins_task(state.clone(), move |state| {
+    let response = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.agent_pins.pin(&pane_id, &panes)?)
     })
@@ -2013,7 +2015,7 @@ async fn agent_pins_unpin_handler(
 ) -> Result<Json<AgentPinsListResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
     let event_pane_id = pane_id.clone();
-    let response = run_agent_pins_task(state.clone(), move |state| {
+    let response = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.agent_pins.unpin(&pane_id, &panes)?)
     })
@@ -2029,7 +2031,7 @@ async fn notes_list_handler(
 ) -> Result<Json<NotesListResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
     Ok(Json(
-        run_notes_task(state, move |state| {
+        run_store_task(state, move |state| {
             let panes = current_panes(&state.api)?;
             Ok(state.notes.list(query, &panes)?)
         })
@@ -2043,7 +2045,7 @@ async fn notes_create_handler(
     Json(body): Json<CreateNoteRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let note = run_notes_task(state.clone(), move |state| {
+    let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.create(body, &panes)?)
     })
@@ -2059,7 +2061,7 @@ async fn notes_update_handler(
     Json(body): Json<UpdateNoteRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let note = run_notes_task(state.clone(), move |state| {
+    let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.update(&note_id, body, &panes)?)
     })
@@ -2075,7 +2077,7 @@ async fn notes_attach_handler(
     Json(body): Json<AttachNoteRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let note = run_notes_task(state.clone(), move |state| {
+    let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.attach(&note_id, body, &panes)?)
     })
@@ -2091,7 +2093,7 @@ async fn notes_detach_handler(
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let note = run_notes_task(state.clone(), move |state| {
+    let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.detach(&note_id, body, &panes)?)
     })
@@ -2107,7 +2109,7 @@ async fn notes_archive_handler(
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let note = run_notes_task(state.clone(), move |state| {
+    let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.archive(&note_id, body, &panes)?)
     })
@@ -2123,7 +2125,7 @@ async fn notes_restore_handler(
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let note = run_notes_task(state.clone(), move |state| {
+    let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.restore(&note_id, body, &panes)?)
     })
@@ -2139,7 +2141,7 @@ async fn notes_delete_handler(
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let note = run_notes_task(state.clone(), move |state| {
+    let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.delete(&note_id, body, &panes)?)
     })
@@ -2148,17 +2150,7 @@ async fn notes_delete_handler(
     Ok(Json(note))
 }
 
-async fn run_agent_pins_task<T, F>(state: BridgeState, task: F) -> Result<T, BridgeError>
-where
-    T: Send + 'static,
-    F: FnOnce(BridgeState) -> Result<T, BridgeError> + Send + 'static,
-{
-    tokio::task::spawn_blocking(move || task(state))
-        .await
-        .map_err(|err| BridgeError::Protocol(err.to_string()))?
-}
-
-async fn run_notes_task<T, F>(state: BridgeState, task: F) -> Result<T, BridgeError>
+async fn run_store_task<T, F>(state: BridgeState, task: F) -> Result<T, BridgeError>
 where
     T: Send + 'static,
     F: FnOnce(BridgeState) -> Result<T, BridgeError> + Send + 'static,

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -546,18 +546,20 @@ impl TerminalWriter {
         self.tx.send(message)
     }
 
-    fn send_input(&self, data: Vec<u8>) -> Result<(), String> {
-        let len = data.len();
+    /// Reserve queue budget for a whole input frame before any of its chunks
+    /// are enqueued, so an oversized frame is rejected atomically instead of
+    /// delivering truncated input to the pty.
+    fn reserve_input_bytes(&self, len: usize) -> Result<(), String> {
         let queued = self.queued_input_bytes.fetch_add(len, Ordering::AcqRel);
         if queued + len > MAX_QUEUED_TERMINAL_INPUT_BYTES {
             self.queued_input_bytes.fetch_sub(len, Ordering::AcqRel);
             return Err("terminal input backlog exceeded".to_string());
         }
-        if self.tx.send(ClientMessage::Input { data }).is_err() {
-            self.queued_input_bytes.fetch_sub(len, Ordering::AcqRel);
-            return Err("terminal writer closed".to_string());
-        }
         Ok(())
+    }
+
+    fn release_input_bytes(&self, len: usize) {
+        self.queued_input_bytes.fetch_sub(len, Ordering::AcqRel);
     }
 }
 
@@ -3046,8 +3048,14 @@ fn send_terminal_input_chunks(
     write_tx: &TerminalWriter,
     data: &[u8],
 ) -> Result<TerminalInputChunkStats, String> {
+    write_tx.reserve_input_bytes(data.len())?;
     if data.is_empty() {
-        write_tx.send_input(Vec::new())?;
+        if write_tx
+            .send(ClientMessage::Input { data: Vec::new() })
+            .is_err()
+        {
+            return Err("terminal writer closed".to_string());
+        }
         return Ok(TerminalInputChunkStats {
             chunks: 1,
             max_chunk_bytes: 0,
@@ -3058,10 +3066,20 @@ fn send_terminal_input_chunks(
         chunks: 0,
         max_chunk_bytes: 0,
     };
+    let mut sent_bytes = 0usize;
     for chunk in data.chunks(MAX_TERMINAL_INPUT_CHUNK_BYTES) {
         stats.chunks += 1;
         stats.max_chunk_bytes = stats.max_chunk_bytes.max(chunk.len());
-        write_tx.send_input(chunk.to_vec())?;
+        if write_tx
+            .send(ClientMessage::Input {
+                data: chunk.to_vec(),
+            })
+            .is_err()
+        {
+            write_tx.release_input_bytes(data.len() - sent_bytes);
+            return Err("terminal writer closed".to_string());
+        }
+        sent_bytes += chunk.len();
     }
     Ok(stats)
 }
@@ -3607,12 +3625,25 @@ mod tests {
     }
 
     #[test]
-    fn rejects_terminal_input_over_queue_budget() {
+    fn rejects_oversized_terminal_input_frame_atomically() {
         let (tx, rx) = test_terminal_writer();
         let data = vec![b'x'; MAX_QUEUED_TERMINAL_INPUT_BYTES + 1];
 
-        // Nothing drains the queue, so the final chunk must be refused.
+        // The frame exceeds the whole budget: no chunk may reach the pty.
         assert!(send_terminal_input_chunks(&tx, &data).is_err());
+        assert_eq!(rx.try_iter().count(), 0);
+    }
+
+    #[test]
+    fn rejects_terminal_input_frame_exceeding_remaining_budget_atomically() {
+        let (tx, rx) = test_terminal_writer();
+        let first = vec![b'x'; MAX_QUEUED_TERMINAL_INPUT_BYTES - 1024];
+        let second = vec![b'y'; 4096];
+
+        // Nothing drains the queue, so the second frame must be refused
+        // whole even though part of it would still fit.
+        assert!(send_terminal_input_chunks(&tx, &first).is_ok());
+        assert!(send_terminal_input_chunks(&tx, &second).is_err());
         let queued: usize = rx
             .try_iter()
             .map(|message| match message {
@@ -3620,7 +3651,7 @@ mod tests {
                 other => panic!("unexpected terminal message: {other:?}"),
             })
             .sum();
-        assert!(queued <= MAX_QUEUED_TERMINAL_INPUT_BYTES);
+        assert_eq!(queued, first.len());
     }
 
     #[test]

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -59,6 +59,7 @@ const MIN_TERMINAL_ATTACH_PROTOCOL: u32 = 13;
 const MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
 const MAX_NOTES_REQUEST_BYTES: usize = 512 * 1024;
 const MAX_TERMINAL_INPUT_CHUNK_BYTES: usize = 768 * 1024;
+const MAX_QUEUED_TERMINAL_INPUT_BYTES: usize = 8 * 1024 * 1024;
 const DEFAULT_TERMINAL_OUTPUT_COALESCE_MS: u64 = 16;
 const MAX_TERMINAL_OUTPUT_COALESCE_MS: u64 = 256;
 const TERMINAL_OUTPUT_COALESCE_MAX_BYTES: usize = 32 * 1024;
@@ -526,9 +527,38 @@ fn terminal_output_coalesce_window(coalesce_ms: Option<u64>) -> Duration {
 
 #[derive(Clone)]
 struct SharedTerminalSession {
-    write_tx: mpsc::Sender<ClientMessage>,
+    write_tx: TerminalWriter,
     output_tx: tokio::sync::broadcast::Sender<TerminalOutput>,
     client_count: Arc<AtomicUsize>,
+}
+
+/// Sender for daemon-bound terminal messages that bounds how many input
+/// bytes may sit in the writer queue, so a client streaming input faster
+/// than the pty consumes it cannot balloon bridge memory.
+#[derive(Clone)]
+struct TerminalWriter {
+    tx: mpsc::Sender<ClientMessage>,
+    queued_input_bytes: Arc<AtomicUsize>,
+}
+
+impl TerminalWriter {
+    fn send(&self, message: ClientMessage) -> Result<(), mpsc::SendError<ClientMessage>> {
+        self.tx.send(message)
+    }
+
+    fn send_input(&self, data: Vec<u8>) -> Result<(), String> {
+        let len = data.len();
+        let queued = self.queued_input_bytes.fetch_add(len, Ordering::AcqRel);
+        if queued + len > MAX_QUEUED_TERMINAL_INPUT_BYTES {
+            self.queued_input_bytes.fetch_sub(len, Ordering::AcqRel);
+            return Err("terminal input backlog exceeded".to_string());
+        }
+        if self.tx.send(ClientMessage::Input { data }).is_err() {
+            self.queued_input_bytes.fetch_sub(len, Ordering::AcqRel);
+            return Err("terminal writer closed".to_string());
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -1040,9 +1070,12 @@ fn expand_home(value: &str) -> PathBuf {
 }
 
 fn ensure_upload_dir(path: &Path) -> io::Result<()> {
+    // Only tighten permissions on directories the bridge itself creates; an
+    // operator-supplied pre-existing directory keeps its permissions.
+    let pre_existing = path.is_dir();
     std::fs::create_dir_all(path)?;
     #[cfg(unix)]
-    {
+    if !pre_existing {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
     }
@@ -1484,6 +1517,12 @@ fn validate_web_command(method: &Method) -> Result<(), BridgeError> {
                 }
             }
         }
+        Method::PaneRename(params) => {
+            if params.pane_id.trim().is_empty() {
+                return Err(BridgeError::BadRequest("pane_id is required".to_string()));
+            }
+            validate_optional_label(&params.label, "pane.rename label")?;
+        }
         Method::AgentStart(params) => {
             if params.name.trim().is_empty() || params.name.len() > 120 {
                 return Err(BridgeError::BadRequest(
@@ -1593,13 +1632,15 @@ async fn command_handler(
     let mut request: Request = serde_json::from_value(request_value)
         .map_err(|err| BridgeError::BadRequest(format!("invalid command: {err}")))?;
     validate_web_command(&request.method)?;
-    fill_clear_rename_labels(&state.api, &mut request.method)?;
     let should_prune_terminal_sessions = command_may_close_terminal_session(&request.method);
 
     let api = state.api.clone();
-    let response = tokio::task::spawn_blocking(move || api.request(request))
-        .await
-        .map_err(|err| BridgeError::Protocol(err.to_string()))??;
+    let response = tokio::task::spawn_blocking(move || {
+        fill_clear_rename_labels(&api, &mut request.method)?;
+        Ok::<_, BridgeError>(api.request(request)?)
+    })
+    .await
+    .map_err(|err| BridgeError::Protocol(err.to_string()))??;
     if let ResponseResult::PaneMove { move_result } = &response.result {
         if move_result.changed {
             let notes = state.notes.clone();
@@ -1696,7 +1737,10 @@ async fn selection_handler(
     if pane_id.is_empty() {
         return Err(BridgeError::BadRequest("missing pane_id".to_string()));
     }
-    let panes = current_panes(&state.api)?;
+    let api = state.api.clone();
+    let panes = tokio::task::spawn_blocking(move || current_panes(&api))
+        .await
+        .map_err(|err| BridgeError::Protocol(err.to_string()))??;
     if !panes.iter().any(|pane| pane.pane_id == pane_id) {
         return Err(BridgeError::Protocol(format!("pane not found: {pane_id}")));
     }
@@ -1823,32 +1867,39 @@ async fn snapshot_handler(
     headers: HeaderMap,
 ) -> Result<Json<Snapshot>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let workspaces = match api_request(
-        &state.api,
-        "herdr-web:workspace-list",
-        Method::WorkspaceList(EmptyParams::default()),
-    )? {
-        ResponseResult::WorkspaceList { workspaces } => workspaces,
-        other => {
-            return Err(BridgeError::Protocol(format!(
-                "unexpected response: {other:?}"
-            )))
-        }
-    };
-    let tabs = match api_request(
-        &state.api,
-        "herdr-web:tab-list",
-        Method::TabList(TabListParams::default()),
-    )? {
-        ResponseResult::TabList { tabs } => tabs,
-        other => {
-            return Err(BridgeError::Protocol(format!(
-                "unexpected response: {other:?}"
-            )))
-        }
-    };
-    let panes = current_panes(&state.api)?;
-    observe_agent_activity_snapshot(&state, &panes);
+    let api_state = state.clone();
+    let (workspaces, tabs, panes, layouts) = tokio::task::spawn_blocking(move || {
+        let workspaces = match api_request(
+            &api_state.api,
+            "herdr-web:workspace-list",
+            Method::WorkspaceList(EmptyParams::default()),
+        )? {
+            ResponseResult::WorkspaceList { workspaces } => workspaces,
+            other => {
+                return Err(BridgeError::Protocol(format!(
+                    "unexpected response: {other:?}"
+                )))
+            }
+        };
+        let tabs = match api_request(
+            &api_state.api,
+            "herdr-web:tab-list",
+            Method::TabList(TabListParams::default()),
+        )? {
+            ResponseResult::TabList { tabs } => tabs,
+            other => {
+                return Err(BridgeError::Protocol(format!(
+                    "unexpected response: {other:?}"
+                )))
+            }
+        };
+        let panes = current_panes(&api_state.api)?;
+        observe_agent_activity_snapshot(&api_state, &panes);
+        let layouts = collect_tab_layouts(&api_state.api, &tabs, &panes);
+        Ok((workspaces, tabs, panes, layouts))
+    })
+    .await
+    .map_err(|err| BridgeError::Protocol(err.to_string()))??;
     let notes = state.notes.clone();
     let note_panes = panes.clone();
     match tokio::task::spawn_blocking(move || notes.observe_panes(&note_panes))
@@ -1859,7 +1910,6 @@ async fn snapshot_handler(
         Ok(false) => {}
         Err(err) => warn!(error = %err, "failed to update pane note observations"),
     }
-    let layouts = collect_tab_layouts(&state.api, &tabs, &panes);
     let selected_pane_id = shared_selected_pane(&state, &panes)?;
     let workspaces = workspaces
         .into_iter()
@@ -1915,9 +1965,15 @@ async fn agent_activity_list_handler(
     headers: HeaderMap,
 ) -> Result<Json<AgentActivityListResponse>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
-    let panes = current_panes(&state.api)?;
-    observe_agent_activity_snapshot(&state, &panes);
-    Ok(Json(state.agent_activity.list(&panes)))
+    let list_state = state.clone();
+    let response = tokio::task::spawn_blocking(move || {
+        let panes = current_panes(&list_state.api)?;
+        observe_agent_activity_snapshot(&list_state, &panes);
+        Ok::<_, BridgeError>(list_state.agent_activity.list(&panes))
+    })
+    .await
+    .map_err(|err| BridgeError::Protocol(err.to_string()))??;
+    Ok(Json(response))
 }
 
 async fn agent_pins_list_handler(
@@ -2407,7 +2463,6 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
             return;
         }
     };
-    session.client_count.fetch_add(1, Ordering::AcqRel);
 
     let write_tx = session.write_tx.clone();
     let mut terminal_rx = session.output_tx.subscribe();
@@ -2533,15 +2588,19 @@ async fn handle_terminal_output_message(
             false
         }
         Err(tokio::sync::broadcast::error::RecvError::Lagged(frames)) => {
+            // Dropped frames would silently corrupt the stateful ANSI stream.
+            // Close the socket without a "closed" frame so the client
+            // reconnects and gets a clean repaint from a fresh attach.
             output_coalescer.record_lagged(frames);
-            true
+            warn!(frames, "terminal output lagged; closing socket for resync");
+            false
         }
         Err(tokio::sync::broadcast::error::RecvError::Closed) => false,
     }
 }
 
 fn handle_terminal_client_message(
-    write_tx: &mpsc::Sender<ClientMessage>,
+    write_tx: &TerminalWriter,
     message: Result<Message, axum::Error>,
 ) -> bool {
     match message {
@@ -2561,14 +2620,21 @@ async fn acquire_terminal_session(
     takeover: bool,
 ) -> Result<SharedTerminalSession, BridgeError> {
     tokio::task::spawn_blocking(move || {
-        let mut sessions = state
-            .terminal_sessions
-            .lock()
-            .map_err(|_| BridgeError::Protocol("terminal session lock poisoned".to_string()))?;
-        if let Some(session) = sessions.get(&terminal_id) {
-            return Ok(session.clone());
+        // Fast path: join an existing session, counting the client while the
+        // map lock is held so a concurrent release cannot detach it first.
+        {
+            let sessions = state
+                .terminal_sessions
+                .lock()
+                .map_err(|_| BridgeError::Protocol("terminal session lock poisoned".to_string()))?;
+            if let Some(session) = sessions.get(&terminal_id) {
+                session.client_count.fetch_add(1, Ordering::AcqRel);
+                return Ok(session.clone());
+            }
         }
 
+        // Perform the daemon handshake without holding the map lock so a
+        // stalled daemon cannot wedge every other terminal client.
         let protocol_version = terminal_attach_protocol(&state.api)?;
         let (output_tx, _) = tokio::sync::broadcast::channel(256);
         let attach = open_terminal_attach(
@@ -2585,6 +2651,20 @@ async fn acquire_terminal_session(
             output_tx,
             client_count: Arc::new(AtomicUsize::new(0)),
         };
+
+        let mut sessions = state
+            .terminal_sessions
+            .lock()
+            .map_err(|_| BridgeError::Protocol("terminal session lock poisoned".to_string()))?;
+        if let Some(existing) = sessions.get(&terminal_id) {
+            // Another connection attached while we were handshaking; keep the
+            // established session and detach the redundant one.
+            existing.client_count.fetch_add(1, Ordering::AcqRel);
+            let existing = existing.clone();
+            let _ = session.write_tx.send(ClientMessage::Detach);
+            return Ok(existing);
+        }
+        session.client_count.fetch_add(1, Ordering::AcqRel);
         sessions.insert(terminal_id, session.clone());
         Ok(session)
     })
@@ -2597,14 +2677,16 @@ fn release_terminal_session(
     terminal_id: &str,
     session: &SharedTerminalSession,
 ) {
+    // Decrement while holding the map lock so a concurrent acquire cannot
+    // join the session between the last-client check and its removal.
+    let Ok(mut sessions) = state.terminal_sessions.lock() else {
+        return;
+    };
     if session.client_count.fetch_sub(1, Ordering::AcqRel) != 1 {
         return;
     }
 
     let _ = session.write_tx.send(ClientMessage::Detach);
-    let Ok(mut sessions) = state.terminal_sessions.lock() else {
-        return;
-    };
     if sessions
         .get(terminal_id)
         .is_some_and(|current| Arc::ptr_eq(&current.client_count, &session.client_count))
@@ -2969,13 +3051,11 @@ struct TerminalInputChunkStats {
 }
 
 fn send_terminal_input_chunks(
-    write_tx: &mpsc::Sender<ClientMessage>,
+    write_tx: &TerminalWriter,
     data: &[u8],
 ) -> Result<TerminalInputChunkStats, String> {
     if data.is_empty() {
-        write_tx
-            .send(ClientMessage::Input { data: Vec::new() })
-            .map_err(|_| "terminal writer closed".to_string())?;
+        write_tx.send_input(Vec::new())?;
         return Ok(TerminalInputChunkStats {
             chunks: 1,
             max_chunk_bytes: 0,
@@ -2989,19 +3069,12 @@ fn send_terminal_input_chunks(
     for chunk in data.chunks(MAX_TERMINAL_INPUT_CHUNK_BYTES) {
         stats.chunks += 1;
         stats.max_chunk_bytes = stats.max_chunk_bytes.max(chunk.len());
-        write_tx
-            .send(ClientMessage::Input {
-                data: chunk.to_vec(),
-            })
-            .map_err(|_| "terminal writer closed".to_string())?;
+        write_tx.send_input(chunk.to_vec())?;
     }
     Ok(stats)
 }
 
-fn handle_terminal_text_frame(
-    write_tx: &mpsc::Sender<ClientMessage>,
-    text: &str,
-) -> Result<(), String> {
+fn handle_terminal_text_frame(write_tx: &TerminalWriter, text: &str) -> Result<(), String> {
     let frame = parse_terminal_client_frame(text)?;
     match frame {
         TerminalClientFrame::Input { data } => {
@@ -3044,7 +3117,7 @@ fn parse_terminal_client_frame(text: &str) -> Result<TerminalClientFrame, String
 }
 
 struct TerminalAttach {
-    write_tx: mpsc::Sender<ClientMessage>,
+    write_tx: TerminalWriter,
 }
 
 fn open_terminal_attach(
@@ -3097,11 +3170,21 @@ fn open_terminal_attach(
 
     let mut read_stream = stream.try_clone()?;
     let (write_tx, write_rx) = mpsc::channel::<ClientMessage>();
+    let queued_input_bytes = Arc::new(AtomicUsize::new(0));
+    let writer_queued_input_bytes = queued_input_bytes.clone();
 
     thread::spawn(move || {
         let mut write_stream = stream;
         for message in write_rx {
-            if protocol::write_message(&mut write_stream, &message).is_err() {
+            let input_len = match &message {
+                ClientMessage::Input { data } => data.len(),
+                _ => 0,
+            };
+            let result = protocol::write_message(&mut write_stream, &message);
+            if input_len > 0 {
+                writer_queued_input_bytes.fetch_sub(input_len, Ordering::AcqRel);
+            }
+            if result.is_err() {
                 break;
             }
             let _ = write_stream.flush();
@@ -3138,7 +3221,12 @@ fn open_terminal_attach(
         }
     });
 
-    Ok(TerminalAttach { write_tx })
+    Ok(TerminalAttach {
+        write_tx: TerminalWriter {
+            tx: write_tx,
+            queued_input_bytes,
+        },
+    })
 }
 
 fn terminal_attach_protocol(api: &ApiClient) -> Result<u32, BridgeError> {
@@ -3468,9 +3556,20 @@ mod tests {
         );
     }
 
+    fn test_terminal_writer() -> (TerminalWriter, mpsc::Receiver<ClientMessage>) {
+        let (tx, rx) = mpsc::channel();
+        (
+            TerminalWriter {
+                tx,
+                queued_input_bytes: Arc::new(AtomicUsize::new(0)),
+            },
+            rx,
+        )
+    }
+
     #[test]
     fn chunks_terminal_input_below_daemon_limit() {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = test_terminal_writer();
         let data = vec![b'x'; MAX_TERMINAL_INPUT_CHUNK_BYTES * 2 + 17];
 
         let stats = send_terminal_input_chunks(&tx, &data).unwrap();
@@ -3498,7 +3597,7 @@ mod tests {
 
     #[test]
     fn forwards_empty_terminal_input_as_one_message() {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = test_terminal_writer();
 
         let stats = send_terminal_input_chunks(&tx, &[]).unwrap();
 
@@ -3513,6 +3612,23 @@ mod tests {
             rx.recv().unwrap(),
             ClientMessage::Input { data: Vec::new() }
         );
+    }
+
+    #[test]
+    fn rejects_terminal_input_over_queue_budget() {
+        let (tx, rx) = test_terminal_writer();
+        let data = vec![b'x'; MAX_QUEUED_TERMINAL_INPUT_BYTES + 1];
+
+        // Nothing drains the queue, so the final chunk must be refused.
+        assert!(send_terminal_input_chunks(&tx, &data).is_err());
+        let queued: usize = rx
+            .try_iter()
+            .map(|message| match message {
+                ClientMessage::Input { data } => data.len(),
+                other => panic!("unexpected terminal message: {other:?}"),
+            })
+            .sum();
+        assert!(queued <= MAX_QUEUED_TERMINAL_INPUT_BYTES);
     }
 
     #[test]

--- a/docs/android.md
+++ b/docs/android.md
@@ -45,7 +45,7 @@ The web app validates backend URLs before saving them:
 
 - accepted URLs must be origin-style HTTP or HTTPS URLs;
 - credentials, paths, query strings, and fragments are rejected;
-- HTTP URLs to public IP literals are rejected;
+- HTTP and HTTPS URLs may use any valid hostname or IP literal;
 - hostnames are syntax-validated in the app and still must be accepted by the bridge Host policy.
 
 The Android WebView app origin is `http://localhost`. A LAN bridge must allow that origin before
@@ -189,7 +189,8 @@ On a trusted LAN:
 4. Open Settings and select the Bridge area.
 5. Add a backend such as `http://192.168.1.20:4000`.
 6. Use `Test` and confirm it reports reachable.
-7. Use `Save & enable` and confirm the bridge chip appears in the sidebar.
+7. Use `Save`, enable the saved bridge with its Enable toggle, and confirm the bridge chip appears
+   in the sidebar.
 8. Confirm snapshot, event updates, terminal attach, text input, stage-only input, uploads, and pane controls work.
 9. Open the Terminal area, change input transport and batching delay, and confirm terminal input
    still works.

--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -70,6 +70,13 @@ if [[ -n "${HERDR_SRC:-}" ]]; then
   }
 
   compare_wire_body() {
+    local wire_file
+    for wire_file in "$HERDR_SRC/src/protocol/wire.rs" "$COMPAT/src/protocol/wire.rs"; do
+      if ! grep -q '^use std::collections::HashMap;' "$wire_file"; then
+        echo "wire.rs anchor line missing in $wire_file; update compare_wire_body" >&2
+        exit 1
+      fi
+    done
     if ! diff -q \
       <(awk 'seen || /^use std::collections::HashMap;/{seen=1} seen {print}' "$HERDR_SRC/src/protocol/wire.rs") \
       <(awk 'seen || /^use std::collections::HashMap;/{seen=1} seen {print}' "$COMPAT/src/protocol/wire.rs") \

--- a/scripts/package-tarball.sh
+++ b/scripts/package-tarball.sh
@@ -31,7 +31,7 @@ NAME="herdr-web-${VERSION}-${PLATFORM}"
 STAGE="$PKG_ROOT/$NAME"
 ARCHIVE="$PKG_ROOT/$NAME.tar.gz"
 
-npm run build:web
+npm --prefix "$ROOT" run build:web
 cargo build --release --manifest-path "$ROOT/bridge/Cargo.toml" --bin herdr-web-bridge
 
 rm -rf "$STAGE" "$ARCHIVE"

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -75,7 +75,7 @@ function readChangelogForRelease() {
   if (!unreleased) {
     fail("CHANGELOG.md is missing an Unreleased section");
   }
-  if (!unreleased[1].trim()) {
+  if (!removeEmptyChangelogSubsections(unreleased[1]).trim()) {
     fail("CHANGELOG.md has no release notes under Unreleased");
   }
   return changelog;
@@ -138,16 +138,17 @@ function escapeRegex(value) {
 try {
   validatePreflight();
   const changelog = readChangelogForRelease();
-  const released = stampChangelog(changelog);
 
   run("npm", ["run", "check"]);
+
+  const released = stampChangelog(changelog);
+  writeFileSync(notesFile, extractReleaseNotes(released));
 
   run("git", ["add", "CHANGELOG.md"]);
   run("git", ["commit", "-m", `Release ${tag}`]);
   run("git", ["tag", tag]);
   run("git", ["push", "--atomic", "origin", RELEASE_BRANCH, tag]);
 
-  writeFileSync(notesFile, extractReleaseNotes(released));
   run("gh", ["release", "create", tag, "--notes-file", notesFile]);
 
   openNextUnreleased(released);

--- a/web/README.md
+++ b/web/README.md
@@ -36,6 +36,9 @@ The app expects these bridge routes:
 - `/api/snapshot`
 - `/api/command`
 - `/api/selection`
+- `/api/notes` (and `/api/notes/{note_id}/...` actions)
+- `/api/agent-pins` (and `/api/agent-pins/{pane_id}/pin|unpin`)
+- `/api/agent-activity`
 - `/api/uploads`
 - `/ws/activity`
 - `/ws/events`

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -131,6 +131,7 @@ import {
 } from "./terminalPrefs";
 import {
   aggregateStatus,
+  basename,
   canClearTabName,
   canClearWorkspaceName,
   choosePaneForTab,
@@ -193,12 +194,13 @@ export type BridgeConnectionState = {
   snapshot: Snapshot | null;
   loadState: LoadState;
 };
-type BridgeNotesState = {
+type BridgeResourceState<Response> = {
   connectionKey: string;
-  response: NotesListResponse | null;
+  response: Response | null;
   loadState: LoadState;
   error: string | null;
 };
+type BridgeNotesState = BridgeResourceState<NotesListResponse>;
 type PendingCreatedPaneNoteTarget = {
   note: PaneNote;
   pane: PaneInfo;
@@ -209,18 +211,8 @@ type PendingCreatedPaneNote = PendingCreatedPaneNoteTarget & {
 type QuickPaneNoteTarget = ScopedPaneRef & {
   label: string;
 };
-type BridgeAgentPinsState = {
-  connectionKey: string;
-  response: AgentPinsListResponse | null;
-  loadState: LoadState;
-  error: string | null;
-};
-type BridgeAgentActivityState = {
-  connectionKey: string;
-  response: AgentActivityListResponse | null;
-  loadState: LoadState;
-  error: string | null;
-};
+type BridgeAgentPinsState = BridgeResourceState<AgentPinsListResponse>;
+type BridgeAgentActivityState = BridgeResourceState<AgentActivityListResponse>;
 export type BridgeConnectionRef = {
   connectionKey: string;
   snapshot: Snapshot | null;
@@ -544,87 +536,13 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
       selectedPaneId?: unknown;
       mobileTouchSelection?: unknown;
     } & Partial<DisplayPrefs>;
-    const sidebarWidth =
-      typeof parsed.sidebarWidth === "number"
-        ? clampSidebarWidth(parsed.sidebarWidth)
-        : fallback.sidebarWidth;
-    const sidebarOpen =
-      typeof parsed.sidebarOpen === "boolean" ? parsed.sidebarOpen : fallback.sidebarOpen;
-    const notesPanelWidth =
-      typeof parsed.notesPanelWidth === "number"
-        ? clampNotesPanelWidth(parsed.notesPanelWidth, sidebarWidth, sidebarOpen)
-        : fallback.notesPanelWidth;
     return {
-      ...fallback,
-      hostScope:
-        parsed.hostScope === "selected" || parsed.hostScope === "all"
-          ? parsed.hostScope
-          : fallback.hostScope,
-      scope: parsed.scope === "all" || parsed.scope === "space" ? parsed.scope : fallback.scope,
-      sidebarView:
-        parsed.sidebarView === "agents" ||
-        parsed.sidebarView === "tabs" ||
-        parsed.sidebarView === "notes"
-          ? parsed.sidebarView
-          : fallback.sidebarView,
-      agentSort:
-        parsed.agentSort === "attention" ||
-        parsed.agentSort === "status" ||
-        parsed.agentSort === "workspace" ||
-        parsed.agentSort === "lastStatusChange"
-          ? parsed.agentSort
-          : fallback.agentSort,
-      agentGroup:
-        parsed.agentGroup === "none" ||
-        parsed.agentGroup === "host" ||
-        parsed.agentGroup === "workspace" ||
-        parsed.agentGroup === "hostWorkspace"
-          ? parsed.agentGroup
-          : fallback.agentGroup,
-      agentPinnedOnly:
-        typeof parsed.agentPinnedOnly === "boolean"
-          ? parsed.agentPinnedOnly
-          : fallback.agentPinnedOnly,
-      sidebarWidth,
-      notesPanelWidth,
-      notesListPaneWidth:
-        typeof parsed.notesListPaneWidth === "number"
-          ? clampNotesListPaneWidth(parsed.notesListPaneWidth, notesPanelWidth)
-          : fallback.notesListPaneWidth,
-      notesListPaneCollapsed:
-        typeof parsed.notesListPaneCollapsed === "boolean"
-          ? parsed.notesListPaneCollapsed
-          : fallback.notesListPaneCollapsed,
-      notesEnabled:
-        typeof parsed.notesEnabled === "boolean" ? parsed.notesEnabled : fallback.notesEnabled,
-      notesPanelOpen:
-        typeof parsed.notesPanelOpen === "boolean"
-          ? parsed.notesPanelOpen
-          : fallback.notesPanelOpen,
-      sidebarOpen,
-      terminalFontSizePx: parseTerminalFontSizePx(parsed.terminalFontSizePx),
-      terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
-      terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
-      terminalOutputCoalesceMs: parseTerminalOutputCoalesceMs(
-        parsed.terminalOutputCoalesceMs,
-      ),
-      contentInsetTopPx: parseContentInsetTopPx(parsed.contentInsetTopPx),
-      contentInsetBottomPx: parseContentInsetBottomPx(parsed.contentInsetBottomPx),
-      mobileControlsScalePercent: parseMobileControlsScalePercent(
-        parsed.mobileControlsScalePercent,
-      ),
-      mobileTerminalTapTarget: parseMobileTerminalTapTarget(parsed.mobileTerminalTapTarget),
-      mobileLongPressBehavior: parseStoredMobileLongPressBehavior(parsed),
-      mobileTouchSelectionEndpointTimeoutMs: parseMobileTouchSelectionEndpointTimeoutMs(
-        parsed.mobileTouchSelectionEndpointTimeoutMs,
-      ),
-      mobileKeyboardHideRefit: parseMobileKeyboardHideRefit(parsed.mobileKeyboardHideRefit),
-      mobileCommandExpandingInput: parseMobileCommandExpandingInput(
-        parsed.mobileCommandExpandingInput,
-      ),
-      mobileCommandEnterNewline: parseMobileCommandEnterNewline(
-        parsed.mobileCommandEnterNewline,
-      ),
+      ...parseDisplayPrefsValue(parsed, fallback),
+      selectedBridgeId: fallback.selectedBridgeId,
+      selectedPane: fallback.selectedPane,
+      activeWorkspace: fallback.activeWorkspace,
+      selectedPanesByBridgeId: fallback.selectedPanesByBridgeId,
+      activeWorkspacesByBridgeId: fallback.activeWorkspacesByBridgeId,
     };
   } catch {
     return fallback;
@@ -764,6 +682,30 @@ function stripMobileHistoryState(value: unknown) {
   delete next[MOBILE_SIDEBAR_HISTORY_KEY];
   delete next[MOBILE_DETAIL_HISTORY_KEY];
   return next;
+}
+
+function usePointerDragResize(
+  active: boolean,
+  onMove: (event: PointerEvent) => void,
+  onEnd: () => void,
+) {
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onEnd, { once: true });
+    window.addEventListener("pointercancel", onEnd, { once: true });
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onEnd);
+      window.removeEventListener("pointercancel", onEnd);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [active, onMove, onEnd]);
 }
 
 export function App() {
@@ -1377,7 +1319,7 @@ export function App() {
     }
   }, [notesEnabled, sidebarView]);
 
-  const clearSidebarResizePress = () => {
+  const clearSidebarResizePress = useCallback(() => {
     const pending = sidebarResizePressRef.current;
     if (!pending) {
       return;
@@ -1387,92 +1329,43 @@ export function App() {
       pending.target.releasePointerCapture(pending.pointerId);
     }
     sidebarResizePressRef.current = null;
-  };
+  }, []);
 
-  useEffect(() => {
-    if (!resizingSidebar) {
-      return;
-    }
-    const onPointerMove = (event: PointerEvent) => {
+  usePointerDragResize(
+    resizingSidebar,
+    useCallback((event: PointerEvent) => {
       setSidebarWidth(clampSidebarWidth(event.clientX));
-    };
-    const onPointerUp = () => setResizingSidebar(false);
-    window.addEventListener("pointermove", onPointerMove);
-    window.addEventListener("pointerup", onPointerUp, { once: true });
-    window.addEventListener("pointercancel", onPointerUp, { once: true });
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-    return () => {
-      window.removeEventListener("pointermove", onPointerMove);
-      window.removeEventListener("pointerup", onPointerUp);
-      window.removeEventListener("pointercancel", onPointerUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [resizingSidebar]);
-
-  useEffect(() => {
-    if (!resizingNotesPanel) {
-      return;
-    }
-    const onPointerMove = (event: PointerEvent) => {
-      setNotesPanelWidth(
-        clampNotesPanelWidth(window.innerWidth - event.clientX, sidebarWidth, sidebarOpen),
-      );
-    };
-    const onPointerUp = () => setResizingNotesPanel(false);
-    window.addEventListener("pointermove", onPointerMove);
-    window.addEventListener("pointerup", onPointerUp, { once: true });
-    window.addEventListener("pointercancel", onPointerUp, { once: true });
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-    return () => {
-      window.removeEventListener("pointermove", onPointerMove);
-      window.removeEventListener("pointerup", onPointerUp);
-      window.removeEventListener("pointercancel", onPointerUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [resizingNotesPanel, sidebarOpen, sidebarWidth]);
-
-  useEffect(() => {
-    if (!resizingNotesListPane) {
-      return;
-    }
-    const onPointerMove = (event: PointerEvent) => {
-      setNotesListPaneWidth(
-        clampNotesListPaneWidth(event.clientX - notesListResizeLeftRef.current, notesPanelWidth),
-      );
-    };
-    const onPointerUp = () => setResizingNotesListPane(false);
-    window.addEventListener("pointermove", onPointerMove);
-    window.addEventListener("pointerup", onPointerUp, { once: true });
-    window.addEventListener("pointercancel", onPointerUp, { once: true });
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-    return () => {
-      window.removeEventListener("pointermove", onPointerMove);
-      window.removeEventListener("pointerup", onPointerUp);
-      window.removeEventListener("pointercancel", onPointerUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [notesPanelWidth, resizingNotesListPane]);
-
-  useEffect(
-    () => () => {
-      const pending = sidebarResizePressRef.current;
-      if (!pending) {
-        return;
-      }
-      window.clearTimeout(pending.timer);
-      if (pending.target.hasPointerCapture(pending.pointerId)) {
-        pending.target.releasePointerCapture(pending.pointerId);
-      }
-      sidebarResizePressRef.current = null;
-    },
-    [],
+    }, []),
+    useCallback(() => setResizingSidebar(false), []),
   );
+
+  usePointerDragResize(
+    resizingNotesPanel,
+    useCallback(
+      (event: PointerEvent) => {
+        setNotesPanelWidth(
+          clampNotesPanelWidth(window.innerWidth - event.clientX, sidebarWidth, sidebarOpen),
+        );
+      },
+      [sidebarOpen, sidebarWidth],
+    ),
+    useCallback(() => setResizingNotesPanel(false), []),
+  );
+
+  usePointerDragResize(
+    resizingNotesListPane,
+    useCallback(
+      (event: PointerEvent) => {
+        setNotesListPaneWidth(
+          clampNotesListPaneWidth(event.clientX - notesListResizeLeftRef.current, notesPanelWidth),
+        );
+      },
+      [notesPanelWidth],
+    ),
+    useCallback(() => setResizingNotesListPane(false), []),
+  );
+
+  useEffect(() => clearSidebarResizePress, [clearSidebarResizePress]);
 
   const rememberPaneSelection = useCallback((
     bridgeId: BridgeId,
@@ -2675,7 +2568,17 @@ export function App() {
     }
   }
 
-  async function refreshBridgeAgentActivity(runtime: BridgeRuntime, setLoading: boolean) {
+  async function refreshBridgeResource<Resource>(options: {
+    runtime: BridgeRuntime;
+    setLoading: boolean;
+    supported: boolean;
+    setState: Dispatch<SetStateAction<Record<string, BridgeResourceState<Resource>>>>;
+    fetchResponse: () => Promise<Resource>;
+    fallbackError: string;
+    isEnabled?: () => boolean;
+    transformResponse?: (response: Resource, requestConnectionKey: string) => Resource;
+  }): Promise<Resource | null> {
+    const { runtime, setLoading, supported, setState, fetchResponse, fallbackError } = options;
     ensureBridgeConnectionRef(connectionRefs, runtime);
     const requestConnectionKey = runtime.connectionKey;
     const isCurrentConnection = () =>
@@ -2683,12 +2586,8 @@ export function App() {
         connectionRefs.current[runtime.id]?.connectionKey ?? "",
         requestConnectionKey,
       );
-    if (
-      !runtime.canConnect ||
-      runtime.capabilityState !== "ready" ||
-      !supportsAgentActivity(runtime.capabilities)
-    ) {
-      setAgentActivityStates((current) => ({
+    if (!runtime.canConnect || runtime.capabilityState !== "ready" || !supported) {
+      setState((current) => ({
         ...current,
         [runtime.id]: {
           connectionKey: requestConnectionKey,
@@ -2700,7 +2599,7 @@ export function App() {
       return null;
     }
     if (setLoading) {
-      setAgentActivityStates((current) => ({
+      setState((current) => ({
         ...current,
         [runtime.id]: {
           connectionKey: requestConnectionKey,
@@ -2714,8 +2613,18 @@ export function App() {
       }));
     }
     try {
-      const response = await fetchAgentActivity(runtime.httpUrl);
-      setAgentActivityStates((current) => {
+      const response = (await fetchResponse()) as Resource;
+      if (options.isEnabled && !options.isEnabled()) {
+        return null;
+      }
+      let effectiveResponse = response;
+      if (options.transformResponse) {
+        if (!isCurrentConnection()) {
+          return null;
+        }
+        effectiveResponse = options.transformResponse(response, requestConnectionKey);
+      }
+      setState((current) => {
         if (!isCurrentConnection()) {
           return current;
         }
@@ -2723,19 +2632,22 @@ export function App() {
           ...current,
           [runtime.id]: {
             connectionKey: requestConnectionKey,
-            response,
+            response: effectiveResponse,
             loadState: "ready",
             error: null,
           },
         };
       });
-      return response;
+      return effectiveResponse;
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : "Agent activity unavailable";
+      const message = caught instanceof Error ? caught.message : fallbackError;
+      if (options.isEnabled && !options.isEnabled()) {
+        return null;
+      }
       if (!isCurrentConnection()) {
         return null;
       }
-      setAgentActivityStates((current) => ({
+      setState((current) => ({
         ...current,
         [runtime.id]: {
           connectionKey: requestConnectionKey,
@@ -2749,6 +2661,17 @@ export function App() {
       }));
       return null;
     }
+  }
+
+  async function refreshBridgeAgentActivity(runtime: BridgeRuntime, setLoading: boolean) {
+    return refreshBridgeResource({
+      runtime,
+      setLoading,
+      supported: supportsAgentActivity(runtime.capabilities),
+      setState: setAgentActivityStates,
+      fetchResponse: () => fetchAgentActivity(runtime.httpUrl),
+      fallbackError: "Agent activity unavailable",
+    });
   }
 
   const refreshAgentActivityForBridge = (bridgeId: BridgeId) => {
@@ -2767,79 +2690,14 @@ export function App() {
   }, [bridge.enabledRuntimes]);
 
   async function refreshBridgeAgentPins(runtime: BridgeRuntime, setLoading: boolean) {
-    ensureBridgeConnectionRef(connectionRefs, runtime);
-    const requestConnectionKey = runtime.connectionKey;
-    const isCurrentConnection = () =>
-      isConnectionResultCurrent(
-        connectionRefs.current[runtime.id]?.connectionKey ?? "",
-        requestConnectionKey,
-      );
-    if (
-      !runtime.canConnect ||
-      runtime.capabilityState !== "ready" ||
-      !supportsAgentPins(runtime.capabilities)
-    ) {
-      setAgentPinsStates((current) => ({
-        ...current,
-        [runtime.id]: {
-          connectionKey: requestConnectionKey,
-          response: null,
-          loadState: "ready",
-          error: null,
-        },
-      }));
-      return null;
-    }
-    if (setLoading) {
-      setAgentPinsStates((current) => ({
-        ...current,
-        [runtime.id]: {
-          connectionKey: requestConnectionKey,
-          response:
-            current[runtime.id]?.connectionKey === requestConnectionKey
-              ? current[runtime.id]?.response ?? null
-              : null,
-          loadState: "loading",
-          error: null,
-        },
-      }));
-    }
-    try {
-      const response = await fetchAgentPins(runtime.httpUrl);
-      setAgentPinsStates((current) => {
-        if (!isCurrentConnection()) {
-          return current;
-        }
-        return {
-          ...current,
-          [runtime.id]: {
-            connectionKey: requestConnectionKey,
-            response,
-            loadState: "ready",
-            error: null,
-          },
-        };
-      });
-      return response;
-    } catch (caught) {
-      const message = caught instanceof Error ? caught.message : "Agent pins unavailable";
-      if (!isCurrentConnection()) {
-        return null;
-      }
-      setAgentPinsStates((current) => ({
-        ...current,
-        [runtime.id]: {
-          connectionKey: requestConnectionKey,
-          response:
-            current[runtime.id]?.connectionKey === requestConnectionKey
-              ? current[runtime.id]?.response ?? null
-              : null,
-          loadState: "error",
-          error: message,
-        },
-      }));
-      return null;
-    }
+    return refreshBridgeResource({
+      runtime,
+      setLoading,
+      supported: supportsAgentPins(runtime.capabilities),
+      setState: setAgentPinsStates,
+      fetchResponse: () => fetchAgentPins(runtime.httpUrl),
+      fallbackError: "Agent pins unavailable",
+    });
   }
 
   const refreshAgentPinsForBridge = (bridgeId: BridgeId) => {
@@ -2858,98 +2716,22 @@ export function App() {
   }, [bridge.enabledRuntimes]);
 
   async function refreshBridgeNotes(runtime: BridgeRuntime, setLoading: boolean) {
-    ensureBridgeConnectionRef(connectionRefs, runtime);
-    const requestConnectionKey = runtime.connectionKey;
-    const isCurrentConnection = () =>
-      isConnectionResultCurrent(
-        connectionRefs.current[runtime.id]?.connectionKey ?? "",
-        requestConnectionKey,
-      );
-    if (
-      !notesEnabled ||
-      !runtime.canConnect ||
-      runtime.capabilityState !== "ready" ||
-      !supportsNotes(runtime.capabilities)
-    ) {
-      setNotesStates((current) => ({
-        ...current,
-        [runtime.id]: {
-          connectionKey: requestConnectionKey,
-          response: null,
-          loadState: "ready",
-          error: null,
-        },
-      }));
-      return null;
-    }
-    if (setLoading) {
-      setNotesStates((current) => ({
-        ...current,
-        [runtime.id]: {
-          connectionKey: requestConnectionKey,
-          response:
-            current[runtime.id]?.connectionKey === requestConnectionKey
-              ? current[runtime.id]?.response ?? null
-              : null,
-          loadState: "loading",
-          error: null,
-        },
-      }));
-    }
-    try {
-      const response = await fetchNotes(runtime.httpUrl, {
-        includeArchived: true,
-        includeDeleted: true,
-        includeOtherSessions: true,
-      });
-      if (!notesEnabledRef.current) {
-        return null;
-      }
-      if (!isCurrentConnection()) {
-        return null;
-      }
-      const effectiveResponse = mergePendingCreatedPaneNotesForResponse(
-        runtime.id,
-        requestConnectionKey,
-        response,
-      );
-      setNotesStates((current) => {
-        if (!isCurrentConnection()) {
-          return current;
-        }
-        return {
-          ...current,
-          [runtime.id]: {
-            connectionKey: requestConnectionKey,
-            response: effectiveResponse,
-            loadState: "ready",
-            error: null,
-          },
-        };
-      });
-      return effectiveResponse;
-    } catch (caught) {
-      const message = caught instanceof Error ? caught.message : "Notes unavailable";
-      if (!notesEnabledRef.current) {
-        return null;
-      }
-      if (!isCurrentConnection()) {
-        return null;
-      }
-      setNotesStates((current) => ({
-        ...current,
-        [runtime.id]: {
-          connectionKey: requestConnectionKey,
-          response:
-            current[runtime.id]?.connectionKey === requestConnectionKey
-              ? current[runtime.id]?.response ?? null
-              : null,
-          loadState: "error",
-          error: message,
-        },
-      }));
-      return null;
-    }
+    return refreshBridgeResource({
+      runtime,
+      setLoading,
+      supported: notesEnabled && supportsNotes(runtime.capabilities),
+      setState: setNotesStates,
+      fetchResponse: () =>
+        fetchNotes(runtime.httpUrl, {
+          includeArchived: true,
+          includeDeleted: true,
+          includeOtherSessions: true,
+        }),
+      fallbackError: "Notes unavailable",
+      isEnabled: () => notesEnabledRef.current,
+      transformResponse: (response, requestConnectionKey) =>
+        mergePendingCreatedPaneNotesForResponse(runtime.id, requestConnectionKey, response),
+    });
   }
 
   const refreshNotesForBridge = (bridgeId: BridgeId) => {
@@ -5351,6 +5133,34 @@ function Switcher({
       />
     ));
   const showAgentRowBridgeLabel = showGroupedHostContext && agentGroup === "none";
+  const renderAgentRow = (entry: ScopedAgentPane, index: number) => (
+    <AgentRow
+      key={`${entry.bridgeId}:${entry.pane.pane_id}`}
+      index={index}
+      pane={entry.pane}
+      workspace={entry.workspace}
+      tabLabel={entry.tabLabel}
+      bridgeLabel={showAgentRowBridgeLabel ? entry.bridgeLabel : undefined}
+      pinned={entry.pinned === true}
+      active={
+        entry.bridgeId === selectedBridgeId &&
+        entry.pane.pane_id === selectedPane?.pane_id
+      }
+      onSelect={() => onSelectPane(entry.bridgeId, entry.pane)}
+      onMenu={(x, y) =>
+        onScopedMenu(
+          "pane",
+          entry.bridgeId,
+          entry.pane.pane_id,
+          paneTitle(entry.pane),
+          x,
+          y,
+          undefined,
+          "agent",
+        )
+      }
+    />
+  );
   const renderAgentGroupRows = () => {
     const renderGroup = (group: ScopedAgentGroup) => (
       <Fragment key={group.key}>
@@ -5359,34 +5169,7 @@ function Switcher({
           bridgeColor={agentGroup === "host" ? group.bridgeColor : undefined}
           status={agentGroup === "workspace" || agentGroup === "hostWorkspace" ? group.status : undefined}
         />
-        {group.panes.map((entry) => (
-          <AgentRow
-            key={`${entry.bridgeId}:${entry.pane.pane_id}`}
-            index={agentPaneIndex++}
-            pane={entry.pane}
-            workspace={entry.workspace}
-            tabLabel={entry.tabLabel}
-            bridgeLabel={showAgentRowBridgeLabel ? entry.bridgeLabel : undefined}
-            pinned={entry.pinned === true}
-            active={
-              entry.bridgeId === selectedBridgeId &&
-              entry.pane.pane_id === selectedPane?.pane_id
-            }
-            onSelect={() => onSelectPane(entry.bridgeId, entry.pane)}
-            onMenu={(x, y) =>
-              onScopedMenu(
-                "pane",
-                entry.bridgeId,
-                entry.pane.pane_id,
-                paneTitle(entry.pane),
-                x,
-                y,
-                undefined,
-                "agent",
-              )
-            }
-          />
-        ))}
+        {group.panes.map((entry) => renderAgentRow(entry, agentPaneIndex++))}
       </Fragment>
     );
 
@@ -5771,34 +5554,7 @@ function Switcher({
                     {renderDisconnectedBridgeRows()}
                     {agentGroup !== "none"
                       ? renderAgentGroupRows()
-                      : agentPanes.map((entry, index) => (
-                          <AgentRow
-                            key={`${entry.bridgeId}:${entry.pane.pane_id}`}
-                            index={index}
-                            pane={entry.pane}
-                            workspace={entry.workspace}
-                            tabLabel={entry.tabLabel}
-                            bridgeLabel={showAgentRowBridgeLabel ? entry.bridgeLabel : undefined}
-                            pinned={entry.pinned === true}
-                            active={
-                              entry.bridgeId === selectedBridgeId &&
-                              entry.pane.pane_id === selectedPane?.pane_id
-                            }
-                            onSelect={() => onSelectPane(entry.bridgeId, entry.pane)}
-                            onMenu={(x, y) =>
-                              onScopedMenu(
-                                "pane",
-                                entry.bridgeId,
-                                entry.pane.pane_id,
-                                paneTitle(entry.pane),
-                                x,
-                                y,
-                                undefined,
-                                "agent",
-                              )
-                            }
-                          />
-                        ))}
+                      : agentPanes.map((entry, index) => renderAgentRow(entry, index))}
                   </>
                 )
               ) : spaceGroups.every((group) => group.tabs.length === 0) ? (
@@ -7188,25 +6944,26 @@ function isAgentPane(pane: PaneInfo) {
   );
 }
 
+const AGENT_STATUS_ORDER: Record<AgentStatus, number> = {
+  blocked: 0,
+  working: 1,
+  done: 2,
+  idle: 3,
+  unknown: 4,
+};
+const AGENT_ATTENTION_ORDER: Record<AgentStatus, number> = {
+  blocked: 0,
+  done: 1,
+  working: 2,
+  idle: 3,
+  unknown: 4,
+};
+
 function sortAgentPanes(panes: PaneInfo[], sort: AgentSort, snapshot: Snapshot) {
   const workspaceNumber = new Map(
     snapshot.workspaces.map((workspace) => [workspace.workspace_id, workspace.number]),
   );
   const tabNumber = new Map(snapshot.tabs.map((tab) => [tab.tab_id, tab.number]));
-  const statusOrder: Record<AgentStatus, number> = {
-    blocked: 0,
-    working: 1,
-    done: 2,
-    idle: 3,
-    unknown: 4,
-  };
-  const attentionOrder: Record<AgentStatus, number> = {
-    blocked: 0,
-    done: 1,
-    working: 2,
-    idle: 3,
-    unknown: 4,
-  };
 
   return [...panes].sort((a, b) => {
     if (sort === "attention") {
@@ -7214,12 +6971,12 @@ function sortAgentPanes(panes: PaneInfo[], sort: AgentSort, snapshot: Snapshot) 
       if (attention !== 0) {
         return attention;
       }
-      const status = attentionOrder[a.agent_status] - attentionOrder[b.agent_status];
+      const status = AGENT_ATTENTION_ORDER[a.agent_status] - AGENT_ATTENTION_ORDER[b.agent_status];
       if (status !== 0) {
         return status;
       }
     } else if (sort === "status") {
-      const status = statusOrder[a.agent_status] - statusOrder[b.agent_status];
+      const status = AGENT_STATUS_ORDER[a.agent_status] - AGENT_STATUS_ORDER[b.agent_status];
       if (status !== 0) {
         return status;
       }
@@ -7242,21 +6999,6 @@ function sortAgentPanes(panes: PaneInfo[], sort: AgentSort, snapshot: Snapshot) 
 }
 
 export function sortScopedAgentPanes(entries: ScopedAgentPane[], sort: AgentSort) {
-  const statusOrder: Record<AgentStatus, number> = {
-    blocked: 0,
-    working: 1,
-    done: 2,
-    idle: 3,
-    unknown: 4,
-  };
-  const attentionOrder: Record<AgentStatus, number> = {
-    blocked: 0,
-    done: 1,
-    working: 2,
-    idle: 3,
-    unknown: 4,
-  };
-
   return [...entries].sort((a, b) => {
     if (sort === "attention") {
       const attention =
@@ -7264,12 +7006,14 @@ export function sortScopedAgentPanes(entries: ScopedAgentPane[], sort: AgentSort
       if (attention !== 0) {
         return attention;
       }
-      const status = attentionOrder[a.pane.agent_status] - attentionOrder[b.pane.agent_status];
+      const status =
+        AGENT_ATTENTION_ORDER[a.pane.agent_status] - AGENT_ATTENTION_ORDER[b.pane.agent_status];
       if (status !== 0) {
         return status;
       }
     } else if (sort === "status") {
-      const status = statusOrder[a.pane.agent_status] - statusOrder[b.pane.agent_status];
+      const status =
+        AGENT_STATUS_ORDER[a.pane.agent_status] - AGENT_STATUS_ORDER[b.pane.agent_status];
       if (status !== 0) {
         return status;
       }
@@ -7443,17 +7187,6 @@ function agentSubtitle(
     statusLabel(pane.agent_status);
   const dir = basename(pane.foreground_cwd || pane.cwd);
   return [stateText, bridgeLabel, workspace?.label, tabLabel, dir].filter(Boolean).join(" · ");
-}
-
-function basename(path?: string) {
-  if (!path) {
-    return "";
-  }
-  const trimmed = path.replace(/\/+$/, "");
-  if (!trimmed) {
-    return "";
-  }
-  return trimmed.split("/").pop() ?? "";
 }
 
 function SplitGlyph() {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -948,24 +948,24 @@ export function App() {
         }
         return true;
       }
-      if (notesPanelOpen) {
-        setNotesPanelOpen(false);
-        return true;
-      }
-      if (backendSettingsOpen) {
-        setBackendSettingsOpen(false);
-        return true;
-      }
-      if (launchTarget) {
-        setLaunchTarget(null);
+      if (menu) {
+        setMenu(null);
         return true;
       }
       if (dialog) {
         setDialog(null);
         return true;
       }
-      if (menu) {
-        setMenu(null);
+      if (launchTarget) {
+        setLaunchTarget(null);
+        return true;
+      }
+      if (backendSettingsOpen) {
+        setBackendSettingsOpen(false);
+        return true;
+      }
+      if (notesPanelOpen) {
+        setNotesPanelOpen(false);
         return true;
       }
       return false;
@@ -1221,7 +1221,14 @@ export function App() {
     }
     const restoredPaneId = selectedPanesByBridgeId[selectedRuntime.id] ?? null;
     const nextPaneId = chooseSelectedPane(snapshot, restoredPaneId);
-    setSelectedPaneRefState(nextPaneId ? { bridgeId: selectedRuntime.id, paneId: nextPaneId } : null);
+    setSelectedPaneRefState((current) => {
+      if (!nextPaneId) {
+        return current === null ? current : null;
+      }
+      return current?.bridgeId === selectedRuntime.id && current.paneId === nextPaneId
+        ? current
+        : { bridgeId: selectedRuntime.id, paneId: nextPaneId };
+    });
     if (nextPaneId) {
       setSelectedPanesByBridgeId((current) =>
         current[selectedRuntime.id] === nextPaneId
@@ -1230,10 +1237,11 @@ export function App() {
       );
       const pane = snapshot?.panes.find((item) => item.pane_id === nextPaneId);
       if (pane) {
-        setActiveWorkspaceRefState({
-          bridgeId: selectedRuntime.id,
-          workspaceId: pane.workspace_id,
-        });
+        setActiveWorkspaceRefState((current) =>
+          current?.bridgeId === selectedRuntime.id && current.workspaceId === pane.workspace_id
+            ? current
+            : { bridgeId: selectedRuntime.id, workspaceId: pane.workspace_id },
+        );
         setActiveWorkspacesByBridgeId((current) =>
           current[selectedRuntime.id] === pane.workspace_id
             ? current
@@ -1243,11 +1251,14 @@ export function App() {
       return;
     }
     const restoredWorkspaceId = activeWorkspacesByBridgeId[selectedRuntime.id];
-    setActiveWorkspaceRefState(
-      restoredWorkspaceId
-        ? { bridgeId: selectedRuntime.id, workspaceId: restoredWorkspaceId }
-        : null,
-    );
+    setActiveWorkspaceRefState((current) => {
+      if (!restoredWorkspaceId) {
+        return current === null ? current : null;
+      }
+      return current?.bridgeId === selectedRuntime.id && current.workspaceId === restoredWorkspaceId
+        ? current
+        : { bridgeId: selectedRuntime.id, workspaceId: restoredWorkspaceId };
+    });
   }, [
     activeWorkspacesByBridgeId,
     selectedPanesByBridgeId,
@@ -1632,7 +1643,9 @@ export function App() {
     selectedRuntime && notesStates[selectedRuntime.id]?.connectionKey === selectedRuntime.connectionKey
       ? notesStates[selectedRuntime.id]
       : null;
-  const selectedBridgeNotes = notesEnabled ? selectedNotesState?.response?.notes ?? [] : [];
+  const selectedBridgeNotes = notesEnabled
+    ? selectedNotesState?.response?.notes ?? EMPTY_PANE_NOTES
+    : EMPTY_PANE_NOTES;
   const selectedPaneNotes = useMemo(
     () => notesForPane(selectedBridgeNotes, selectedPane?.pane_id),
     [selectedBridgeNotes, selectedPane?.pane_id],
@@ -1646,7 +1659,9 @@ export function App() {
     const paneChanged = selectedNotePaneKeyRef.current !== selectedPaneKey;
     selectedNotePaneKeyRef.current = selectedPaneKey;
     if (!selectedPaneKey || !selectedRuntimeId) {
-      setSelectedNoteRef(null);
+      if (paneChanged) {
+        setSelectedNoteRef(null);
+      }
       return;
     }
     setSelectedNoteRef((current) => {
@@ -4110,6 +4125,7 @@ export function activeWorkspaceForBridgeView(
   );
 }
 
+const EMPTY_PANE_NOTES: PaneNote[] = [];
 const EMPTY_AGENT_PIN_KEYS = new Set<string>();
 const EMPTY_AGENT_ACTIVITY_TRANSITIONS = new Map<string, number>();
 

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -1077,6 +1077,7 @@ function DraftNumberInput({
   onCommit: (value: number) => void;
 }) {
   const [draft, setDraft] = useState(String(value));
+  const skipDraftBlurCommitRef = useRef(false);
 
   useEffect(() => {
     setDraft(String(value));
@@ -1085,7 +1086,9 @@ function DraftNumberInput({
   const commit = () => {
     const next = Number(draft);
     if (Number.isFinite(next)) {
-      onCommit(next);
+      const clamped = Math.min(max, Math.max(min, next));
+      setDraft(String(clamped));
+      onCommit(clamped);
       return;
     }
     setDraft(String(value));
@@ -1102,11 +1105,22 @@ function DraftNumberInput({
       aria-label={ariaLabel}
       onFocus={(event) => event.currentTarget.select()}
       onChange={(event) => setDraft(event.currentTarget.value)}
-      onBlur={commit}
+      onBlur={() => {
+        if (skipDraftBlurCommitRef.current) {
+          skipDraftBlurCommitRef.current = false;
+          return;
+        }
+        commit();
+      }}
       onKeyDown={(event) => {
         if (event.key === "Enter") {
+          event.preventDefault();
+          event.stopPropagation();
           event.currentTarget.blur();
         } else if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          skipDraftBlurCommitRef.current = true;
           setDraft(String(value));
           event.currentTarget.blur();
         }

--- a/web/src/NoteMarkdownPreview.tsx
+++ b/web/src/NoteMarkdownPreview.tsx
@@ -16,14 +16,16 @@ export default function NoteMarkdownPreview({ body }: NoteMarkdownPreviewProps) 
       remarkPlugins={[remarkGfm]}
       urlTransform={safeMarkdownUrl}
       components={{
-        a: ({ children, href, ...props }) =>
-          href ? (
+        a: ({ node, children, href, ...props }) => {
+          void node;
+          return href ? (
             <a {...props} href={href} target="_blank" rel="noopener noreferrer">
               {children}
             </a>
           ) : (
             <span>{children}</span>
-          ),
+          );
+        },
       }}
     >
       {body}

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -557,10 +557,11 @@ export function TerminalView({
         publishReady();
       })
       .catch((error: unknown) => {
-        console.error("failed to mount terminal renderer", error);
-        if (!disposed) {
-          setConnectionState("error");
+        if (disposed) {
+          return;
         }
+        console.error("failed to mount terminal renderer", error);
+        setConnectionState("error");
       });
 
     return () => {

--- a/web/src/agentActivity.ts
+++ b/web/src/agentActivity.ts
@@ -1,3 +1,5 @@
+import { apiErrorMessage } from "./bridgeApi";
+import type { BridgeHttpUrl } from "./bridgeApi";
 import { fetchWithTimeout } from "./fetchWithTimeout";
 import type { BridgeCapabilities } from "./bridge";
 import type { AgentStatus } from "./types";
@@ -16,7 +18,7 @@ export type AgentActivityListResponse = {
   records: AgentActivityRecord[];
 };
 
-export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
+export type { BridgeHttpUrl } from "./bridgeApi";
 
 export class AgentActivityApiError extends Error {
   readonly status: number;
@@ -114,15 +116,11 @@ async function parseAgentActivityResponse(response: Response) {
 }
 
 async function agentActivityApiError(response: Response) {
-  try {
-    const parsed = (await response.json()) as { error?: unknown };
-    if (typeof parsed.error === "string" && parsed.error.trim()) {
-      return new AgentActivityApiError(parsed.error, response.status);
-    }
-  } catch {
-    // Fall through to the status-based error.
-  }
-  return new AgentActivityApiError(`agent activity failed: ${response.status}`, response.status);
+  const message = await apiErrorMessage(response);
+  return new AgentActivityApiError(
+    message ?? `agent activity failed: ${response.status}`,
+    response.status,
+  );
 }
 
 function isAgentStatus(value: unknown): value is AgentStatus {

--- a/web/src/agentPins.test.ts
+++ b/web/src/agentPins.test.ts
@@ -3,6 +3,8 @@ import {
   AgentPinsApiError,
   agentPinKey,
   agentPinKeys,
+  fetchAgentPins,
+  parseAgentPinsListResponse,
   pinAgent,
   supportsAgentPins,
 } from "./agentPins";
@@ -35,6 +37,58 @@ describe("agent pin helpers", () => {
         ],
       })],
     ).toEqual(["bridge-a:pane-a"]);
+  });
+
+  it("rejects malformed 200 responses at the fetch boundary", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ session_key: "session:default", pins: "nope" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(fetchAgentPins((path) => `http://bridge${path}`)).rejects.toThrow(
+      "agent pins response is invalid",
+    );
+  });
+
+  it("validates pin records and tolerates missing context", () => {
+    expect(
+      parseAgentPinsListResponse({
+        session_key: "session:default",
+        pins: [
+          {
+            pane_id: "pane-a",
+            terminal_id: "terminal-a",
+            workspace_id: "workspace-a",
+            tab_id: "tab-a",
+            created_at: "100",
+            context: { pane_label: "build", ignored: 3 },
+          },
+        ],
+      }),
+    ).toEqual({
+      session_key: "session:default",
+      pins: [
+        {
+          pane_id: "pane-a",
+          terminal_id: "terminal-a",
+          workspace_id: "workspace-a",
+          tab_id: "tab-a",
+          created_at: "100",
+          context: { pane_label: "build" },
+        },
+      ],
+    });
+    expect(() =>
+      parseAgentPinsListResponse({
+        session_key: "session:default",
+        pins: [{ pane_id: 5 }],
+      }),
+    ).toThrow("agent pin record is invalid");
   });
 
   it("preserves HTTP status for pin errors", async () => {

--- a/web/src/agentPins.ts
+++ b/web/src/agentPins.ts
@@ -72,7 +72,65 @@ async function parseAgentPinsResponse(response: Response) {
   if (!response.ok) {
     throw await agentPinsApiError(response);
   }
-  return (await response.json()) as AgentPinsListResponse;
+  return parseAgentPinsListResponse(await response.json());
+}
+
+export function parseAgentPinsListResponse(value: unknown): AgentPinsListResponse {
+  if (!isRecord(value) || typeof value.session_key !== "string" || !Array.isArray(value.pins)) {
+    throw new Error("agent pins response is invalid");
+  }
+  return {
+    session_key: value.session_key,
+    pins: value.pins.map(parseAgentPin),
+  };
+}
+
+function parseAgentPin(value: unknown): AgentPin {
+  if (
+    !isRecord(value) ||
+    typeof value.pane_id !== "string" ||
+    typeof value.terminal_id !== "string" ||
+    typeof value.workspace_id !== "string" ||
+    typeof value.tab_id !== "string" ||
+    typeof value.created_at !== "string"
+  ) {
+    throw new Error("agent pin record is invalid");
+  }
+  return {
+    pane_id: value.pane_id,
+    terminal_id: value.terminal_id,
+    workspace_id: value.workspace_id,
+    tab_id: value.tab_id,
+    created_at: value.created_at,
+    context: parseAgentPinContext(value.context),
+  };
+}
+
+const agentPinContextFields = [
+  "pane_label",
+  "pane_title",
+  "agent",
+  "display_agent",
+  "cwd",
+  "foreground_cwd",
+] as const;
+
+function parseAgentPinContext(value: unknown): AgentPinContext {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const context: AgentPinContext = {};
+  for (const field of agentPinContextFields) {
+    const fieldValue = value[field];
+    if (typeof fieldValue === "string") {
+      context[field] = fieldValue;
+    }
+  }
+  return context;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function agentPinsApiError(response: Response) {

--- a/web/src/agentPins.ts
+++ b/web/src/agentPins.ts
@@ -1,3 +1,5 @@
+import { apiErrorMessage } from "./bridgeApi";
+import type { BridgeHttpUrl } from "./bridgeApi";
 import { fetchWithTimeout } from "./fetchWithTimeout";
 import type { BridgeCapabilities } from "./bridge";
 
@@ -24,7 +26,7 @@ export type AgentPinsListResponse = {
   pins: AgentPin[];
 };
 
-export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
+export type { BridgeHttpUrl } from "./bridgeApi";
 
 export class AgentPinsApiError extends Error {
   readonly status: number;
@@ -134,13 +136,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 async function agentPinsApiError(response: Response) {
-  try {
-    const parsed = (await response.json()) as { error?: unknown };
-    if (typeof parsed.error === "string" && parsed.error.trim()) {
-      return new AgentPinsApiError(parsed.error, response.status);
-    }
-  } catch {
-    // Fall through to the status-based error.
-  }
-  return new AgentPinsApiError(`agent pins failed: ${response.status}`, response.status);
+  const message = await apiErrorMessage(response);
+  return new AgentPinsApiError(
+    message ?? `agent pins failed: ${response.status}`,
+    response.status,
+  );
 }

--- a/web/src/bridgeApi.ts
+++ b/web/src/bridgeApi.ts
@@ -1,0 +1,13 @@
+export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
+
+export async function apiErrorMessage(response: Response): Promise<string | null> {
+  try {
+    const parsed = (await response.json()) as { error?: unknown };
+    if (typeof parsed.error === "string" && parsed.error.trim()) {
+      return parsed.error.trim();
+    }
+  } catch {
+    // Fall through to the status-based error.
+  }
+  return null;
+}

--- a/web/src/commands.test.ts
+++ b/web/src/commands.test.ts
@@ -3,7 +3,6 @@ import {
   commands,
   createCommands,
   createdPaneId,
-  probeSupportedCommands,
 } from "./commands";
 
 describe("command helpers", () => {
@@ -19,34 +18,21 @@ describe("command helpers", () => {
     expect(createdPaneId({})).toBeNull();
   });
 
-  it("returns supported command names from bridge capabilities", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ commands: ["pane.split", "pane.move", 42] }), {
-        status: 200,
-      }),
-    );
-
-    await expect(probeSupportedCommands()).resolves.toEqual(new Set(["pane.split", "pane.move"]));
-    expect(fetch).toHaveBeenCalledWith("/api/capabilities");
-  });
-
-  it("uses injected bridge URLs for commands and capability probes", async () => {
+  it("uses injected bridge URLs for commands", async () => {
     const httpUrl = (path: string) => `http://192.168.1.20:4000${path}`;
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ commands: ["pane.split"], type: "ok" }), {
+      new Response(JSON.stringify({ type: "ok" }), {
         status: 200,
       }),
     );
 
     await createCommands(httpUrl).closePane("pane-1");
-    await probeSupportedCommands(httpUrl);
 
     expect(fetch).toHaveBeenNthCalledWith(
       1,
       "http://192.168.1.20:4000/api/command",
       expect.objectContaining({ method: "POST" }),
     );
-    expect(fetch).toHaveBeenNthCalledWith(2, "http://192.168.1.20:4000/api/capabilities");
   });
 
   it("creates launch tabs without a tab label and renames the root pane", async () => {

--- a/web/src/commands.ts
+++ b/web/src/commands.ts
@@ -1,5 +1,6 @@
 // Mutating commands proxied through the bridge's allow-listed /api/command.
 
+import type { BridgeHttpUrl } from "./bridgeApi";
 import { agentArgv } from "./launch";
 import type { LaunchSpec, SplitDirection } from "./launch";
 import { shellCommand } from "./shell";
@@ -7,7 +8,7 @@ import { shellCommand } from "./shell";
 export type CommandResult = { type?: string; [key: string]: unknown };
 export type PaneFocusDirection = "left" | "right" | "up" | "down";
 export type { LaunchSpec, SplitDirection };
-export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
+export type { BridgeHttpUrl } from "./bridgeApi";
 
 const sameOriginHttpUrl: BridgeHttpUrl = (path, query) => {
   const suffix = query && query.toString() ? `?${query.toString()}` : "";
@@ -142,21 +143,3 @@ export function createCommands(httpUrl: BridgeHttpUrl = sameOriginHttpUrl) {
 }
 
 export const commands = createCommands();
-
-export async function probeSupportedCommands(
-  httpUrl: BridgeHttpUrl = sameOriginHttpUrl,
-): Promise<Set<string>> {
-  try {
-    const response = await fetch(httpUrl("/api/capabilities"));
-    if (!response.ok) {
-      return new Set();
-    }
-    const body = (await response.json()) as { commands?: unknown };
-    if (!Array.isArray(body.commands)) {
-      return new Set();
-    }
-    return new Set(body.commands.filter((command): command is string => typeof command === "string"));
-  } catch {
-    return new Set();
-  }
-}

--- a/web/src/notes.ts
+++ b/web/src/notes.ts
@@ -1,3 +1,5 @@
+import { apiErrorMessage } from "./bridgeApi";
+import type { BridgeHttpUrl } from "./bridgeApi";
 import { fetchWithTimeout } from "./fetchWithTimeout";
 import type { PaneInfo } from "./types";
 import type { BridgeCapabilities } from "./bridge";
@@ -75,7 +77,7 @@ export type NoteRevisionInput = {
   expectedRevision: number;
 };
 
-export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
+export type { BridgeHttpUrl } from "./bridgeApi";
 
 export class NotesApiError extends Error {
   readonly status: number;
@@ -214,15 +216,11 @@ async function parseNoteResponse(response: Response) {
 }
 
 async function notesApiError(response: Response, fallback: string) {
-  try {
-    const parsed = (await response.json()) as { error?: unknown };
-    if (typeof parsed.error === "string" && parsed.error.trim()) {
-      return new NotesApiError(parsed.error, response.status);
-    }
-  } catch {
-    // Fall through to the status-based error.
-  }
-  return new NotesApiError(`${fallback} failed: ${response.status}`, response.status);
+  const message = await apiErrorMessage(response);
+  return new NotesApiError(
+    message ?? `${fallback} failed: ${response.status}`,
+    response.status,
+  );
 }
 
 function notePath(noteId: string, action: string) {

--- a/web/src/overlays.tsx
+++ b/web/src/overlays.tsx
@@ -174,7 +174,15 @@ export function RenameDialog({
   return (
     <div className="overlay-root">
       <button className="overlay-scrim" type="button" aria-label="Cancel" onClick={onCancel} />
-      <form className="modal" onSubmit={submit}>
+      <form
+        className="modal"
+        onSubmit={submit}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            onCancel();
+          }
+        }}
+      >
         <div className="modal-title">{title}</div>
         <input
           ref={inputRef}
@@ -184,11 +192,6 @@ export function RenameDialog({
           spellCheck={false}
           autoComplete="off"
           onChange={(event) => setValue(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === "Escape") {
-              onCancel();
-            }
-          }}
         />
         <div className="modal-actions">
           {onClear ? (

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -178,7 +178,7 @@ export function aggregateStatus(panes: PaneInfo[]): AgentStatus {
   return "unknown";
 }
 
-function basename(path?: string) {
+export function basename(path?: string) {
   if (!path) {
     return "";
   }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -510,7 +510,8 @@ button {
 .space-row,
 .pane-row,
 .tab-head,
-.tabbar-tab {
+.tabbar-tab,
+.stage-id {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   user-select: none;
@@ -1682,13 +1683,13 @@ button {
   border-radius: var(--r-md);
   padding: 10px;
   background: color-mix(in srgb, var(--mantle) 94%, black);
-  box-shadow: var(--shadow);
+  box-shadow: 0 12px 34px rgb(0 0 0 / 44%);
 }
 
 .terminal-selection-url {
   min-width: 0;
   overflow: hidden;
-  color: var(--subtext);
+  color: var(--subtext0);
   font-size: 12px;
   line-height: 1.3;
   text-overflow: ellipsis;

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -92,6 +92,8 @@ type TerminalBufferLine = {
         getCodepoint(): number;
         getWidth(): number;
         getHyperlinkId(): number;
+        // Raw ghostty cell data; grapheme_len > 0 marks a multi-codepoint cluster.
+        cell?: { grapheme_len?: number };
       }
     | undefined;
 };
@@ -136,6 +138,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS;
   #textInputTapGraceUntil = 0;
   #fontSizePx: number;
+  #disposed = false;
 
   constructor(fontSizePx = DEFAULT_TERMINAL_FONT_SIZE_PX) {
     this.#fontSizePx = fontSizePx;
@@ -143,6 +146,9 @@ export class GhosttyRenderer implements TerminalRenderer {
 
   async mount(container: HTMLElement) {
     const { FitAddon, Terminal } = await loadGhosttyModule();
+    if (this.#disposed) {
+      throw new Error("terminal renderer disposed");
+    }
 
     this.#container = container;
     const terminal = new Terminal({
@@ -293,6 +299,7 @@ export class GhosttyRenderer implements TerminalRenderer {
   }
 
   dispose() {
+    this.#disposed = true;
     this.#touchCleanup?.();
     this.#touchCleanup = null;
     this.#mobileInputCleanup?.();
@@ -1299,11 +1306,6 @@ function selectTerminalViewportRange(
     return;
   }
 
-  if (start.row === end.row && start.col === end.col) {
-    terminal.select(start.col, start.row, 1);
-    return;
-  }
-
   markSelectionRowsDirty(selectionManager, selectionManager.getSelectionCoords());
   selectionManager.selectionStart = {
     col: start.col,
@@ -1367,12 +1369,44 @@ function terminalSelectedTextFromViewportRange(
     const line = terminal.buffer.active.getLine(bufferRow) as TerminalBufferLine | undefined;
     const startCol = row === range.from.row ? range.from.col : 0;
     const endCol = row === range.to.row ? range.to.col : terminal.cols - 1;
-    selectedLines.push(line ? terminalBufferLineCellText(line, startCol, endCol).trimEnd() : "");
+    selectedLines.push(
+      line
+        ? terminalBufferLineCellText(
+            line,
+            startCol,
+            endCol,
+            terminalGraphemeReader(terminal, bufferRow),
+          ).trimEnd()
+        : "",
+    );
   }
   return selectedLines.join("\n");
 }
 
-function terminalBufferLineCellText(line: TerminalBufferLine, startCol: number, endCol: number) {
+// Cells holding multi-codepoint grapheme clusters (combining marks, emoji with
+// modifiers/ZWJ) store only the first codepoint; the full cluster has to be
+// read back through the wasm terminal, mirroring the vendored getSelection().
+function terminalGraphemeReader(terminal: Terminal, bufferRow: number) {
+  const wasmTerm = terminal.wasmTerm;
+  if (
+    typeof wasmTerm?.getGraphemeString !== "function" ||
+    typeof wasmTerm.getScrollbackGraphemeString !== "function"
+  ) {
+    return null;
+  }
+  const scrollbackLength = terminal.getScrollbackLength();
+  return (col: number) =>
+    bufferRow < scrollbackLength
+      ? wasmTerm.getScrollbackGraphemeString(bufferRow, col)
+      : wasmTerm.getGraphemeString(bufferRow - scrollbackLength, col);
+}
+
+function terminalBufferLineCellText(
+  line: TerminalBufferLine,
+  startCol: number,
+  endCol: number,
+  readGrapheme: ((col: number) => string) | null = null,
+) {
   let text = "";
   for (let col = startCol; col <= endCol && col < line.length; col += 1) {
     const cell = line.getCell(col);
@@ -1380,7 +1414,13 @@ function terminalBufferLineCellText(line: TerminalBufferLine, startCol: number, 
     if (codepoint === 0 && cell?.getWidth() === 0) {
       continue;
     }
-    text += codepoint === 0 || codepoint < 32 ? " " : String.fromCodePoint(codepoint);
+    if (codepoint === 0 || codepoint < 32) {
+      text += " ";
+      continue;
+    }
+    const graphemeLength = cell?.cell?.grapheme_len ?? 0;
+    const cluster = graphemeLength > 0 ? readGrapheme?.(col) : null;
+    text += cluster || String.fromCodePoint(codepoint);
   }
   return text;
 }


### PR DESCRIPTION
## Summary

Full-repository review and cleanup pass (multi-agent review: 9 dimensions, 50 findings, 23 confirmed bugs after adversarial verification), followed by batched fixes. Targets `feature/sidebar-pane-add-note` so it carries only the review changes.

Net: 29 files, +927/−1034 — the repo shrinks while fixing 23 confirmed bugs and adding tests.

### Bug fixes — web (`8e7fc94`, `e8b4604`)

- Keep the selected note open while no pane is selected; notes no longer deselect mid-edit on bridge disconnect, zero panes, or a notes refresh (directly affects the sidebar-note feature underneath this branch).
- Stop rewriting display prefs to storage on every 10s snapshot poll (ref identity churn).
- Android hardware back closes menus/dialogs before the notes panel beneath them.
- Settings number fields: Escape reverts instead of committing via blur, no longer closes the whole dialog; out-of-range values snap back to the clamped bound.
- Rename dialog cancels on Escape from any focused control.
- Long-press text-selection prevention extended to the stage pane title; terminal selection sheet had two undefined CSS variables (`--shadow`, `--subtext`).
- Agent-pins responses validated at the fetch boundary (malformed 200 no longer crashes the sidebar render); junk `node` attribute removed from markdown preview links.
- Terminal renderer: cancelled mount no longer leaks an orphaned terminal + duplicate canvas; single-cell touch selection stores correct rows and paints; touch-copy preserves combining characters and multi-codepoint emoji.

### Bug fixes — bridge (`34a9936`)

- Lagged terminal broadcasts close the socket for a clean reattach instead of silently corrupting the ANSI stream.
- Remaining synchronous daemon round-trips (snapshot, selection, agent activity, rename labels) moved into `spawn_blocking`; a stalled daemon can no longer pin tokio workers and freeze the bridge.
- Per-terminal input queue bounded at 8 MiB.
- Terminal session client counting moved under the session-map lock (no more detached-session handoff race); attach handshake moved outside the lock.
- Upload dir is only chmod-0700 when the bridge created it; `pane.rename` gets the standard label validation.

### Script hardening (`f60b54f`)

- `release.mjs` can no longer push an empty release commit/tag (empty-template guard, check before stamping, notes extraction before push).
- `package-tarball.sh` no longer depends on the caller's cwd; `check-vendor.sh` wire.rs comparison can no longer pass vacuously.

### Docs (`a4dfd3a`)

AGENTS.md bridge tests require cargo (not Zig); README settings areas and endpoint lists completed; web/README routes completed; android.md stale public-IP claim removed and smoke checklist fixed; CHANGELOG entries corrected.

### Deduplication (`100e2ae`, `012d9a6`) — behavior-neutral

- Web: legacy display-prefs parsing delegates to the canonical parser; one generic `refreshBridgeResource` replaces three copied refresh state machines; shared resize hook, agent-row renderer, `basename`, rank tables; dead `probeSupportedCommands` removed; shared `bridgeApi.ts`.
- Bridge: shared `store_util.rs` for the file-store plumbing triplicated across notes/pins/activity; `run_store_task` merges two identical wrappers; agent-activity session key unified with notes/pins (memory-only state; changelog note included).

## Verification

- `npm run check` (vendor check, ESLint, Vitest 166, cargo tests 92, web + bridge builds) green after every batch; clippy clean.
- Live smoke test against the running bridge service with the release binary: zero console errors, zero failed API calls; sidebar, tabs, terminal rendering, and settings dialog verified via Playwright.

## Known deferrals

- Attach `Welcome` read still has no socket read timeout (`interprocess` lacks a portable API); after the lock restructure a stalled daemon affects only the initiating connection instead of wedging the bridge.
- Pre-existing React 19 type deprecations and the >500 kB chunk warning left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
