### PR TITLE
Fix mobile sidebar space tab selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed mobile sidebar space selection so tapping a space updates the scoped Tabs list instead of
+  snapping back to tabs from the previously selected pane.
 - Fixed a bridge reattach race where a client reconnecting right after the last viewer left a
   terminal could be rejected by the daemon with `already has an attached client` and shown a
   permanent `Attached elsewhere` error; the bridge now shuts detached attach connections down and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed mobile sidebar space selection so tapping a space updates the scoped Tabs list instead of
   snapping back to tabs from the previously selected pane.
+  [PR #29](https://github.com/kcosr/herdr-web/pull/29)
 - Fixed a bridge reattach race where a client reconnecting right after the last viewer left a
   terminal could be rejected by the daemon with `already has an attached client` and shown a
   permanent `Attached elsewhere` error; the bridge now shuts detached attach connections down and

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -137,6 +137,7 @@ import {
   choosePaneForTab,
   choosePaneForWorkspace,
   chooseSelectedPane,
+  chooseSelectedPaneForActiveWorkspace,
   countAttention,
   displayTabLabel,
   isAttention,
@@ -1162,7 +1163,12 @@ export function App() {
       return;
     }
     const restoredPaneId = selectedPanesByBridgeId[selectedRuntime.id] ?? null;
-    const nextPaneId = chooseSelectedPane(snapshot, restoredPaneId);
+    const restoredWorkspaceId = activeWorkspacesByBridgeId[selectedRuntime.id] ?? null;
+    const nextPaneId = chooseSelectedPaneForActiveWorkspace(
+      snapshot,
+      restoredPaneId,
+      restoredWorkspaceId,
+    );
     setSelectedPaneRefState((current) => {
       if (!nextPaneId) {
         return current === null ? current : null;
@@ -1192,7 +1198,6 @@ export function App() {
       }
       return;
     }
-    const restoredWorkspaceId = activeWorkspacesByBridgeId[selectedRuntime.id];
     setActiveWorkspaceRefState((current) => {
       if (!restoredWorkspaceId) {
         return current === null ? current : null;
@@ -1795,7 +1800,7 @@ export function App() {
     setActiveWorkspacesByBridgeId((current) =>
       current[bridgeId] === workspaceId ? current : { ...current, [bridgeId]: workspaceId },
     );
-    if (!isCompactLayout && bridgeSnapshot) {
+    if (bridgeSnapshot) {
       const paneId = choosePaneForWorkspace(bridgeSnapshot, workspaceId);
       if (paneId) {
         const pane = bridgeSnapshot.panes.find((item) => item.pane_id === paneId);

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -5,6 +5,7 @@ import {
   choosePaneForTab,
   choosePaneForWorkspace,
   chooseSelectedPane,
+  chooseSelectedPaneForActiveWorkspace,
   displayTabLabel,
   paneTitle,
   sortPanesForPicker,
@@ -130,6 +131,26 @@ describe("chooseSelectedPane", () => {
   });
 });
 
+describe("chooseSelectedPaneForActiveWorkspace", () => {
+  it("keeps a selected pane that already belongs to the active workspace", () => {
+    const data = multiWorkspaceSnapshot();
+
+    expect(chooseSelectedPaneForActiveWorkspace(data, "2-1", "2")).toBe("2-1");
+  });
+
+  it("chooses from the active workspace instead of keeping a stale pane from another workspace", () => {
+    const data = multiWorkspaceSnapshot();
+
+    expect(chooseSelectedPaneForActiveWorkspace(data, "1-1", "2")).toBe("2-2");
+  });
+
+  it("falls back to normal pane selection when the active workspace is gone", () => {
+    const data = multiWorkspaceSnapshot();
+
+    expect(chooseSelectedPaneForActiveWorkspace(data, "1-1", "missing")).toBe("1-1");
+  });
+});
+
 describe("projection selection helpers", () => {
   it("chooses a pane from the workspace active tab", () => {
     const data = snapshot([
@@ -149,6 +170,68 @@ describe("projection selection helpers", () => {
     expect(choosePaneForTab(data, "1-2")).toBe("1-3");
   });
 });
+
+function multiWorkspaceSnapshot(): Snapshot {
+  return {
+    workspaces: [
+      {
+        workspace_id: "1",
+        number: 1,
+        label: "one",
+        focused: false,
+        pane_count: 1,
+        tab_count: 1,
+        active_tab_id: "1-1",
+        agent_status: "idle",
+      },
+      {
+        workspace_id: "2",
+        number: 2,
+        label: "two",
+        focused: true,
+        pane_count: 2,
+        tab_count: 2,
+        active_tab_id: "2-2",
+        agent_status: "idle",
+      },
+    ],
+    tabs: [
+      {
+        tab_id: "1-1",
+        workspace_id: "1",
+        number: 1,
+        label: "one",
+        focused: false,
+        pane_count: 1,
+        agent_status: "idle",
+      },
+      {
+        tab_id: "2-1",
+        workspace_id: "2",
+        number: 1,
+        label: "two-a",
+        focused: false,
+        pane_count: 1,
+        agent_status: "idle",
+      },
+      {
+        tab_id: "2-2",
+        workspace_id: "2",
+        number: 2,
+        label: "two-b",
+        focused: true,
+        pane_count: 1,
+        agent_status: "idle",
+      },
+    ],
+    panes: [
+      { ...pane("1-1"), workspace_id: "1", tab_id: "1-1" },
+      { ...pane("2-1"), workspace_id: "2", tab_id: "2-1" },
+      { ...pane("2-2"), workspace_id: "2", tab_id: "2-2" },
+    ],
+    layouts: [],
+  };
+}
 
 describe("sortPanesForPicker", () => {
   it("puts urgent agent states first", () => {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -24,6 +24,26 @@ export function chooseSelectedPane(snapshot: Snapshot | null, currentPaneId: str
   return snapshot.panes.find((pane) => pane.focused)?.pane_id ?? snapshot.panes[0].pane_id;
 }
 
+export function chooseSelectedPaneForActiveWorkspace(
+  snapshot: Snapshot | null,
+  currentPaneId: string | null,
+  activeWorkspaceId: string | null,
+) {
+  if (!snapshot || !activeWorkspaceId) {
+    return chooseSelectedPane(snapshot, currentPaneId);
+  }
+  if (!snapshot.workspaces.some((workspace) => workspace.workspace_id === activeWorkspaceId)) {
+    return chooseSelectedPane(snapshot, currentPaneId);
+  }
+  const currentPane = currentPaneId
+    ? snapshot.panes.find((pane) => pane.pane_id === currentPaneId)
+    : null;
+  if (currentPane?.workspace_id === activeWorkspaceId) {
+    return chooseSelectedPane(snapshot, currentPaneId);
+  }
+  return choosePaneForWorkspace(snapshot, activeWorkspaceId);
+}
+
 export function choosePaneForWorkspace(snapshot: Snapshot, workspaceId: string) {
   const workspace = snapshot.workspaces.find((item) => item.workspace_id === workspaceId);
   const preferredTabId =


### PR DESCRIPTION
## Summary
- keep the selected pane scoped to the active workspace when the mobile sidebar space changes
- update mobile space selection to choose that space's active pane instead of preserving a stale pane from another workspace
- add state helper coverage for stale cross-workspace pane selection

## Tests
- Not run in this handoff; branch contains focused Vitest coverage.
