### PR TITLE
Use Herdr 0.7.2 session snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Breaking Changes
 
-- The bridge now requires a Herdr `v0.7.2` or newer daemon with protocol `16` because browser
-  snapshots use Herdr's native `session.snapshot` API.
+- Users must upgrade Herdr to `v0.7.2` or newer before upgrading herdr-web. The bridge now requires
+  a Herdr daemon with protocol `16` because browser snapshots use Herdr's native
+  `session.snapshot` API.
   [PR #32](https://github.com/kcosr/herdr-web/pull/32)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The bridge now requires a Herdr `v0.7.2` or newer daemon with protocol `16` because browser
   snapshots use Herdr's native `session.snapshot` API.
+  [PR #32](https://github.com/kcosr/herdr-web/pull/32)
 
 ### Added
 
@@ -17,8 +18,10 @@
 
 - Refreshed the vendored Herdr compatibility baseline to `v0.7.2`, including protocol `16`, native
   session snapshots, layout/scroll event schema drift, and terminal observe/control wire messages.
+  [PR #32](https://github.com/kcosr/herdr-web/pull/32)
 - Changed `/api/snapshot` to use one native Herdr `session.snapshot` request instead of separate
   workspace, tab, pane, and per-tab layout requests.
+  [PR #32](https://github.com/kcosr/herdr-web/pull/32)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking Changes
 
+- The bridge now requires a Herdr `v0.7.2` or newer daemon with protocol `16` because browser
+  snapshots use Herdr's native `session.snapshot` API.
+
 ### Added
 
 - Added an Agents-view active-status filter that shows only agents currently
@@ -11,6 +14,11 @@
   filtering. [PR #31](https://github.com/kcosr/herdr-web/pull/31)
 
 ### Changed
+
+- Refreshed the vendored Herdr compatibility baseline to `v0.7.2`, including protocol `16`, native
+  session snapshots, layout/scroll event schema drift, and terminal observe/control wire messages.
+- Changed `/api/snapshot` to use one native Herdr `session.snapshot` request instead of separate
+  workspace, tab, pane, and per-tab layout requests.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The top-level scripts hide that detail.
 
 For release tarball users:
 
-- A running Herdr daemon/session
+- A running Herdr `v0.7.2` or newer daemon/session
 - A supported host for the downloaded bridge tarball. Current planned desktop release artifacts are
   Linux x86_64, macOS ARM64, and macOS x86_64.
 
@@ -75,7 +75,7 @@ For source development:
 - Node.js 22 or newer
 - npm
 - Rust stable
-- A running Herdr daemon/session
+- A running Herdr `v0.7.2` or newer daemon/session
 
 Android development also needs a JDK and Android SDK. See [docs/android.md](docs/android.md).
 
@@ -97,7 +97,7 @@ http://127.0.0.1:8787
 ```
 
 The desktop tarball includes the web assets and `herdr-web-bridge`; it does not include Herdr.
-Start or attach Herdr separately before running the bridge.
+Start or attach Herdr `v0.7.2` or newer separately before running the bridge.
 
 For Android, install the APK from the same release and add the bridge URL in the Bridge area of
 Settings. LAN bridges must allow Android's app origin:
@@ -200,12 +200,11 @@ Example:
 
 Presets use explicit argv, not multi-step terminal typing. Use `["bash", "-lc", "... && exec codex"]`
 when shell sequencing is needed. `agent_hint` injects `HERDR_AGENT=<agent>` for the launched process;
-Herdr `v0.7.1+` on Linux uses that hint to detect agents behind wrappers, SSH, containers, and VMs.
-Older Herdr versions still launch the command, but may display ordinary process detection.
+Herdr `v0.7.2+` on Linux uses that hint to detect agents behind wrappers, SSH, containers, and VMs.
 
 ## Run Locally
 
-Start or attach a normal Herdr session first:
+Start or attach a normal Herdr `v0.7.2` or newer session first:
 
 ```bash
 herdr

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -444,6 +444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +697,7 @@ dependencies = [
  "crossterm",
  "interprocess",
  "ratatui",
+ "schemars",
  "serde",
  "serde_json",
  "sha2",
@@ -1532,6 +1539,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1622,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1682,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bridge/src/agent_activity.rs
+++ b/bridge/src/agent_activity.rs
@@ -496,6 +496,7 @@ mod tests {
             agent_status: AgentStatus::Unknown,
             custom_status: None,
             state_labels: HashMap::new(),
+            scroll: None,
             revision: 1,
         }
     }

--- a/bridge/src/agent_pins.rs
+++ b/bridge/src/agent_pins.rs
@@ -427,6 +427,7 @@ mod tests {
             agent_status: AgentStatus::Idle,
             custom_status: None,
             state_labels: HashMap::new(),
+            scroll: None,
             revision: 1,
         }
     }

--- a/bridge/src/notes.rs
+++ b/bridge/src/notes.rs
@@ -1396,6 +1396,7 @@ mod tests {
             custom_status: None,
             state_labels: Default::default(),
             agent_session: None,
+            scroll: None,
             revision,
         }
     }

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -33,8 +33,8 @@ use tracing::{debug, info, warn};
 use herdr_compat::api::client::{ApiClient, ApiClientError};
 use herdr_compat::api::schema::{
     AgentStartParams, AgentStatus, EmptyParams, EventsSubscribeParams, LayoutApplyParams,
-    LayoutExportParams, Method, PaneInfo, PaneLayoutParams, PaneLayoutSnapshot, PaneListParams,
-    PaneMoveDestination, PaneSplitParams, Request, ResponseResult, SplitDirection, Subscription,
+    LayoutExportParams, Method, PaneInfo, PaneLayoutSnapshot, PaneListParams, PaneMoveDestination,
+    PaneSplitParams, Request, ResponseResult, SessionSnapshot, SplitDirection, Subscription,
     SubscriptionEventData, SubscriptionEventEnvelope, SubscriptionEventKind, TabCreateParams,
     TabInfo, TabListParams, WorkspaceInfo,
 };
@@ -60,7 +60,7 @@ const DEFAULT_PORT: u16 = 8787;
 const DEFAULT_COLS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
 const DEFAULT_STATIC_DIR: &str = "web/dist";
-const MIN_TERMINAL_ATTACH_PROTOCOL: u32 = 13;
+const MIN_TERMINAL_ATTACH_PROTOCOL: u32 = 16;
 const MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
 const MAX_NOTES_REQUEST_BYTES: usize = 512 * 1024;
 const MAX_TERMINAL_INPUT_CHUNK_BYTES: usize = 768 * 1024;
@@ -2227,12 +2227,24 @@ fn command_may_close_terminal_session(method: &Method) -> bool {
 }
 
 fn fill_clear_rename_labels(api: &ApiClient, method: &mut Method) -> Result<(), BridgeError> {
+    fill_clear_rename_labels_with(
+        method,
+        |workspace_id| default_workspace_label(api, workspace_id),
+        |tab_id| default_tab_label(api, tab_id),
+    )
+}
+
+fn fill_clear_rename_labels_with(
+    method: &mut Method,
+    mut workspace_default: impl FnMut(&str) -> Result<String, BridgeError>,
+    mut tab_default: impl FnMut(&str) -> Result<String, BridgeError>,
+) -> Result<(), BridgeError> {
     match method {
         Method::WorkspaceRename(params) if params.label.is_none() => {
-            params.label = Some(default_workspace_label(api, &params.workspace_id)?);
+            params.label = Some(workspace_default(&params.workspace_id)?);
         }
         Method::TabRename(params) if params.label.is_none() => {
-            params.label = Some(default_tab_label(api, &params.tab_id)?);
+            params.label = Some(tab_default(&params.tab_id)?);
         }
         _ => {}
     }
@@ -2245,15 +2257,20 @@ fn default_tab_label(api: &ApiClient, tab_id: &str) -> Result<String, BridgeErro
         "herdr-web:clear-tab-label",
         Method::TabList(TabListParams::default()),
     )? {
-        ResponseResult::TabList { tabs } => tabs
-            .into_iter()
-            .find(|tab| tab.tab_id == tab_id)
-            .map(|tab| tab.number.to_string())
-            .ok_or_else(|| BridgeError::BadRequest(format!("tab not found: {tab_id}"))),
+        ResponseResult::TabList { tabs } => default_tab_label_from_tabs(tab_id, tabs.iter()),
         other => Err(BridgeError::Protocol(format!(
             "unexpected response: {other:?}"
         ))),
     }
+}
+
+fn default_tab_label_from_tabs<'a>(
+    tab_id: &str,
+    mut tabs: impl Iterator<Item = &'a TabInfo>,
+) -> Result<String, BridgeError> {
+    tabs.find(|tab| tab.tab_id == tab_id)
+        .map(|tab| tab.number.to_string())
+        .ok_or_else(|| BridgeError::BadRequest(format!("tab not found: {tab_id}")))
 }
 
 fn default_workspace_label(api: &ApiClient, workspace_id: &str) -> Result<String, BridgeError> {
@@ -2417,40 +2434,23 @@ async fn snapshot_handler(
 ) -> Result<Json<Snapshot>, BridgeError> {
     ensure_allowed_request(&headers, &state.request_policy)?;
     let api_state = state.clone();
-    let (workspaces, tabs, panes, layouts) = tokio::task::spawn_blocking(move || {
-        let workspaces = match api_request(
+    let session_snapshot = tokio::task::spawn_blocking(move || {
+        match api_request(
             &api_state.api,
-            "herdr-web:workspace-list",
-            Method::WorkspaceList(EmptyParams::default()),
+            "herdr-web:session-snapshot",
+            Method::SessionSnapshot(EmptyParams::default()),
         )? {
-            ResponseResult::WorkspaceList { workspaces } => workspaces,
-            other => {
-                return Err(BridgeError::Protocol(format!(
-                    "unexpected response: {other:?}"
-                )))
-            }
-        };
-        let tabs = match api_request(
-            &api_state.api,
-            "herdr-web:tab-list",
-            Method::TabList(TabListParams::default()),
-        )? {
-            ResponseResult::TabList { tabs } => tabs,
-            other => {
-                return Err(BridgeError::Protocol(format!(
-                    "unexpected response: {other:?}"
-                )))
-            }
-        };
-        let panes = current_panes(&api_state.api)?;
-        observe_agent_activity_snapshot(&api_state, &panes);
-        let layouts = collect_tab_layouts(&api_state.api, &tabs, &panes);
-        Ok((workspaces, tabs, panes, layouts))
+            ResponseResult::SessionSnapshot { snapshot } => Ok(*snapshot),
+            other => Err(BridgeError::Protocol(format!(
+                "unexpected response: {other:?}"
+            ))),
+        }
     })
     .await
     .map_err(|err| BridgeError::Protocol(err.to_string()))??;
+    observe_agent_activity_snapshot(&state, &session_snapshot.panes);
     let notes = state.notes.clone();
-    let note_panes = panes.clone();
+    let note_panes = session_snapshot.panes.clone();
     match tokio::task::spawn_blocking(move || notes.observe_panes(&note_panes))
         .await
         .map_err(|err| BridgeError::Protocol(err.to_string()))?
@@ -2459,7 +2459,27 @@ async fn snapshot_handler(
         Ok(false) => {}
         Err(err) => warn!(error = %err, "failed to update pane note observations"),
     }
-    let selected_pane_id = shared_selected_pane(&state, &panes)?;
+    let selected_pane_id = shared_selected_pane(&state, &session_snapshot.panes)?;
+
+    Ok(Json(web_snapshot_from_session_snapshot(
+        session_snapshot,
+        selected_pane_id,
+    )))
+}
+
+fn web_snapshot_from_session_snapshot(
+    snapshot: SessionSnapshot,
+    selected_pane_id: Option<String>,
+) -> Snapshot {
+    let SessionSnapshot {
+        workspaces,
+        tabs,
+        panes,
+        layouts,
+        ..
+    } = snapshot;
+    let selected_pane_id = selected_pane_id
+        .filter(|pane_id| panes.iter().any(|pane| pane.pane_id == pane_id.as_str()));
     let workspaces = workspaces
         .into_iter()
         .map(|workspace| {
@@ -2482,13 +2502,13 @@ async fn snapshot_handler(
         })
         .collect();
 
-    Ok(Json(Snapshot {
+    Snapshot {
         workspaces,
         tabs,
         panes,
         layouts,
         selected_pane_id,
-    }))
+    }
 }
 
 fn is_default_tab_label(label: &str) -> bool {
@@ -2782,28 +2802,6 @@ fn api_request(api: &ApiClient, id: &str, method: Method) -> Result<ResponseResu
             method,
         })?
         .result)
-}
-
-fn collect_tab_layouts(
-    api: &ApiClient,
-    tabs: &[TabInfo],
-    panes: &[PaneInfo],
-) -> Vec<PaneLayoutSnapshot> {
-    tabs.iter()
-        .filter_map(|tab| {
-            let pane = panes.iter().find(|pane| pane.tab_id == tab.tab_id)?;
-            match api_request(
-                api,
-                &format!("herdr-web:layout:{}", tab.tab_id),
-                Method::PaneLayout(PaneLayoutParams {
-                    pane_id: Some(pane.pane_id.clone()),
-                }),
-            ) {
-                Ok(ResponseResult::PaneLayout { layout }) => Some(layout),
-                Ok(_) | Err(_) => None,
-            }
-        })
-        .collect()
 }
 
 async fn terminal_ws_handler(
@@ -3648,6 +3646,7 @@ fn structural_event_subscriptions() -> Vec<Subscription> {
         Subscription::WorkspaceCreated {},
         Subscription::WorkspaceUpdated {},
         Subscription::WorkspaceRenamed {},
+        Subscription::WorkspaceMoved {},
         Subscription::WorkspaceClosed {},
         Subscription::WorkspaceFocused {},
         Subscription::WorktreeCreated {},
@@ -3657,12 +3656,14 @@ fn structural_event_subscriptions() -> Vec<Subscription> {
         Subscription::TabClosed {},
         Subscription::TabFocused {},
         Subscription::TabRenamed {},
+        Subscription::TabMoved {},
         Subscription::PaneCreated {},
         Subscription::PaneClosed {},
         Subscription::PaneFocused {},
         Subscription::PaneMoved {},
         Subscription::PaneExited {},
         Subscription::PaneAgentDetected {},
+        Subscription::LayoutUpdated {},
     ]
 }
 
@@ -3961,6 +3962,7 @@ fn open_terminal_attach(
                 | ServerMessage::WindowTitle { .. }
                 | ServerMessage::ReloadSoundConfig
                 | ServerMessage::MouseCapture { .. }
+                | ServerMessage::PrefixInputSource { .. }
                 | ServerMessage::Frame(_)
                 | ServerMessage::Graphics { .. } => {}
             }
@@ -4702,6 +4704,64 @@ mod tests {
     }
 
     #[test]
+    fn web_snapshot_adapter_preserves_web_shape_and_clear_name_flags() {
+        let snapshot =
+            web_snapshot_from_session_snapshot(test_session_snapshot(), Some("pane-2".to_string()));
+
+        assert_eq!(snapshot.selected_pane_id.as_deref(), Some("pane-2"));
+        assert_eq!(snapshot.workspaces.len(), 2);
+        assert_eq!(snapshot.tabs.len(), 3);
+        assert_eq!(snapshot.panes.len(), 4);
+        assert_eq!(snapshot.layouts.len(), 3);
+
+        let default_workspace = snapshot
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.info.workspace_id == "workspace-1")
+            .unwrap();
+        assert!(!default_workspace.can_clear_name);
+
+        let renamed_workspace = snapshot
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.info.workspace_id == "workspace-2")
+            .unwrap();
+        assert!(renamed_workspace.can_clear_name);
+
+        let default_tab = snapshot
+            .tabs
+            .iter()
+            .find(|tab| tab.info.tab_id == "tab-1")
+            .unwrap();
+        assert!(!default_tab.can_clear_name);
+
+        let renamed_tab = snapshot
+            .tabs
+            .iter()
+            .find(|tab| tab.info.tab_id == "tab-2")
+            .unwrap();
+        assert!(renamed_tab.can_clear_name);
+
+        let non_focused_split_layout = snapshot
+            .layouts
+            .iter()
+            .find(|layout| layout.tab_id == "tab-2")
+            .unwrap();
+        assert_eq!(non_focused_split_layout.panes.len(), 2);
+        assert_eq!(non_focused_split_layout.splits.len(), 1);
+    }
+
+    #[test]
+    fn web_snapshot_adapter_drops_stale_selected_pane_ids() {
+        let snapshot = web_snapshot_from_session_snapshot(
+            test_session_snapshot(),
+            Some("missing".to_string()),
+        );
+
+        assert_eq!(snapshot.selected_pane_id, None);
+    }
+
+    #[test]
     fn structural_subscriptions_are_separate_from_activity_subscriptions() {
         let subscriptions = structural_event_subscriptions();
 
@@ -4711,6 +4771,15 @@ mod tests {
         assert!(subscriptions
             .iter()
             .any(|subscription| matches!(subscription, Subscription::PaneMoved {})));
+        assert!(subscriptions
+            .iter()
+            .any(|subscription| matches!(subscription, Subscription::LayoutUpdated {})));
+        assert!(subscriptions
+            .iter()
+            .any(|subscription| matches!(subscription, Subscription::WorkspaceMoved {})));
+        assert!(subscriptions
+            .iter()
+            .any(|subscription| matches!(subscription, Subscription::TabMoved {})));
         assert!(!subscriptions.iter().any(|subscription| matches!(
             subscription,
             Subscription::PaneAgentStatusChanged { .. }
@@ -4764,15 +4833,139 @@ mod tests {
         })));
     }
 
+    fn test_session_snapshot() -> SessionSnapshot {
+        SessionSnapshot {
+            version: "0.7.2".to_string(),
+            protocol: PROTOCOL_VERSION,
+            focused_workspace_id: Some("workspace-1".to_string()),
+            focused_tab_id: Some("tab-1".to_string()),
+            focused_pane_id: Some("pane-1".to_string()),
+            workspaces: vec![
+                test_workspace("workspace-1", 1, "repo", true, "tab-1", 3, 2),
+                test_workspace("workspace-2", 2, "Custom", false, "tab-3", 1, 1),
+            ],
+            tabs: vec![
+                test_tab("tab-1", "workspace-1", 1, "1", true, 1),
+                test_tab("tab-2", "workspace-1", 2, "Review", false, 2),
+                test_tab("tab-3", "workspace-2", 1, "1", false, 1),
+            ],
+            panes: vec![
+                test_pane_in("pane-1", "workspace-1", "tab-1", "/tmp/repo", true),
+                test_pane_in("pane-2", "workspace-1", "tab-2", "/tmp/repo", false),
+                test_pane_in("pane-3", "workspace-2", "tab-3", "/tmp/space", false),
+                test_pane_in("pane-4", "workspace-1", "tab-2", "/tmp/repo", false),
+            ],
+            layouts: vec![
+                test_layout("workspace-1", "tab-1", &["pane-1"]),
+                test_layout("workspace-1", "tab-2", &["pane-2", "pane-4"]),
+                test_layout("workspace-2", "tab-3", &["pane-3"]),
+            ],
+            agents: Vec::new(),
+        }
+    }
+
+    fn test_workspace(
+        workspace_id: &str,
+        number: usize,
+        label: &str,
+        focused: bool,
+        active_tab_id: &str,
+        pane_count: usize,
+        tab_count: usize,
+    ) -> WorkspaceInfo {
+        WorkspaceInfo {
+            workspace_id: workspace_id.to_string(),
+            number,
+            label: label.to_string(),
+            focused,
+            pane_count,
+            tab_count,
+            active_tab_id: active_tab_id.to_string(),
+            agent_status: AgentStatus::Idle,
+            worktree: None,
+        }
+    }
+
+    fn test_tab(
+        tab_id: &str,
+        workspace_id: &str,
+        number: usize,
+        label: &str,
+        focused: bool,
+        pane_count: usize,
+    ) -> TabInfo {
+        TabInfo {
+            tab_id: tab_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            number,
+            label: label.to_string(),
+            focused,
+            pane_count,
+            agent_status: AgentStatus::Idle,
+        }
+    }
+
+    fn test_layout(workspace_id: &str, tab_id: &str, pane_ids: &[&str]) -> PaneLayoutSnapshot {
+        let area = herdr_compat::api::schema::PaneLayoutRect {
+            x: 0,
+            y: 0,
+            width: 120,
+            height: 40,
+        };
+        PaneLayoutSnapshot {
+            workspace_id: workspace_id.to_string(),
+            tab_id: tab_id.to_string(),
+            zoomed: false,
+            area,
+            focused_pane_id: pane_ids.first().unwrap_or(&"").to_string(),
+            panes: pane_ids
+                .iter()
+                .enumerate()
+                .map(
+                    |(index, pane_id)| herdr_compat::api::schema::PaneLayoutPane {
+                        pane_id: (*pane_id).to_string(),
+                        focused: index == 0,
+                        rect: herdr_compat::api::schema::PaneLayoutRect {
+                            x: (index as u16) * 60,
+                            y: 0,
+                            width: 60,
+                            height: 40,
+                        },
+                    },
+                )
+                .collect(),
+            splits: if pane_ids.len() > 1 {
+                vec![herdr_compat::api::schema::PaneLayoutSplit {
+                    id: "root".to_string(),
+                    direction: SplitDirection::Right,
+                    ratio: 0.5,
+                    rect: area,
+                }]
+            } else {
+                Vec::new()
+            },
+        }
+    }
+
     fn test_pane(pane_id: &str) -> PaneInfo {
+        test_pane_in(pane_id, "workspace-1", "tab-1", "/tmp/repo", false)
+    }
+
+    fn test_pane_in(
+        pane_id: &str,
+        workspace_id: &str,
+        tab_id: &str,
+        cwd: &str,
+        focused: bool,
+    ) -> PaneInfo {
         PaneInfo {
             pane_id: pane_id.to_string(),
             terminal_id: format!("terminal-{pane_id}"),
-            workspace_id: "workspace-1".to_string(),
-            tab_id: "tab-1".to_string(),
-            focused: false,
-            cwd: None,
-            foreground_cwd: None,
+            workspace_id: workspace_id.to_string(),
+            tab_id: tab_id.to_string(),
+            focused,
+            cwd: Some(cwd.to_string()),
+            foreground_cwd: Some(cwd.to_string()),
             label: None,
             agent: None,
             title: None,
@@ -4781,6 +4974,7 @@ mod tests {
             custom_status: None,
             state_labels: HashMap::new(),
             agent_session: None,
+            scroll: None,
             revision: 1,
         }
     }
@@ -5076,6 +5270,74 @@ mod tests {
     }
 
     #[test]
+    fn clear_name_rename_substitution_uses_default_labels() {
+        let panes = [test_pane_in(
+            "pane-1",
+            "workspace-1",
+            "tab-1",
+            "/tmp/herdr",
+            true,
+        )];
+        let tabs = [test_tab("tab-2", "workspace-1", 2, "Review", false, 1)];
+
+        let mut workspace_method =
+            Method::WorkspaceRename(herdr_compat::api::schema::WorkspaceRenameParams {
+                workspace_id: "workspace-1".to_string(),
+                label: None,
+            });
+        fill_clear_rename_labels_with(
+            &mut workspace_method,
+            |workspace_id| {
+                Ok(default_workspace_label_from_panes(
+                    workspace_id,
+                    panes.iter(),
+                ))
+            },
+            |tab_id| default_tab_label_from_tabs(tab_id, tabs.iter()),
+        )
+        .unwrap();
+        let Method::WorkspaceRename(workspace_params) = workspace_method else {
+            panic!("expected workspace rename");
+        };
+        assert_eq!(workspace_params.label.as_deref(), Some("herdr"));
+
+        let mut tab_method = Method::TabRename(herdr_compat::api::schema::TabRenameParams {
+            tab_id: "tab-2".to_string(),
+            label: None,
+        });
+        fill_clear_rename_labels_with(
+            &mut tab_method,
+            |workspace_id| {
+                Ok(default_workspace_label_from_panes(
+                    workspace_id,
+                    panes.iter(),
+                ))
+            },
+            |tab_id| default_tab_label_from_tabs(tab_id, tabs.iter()),
+        )
+        .unwrap();
+        let Method::TabRename(tab_params) = tab_method else {
+            panic!("expected tab rename");
+        };
+        assert_eq!(tab_params.label.as_deref(), Some("2"));
+
+        let mut named_method = Method::TabRename(herdr_compat::api::schema::TabRenameParams {
+            tab_id: "tab-2".to_string(),
+            label: Some("Keep".to_string()),
+        });
+        fill_clear_rename_labels_with(
+            &mut named_method,
+            |_| panic!("workspace default should not be requested"),
+            |_| panic!("tab default should not be requested"),
+        )
+        .unwrap();
+        let Method::TabRename(named_params) = named_method else {
+            panic!("expected tab rename");
+        };
+        assert_eq!(named_params.label.as_deref(), Some("Keep"));
+    }
+
+    #[test]
     fn validates_narrow_pane_splits() {
         let request: Request = serde_json::from_value(serde_json::json!({
             "id": "test",
@@ -5194,16 +5456,19 @@ mod tests {
     }
 
     #[test]
-    fn terminal_attach_protocol_supports_current_and_latest_release_protocols() {
+    fn terminal_attach_protocol_requires_current_snapshot_protocol() {
         assert!(supported_terminal_attach_protocol(PROTOCOL_VERSION));
-        assert!(supported_terminal_attach_protocol(13));
-        assert!(!supported_terminal_attach_protocol(12));
+        assert!(supported_terminal_attach_protocol(
+            MIN_TERMINAL_ATTACH_PROTOCOL
+        ));
+        assert!(!supported_terminal_attach_protocol(
+            MIN_TERMINAL_ATTACH_PROTOCOL - 1
+        ));
         assert!(!supported_terminal_attach_protocol(PROTOCOL_VERSION + 1));
     }
 
     #[test]
     fn daemon_status_protocol_accepts_supported_range() {
-        assert_eq!(daemon_protocol_from_status(runtime_status(13)).unwrap(), 13);
         assert_eq!(
             daemon_protocol_from_status(runtime_status(PROTOCOL_VERSION)).unwrap(),
             PROTOCOL_VERSION
@@ -5225,12 +5490,11 @@ mod tests {
 
     #[test]
     fn daemon_status_protocol_rejects_unsupported_protocols() {
-        assert!(
-            daemon_protocol_from_status(runtime_status(MIN_TERMINAL_ATTACH_PROTOCOL - 1))
-                .unwrap_err()
-                .to_string()
-                .contains("too old")
-        );
+        let too_old = daemon_protocol_from_status(runtime_status(MIN_TERMINAL_ATTACH_PROTOCOL - 1))
+            .unwrap_err()
+            .to_string();
+        assert!(too_old.contains("too old"));
+        assert!(too_old.contains(&MIN_TERMINAL_ATTACH_PROTOCOL.to_string()));
 
         assert!(
             daemon_protocol_from_status(runtime_status(PROTOCOL_VERSION + 1))

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -2,8 +2,8 @@
 
 `herdr-web` ships as separate desktop bridge/web tarballs and an Android APK.
 
-The desktop tarball does not include Herdr itself. Users still need a running Herdr session or
-daemon; the bundled bridge connects to the normal Herdr socket.
+The desktop tarball does not include Herdr itself. Users still need a running Herdr `v0.7.2` or
+newer session or daemon; the bundled bridge connects to the normal Herdr socket.
 
 ## Release Artifacts
 
@@ -121,7 +121,7 @@ dist-packages/herdr-web-vX.Y.Z-android.apk
 
 ## User Quick Start From Tarball
 
-Start or attach Herdr first:
+Start or attach Herdr `v0.7.2` or newer first:
 
 ```bash
 herdr

--- a/docs/release.md
+++ b/docs/release.md
@@ -95,7 +95,7 @@ dist-packages/herdr-web-vX.Y.Z-android.apk
 
 ## Browser Smoke
 
-Start or attach a Herdr session:
+Start or attach a Herdr `v0.7.2` or newer session:
 
 ```bash
 herdr

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -2,8 +2,8 @@
 
 This bundle contains the `herdr-web` browser UI assets and the `herdr-web-bridge` executable.
 
-It does not include Herdr itself. Start or attach a Herdr session separately before running this
-bundle.
+It does not include Herdr itself. Start or attach a Herdr `v0.7.2` or newer session separately
+before running this bundle.
 
 ## Run
 

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -32,7 +32,7 @@ The browser app is not vendored into Herdr. It lives at `web/`, and `herdr-web-b
 ## Current Reference
 
 - Upstream checkout: a clean Herdr source checkout outside this repository
-- Upstream release baseline: `v0.7.1`
+- Upstream release baseline: `v0.7.2`
 
 Use the upstream checkout as an external reference for audits and refreshes. It is not required to
 build `herdr-web`.
@@ -95,7 +95,8 @@ src/server/socket_paths.rs -> vendor/herdr-compat/src/server/socket_paths.rs
 - `logging::init_file_logging` takes a concrete directory from the bridge.
 - socket path helpers derive paths from supplied overrides/defaults; bridge session resolution stays
   in `bridge/src/session.rs`.
-- `tabs.rs` and `workspaces.rs` contain clear-name compatibility changes for older daemons.
+- `tabs.rs` and `workspaces.rs` keep bridge-internal clear-name sentinel fields; the bridge
+  substitutes concrete default labels before forwarding rename requests to Herdr.
 - `protocol.rs` and schema tests include bridge fixture tests for the reviewed protocol/schema
   baseline.
 
@@ -129,10 +130,10 @@ the refit button after changing browser sizes.
 
 ## Compatibility Policy
 
-The bridge pings Herdr's status API at startup and checks the reported daemon protocol against the
-same supported range used for terminal attach. That catches incompatible daemon versions before
-serving the web app, but it is not a complete stability guarantee because the bridge mirrors private
-APIs.
+The bridge pings Herdr's status API at startup and requires daemon protocol `16` or newer. The
+`v0.7.2` baseline provides the native `session.snapshot` bootstrap API used by `/api/snapshot`, so
+older daemons are rejected before serving the web app. This is not a complete stability guarantee
+because the bridge mirrors private APIs.
 
 When updating Herdr:
 

--- a/vendor/herdr-compat/Cargo.lock
+++ b/vendor/herdr-compat/Cargo.lock
@@ -327,6 +327,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +524,7 @@ dependencies = [
  "crossterm",
  "interprocess",
  "ratatui",
+ "schemars",
  "serde",
  "serde_json",
  "sha2",
@@ -1162,6 +1169,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,6 +1252,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1312,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/vendor/herdr-compat/Cargo.toml
+++ b/vendor/herdr-compat/Cargo.toml
@@ -13,6 +13,7 @@ bincode = { version = "2", features = ["serde"] }
 crossterm = "0.29"
 interprocess = "2.4.2"
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
+schemars = { version = "1.2.1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/vendor/herdr-compat/src/agent_resume.rs
+++ b/vendor/herdr-compat/src/agent_resume.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentSessionRefKind {
     Id,

--- a/vendor/herdr-compat/src/api/schema.rs
+++ b/vendor/herdr-compat/src/api/schema.rs
@@ -8,6 +8,7 @@ pub mod panes;
 pub mod plugins;
 pub mod response;
 pub mod server;
+pub mod session;
 pub mod tabs;
 pub mod workspaces;
 pub mod worktrees;
@@ -20,6 +21,7 @@ pub use panes::*;
 pub use plugins::*;
 pub use response::*;
 pub use server::*;
+pub use session::*;
 pub use tabs::*;
 pub use workspaces::*;
 pub use worktrees::*;
@@ -28,14 +30,14 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct Request {
     pub id: String,
     #[serde(flatten)]
     pub method: Method,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "method", content = "params")]
 // Request enums are short-lived wire values; keeping variants direct preserves
 // the simple serde shape and avoids boxing churn across every caller.
@@ -59,6 +61,8 @@ pub enum Method {
     ClientWindowTitleSet(ClientWindowTitleSetParams),
     #[serde(rename = "client.window_title.clear")]
     ClientWindowTitleClear(EmptyParams),
+    #[serde(rename = "session.snapshot")]
+    SessionSnapshot(EmptyParams),
     #[serde(rename = "workspace.create")]
     WorkspaceCreate(WorkspaceCreateParams),
     #[serde(rename = "workspace.list")]
@@ -69,6 +73,8 @@ pub enum Method {
     WorkspaceFocus(WorkspaceTarget),
     #[serde(rename = "workspace.rename")]
     WorkspaceRename(WorkspaceRenameParams),
+    #[serde(rename = "workspace.move")]
+    WorkspaceMove(WorkspaceMoveParams),
     #[serde(rename = "workspace.close")]
     WorkspaceClose(WorkspaceTarget),
     #[serde(rename = "worktree.list")]
@@ -89,6 +95,8 @@ pub enum Method {
     TabFocus(TabTarget),
     #[serde(rename = "tab.rename")]
     TabRename(TabRenameParams),
+    #[serde(rename = "tab.move")]
+    TabMove(TabMoveParams),
     #[serde(rename = "tab.close")]
     TabClose(TabTarget),
     #[serde(rename = "agent.list")]
@@ -123,6 +131,8 @@ pub enum Method {
     LayoutExport(LayoutExportParams),
     #[serde(rename = "layout.apply")]
     LayoutApply(LayoutApplyParams),
+    #[serde(rename = "layout.set_split_ratio")]
+    LayoutSetSplitRatio(LayoutSetSplitRatioParams),
     #[serde(rename = "pane.neighbor")]
     PaneNeighbor(PaneNeighborParams),
     #[serde(rename = "pane.edges")]
@@ -137,6 +147,8 @@ pub enum Method {
     PaneCurrent(PaneCurrentParams),
     #[serde(rename = "pane.get")]
     PaneGet(PaneTarget),
+    #[serde(rename = "pane.focus")]
+    PaneFocus(PaneTarget),
     #[serde(rename = "pane.rename")]
     PaneRename(PaneRenameParams),
     #[serde(rename = "pane.send_text")]

--- a/vendor/herdr-compat/src/api/schema/agents.rs
+++ b/vendor/herdr-compat/src/api/schema/agents.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{AgentStatus, ReadFormat, ReadSource, SplitDirection};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentReadParams {
     pub target: String,
     pub source: ReadSource,
@@ -16,20 +16,20 @@ pub struct AgentReadParams {
     pub strip_ansi: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentSendParams {
     pub target: String,
     pub text: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentRenameParams {
     pub target: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentStartParams {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -47,7 +47,7 @@ pub struct AgentStartParams {
     pub env: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentInfo {
     pub terminal_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -78,7 +78,7 @@ pub struct AgentInfo {
     pub revision: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentSessionInfo {
     pub source: String,
     pub agent: String,

--- a/vendor/herdr-compat/src/api/schema/common.rs
+++ b/vendor/herdr-compat/src/api/schema/common.rs
@@ -1,41 +1,41 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct EmptyParams {}
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkspaceTarget {
     pub workspace_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneTarget {
     pub pane_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct TabTarget {
     pub tab_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentTarget {
     pub target: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ClientWindowTitleSetParams {
     pub title: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SplitDirection {
     Right,
     Down,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReadSource {
     Visible,
@@ -44,7 +44,9 @@ pub enum ReadSource {
     Detection,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum ReadFormat {
     #[default]
@@ -52,7 +54,7 @@ pub enum ReadFormat {
     Ansi,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct NotificationShowParams {
     pub title: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -63,7 +65,9 @@ pub struct NotificationShowParams {
     pub sound: NotificationShowSound,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationShowSound {
     #[default]
@@ -86,7 +90,7 @@ impl NotificationShowSound {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationShowReason {
     Shown,
@@ -96,7 +100,7 @@ pub enum NotificationShowReason {
     Busy,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ClientWindowTitleReason {
     Set,
@@ -104,7 +108,7 @@ pub enum ClientWindowTitleReason {
     NoForegroundClient,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PaneAgentState {
     Idle,
@@ -113,7 +117,7 @@ pub enum PaneAgentState {
     Unknown,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentStatus {
     Idle,

--- a/vendor/herdr-compat/src/api/schema/events.rs
+++ b/vendor/herdr-compat/src/api/schema/events.rs
@@ -3,17 +3,17 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use super::common::{AgentStatus, ReadSource};
-use super::panes::{PaneInfo, PaneReadResult};
+use super::panes::{PaneInfo, PaneReadResult, PaneScrollInfo};
 use super::tabs::TabInfo;
 use super::workspaces::WorkspaceInfo;
 use super::worktrees::WorktreeInfo;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct EventsSubscribeParams {
     pub subscriptions: Vec<Subscription>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type")]
 pub enum Subscription {
     #[serde(rename = "workspace.created")]
@@ -22,6 +22,8 @@ pub enum Subscription {
     WorkspaceUpdated {},
     #[serde(rename = "workspace.renamed")]
     WorkspaceRenamed {},
+    #[serde(rename = "workspace.moved")]
+    WorkspaceMoved {},
     #[serde(rename = "workspace.closed")]
     WorkspaceClosed {},
     #[serde(rename = "workspace.focused")]
@@ -40,6 +42,8 @@ pub enum Subscription {
     TabFocused {},
     #[serde(rename = "tab.renamed")]
     TabRenamed {},
+    #[serde(rename = "tab.moved")]
+    TabMoved {},
     #[serde(rename = "pane.created")]
     PaneCreated {},
     #[serde(rename = "pane.closed")]
@@ -68,16 +72,20 @@ pub enum Subscription {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         agent_status: Option<AgentStatus>,
     },
+    #[serde(rename = "pane.scroll_changed")]
+    PaneScrollChanged { pane_id: String },
+    #[serde(rename = "layout.updated")]
+    LayoutUpdated {},
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct EventsWaitParams {
     pub match_event: EventMatch,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneWaitForOutputParams {
     pub pane_id: String,
     pub source: ReadSource,
@@ -90,14 +98,14 @@ pub struct PaneWaitForOutputParams {
     pub strip_ansi: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum OutputMatch {
     Substring { value: String },
     Regex { value: String },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum EventMatch {
     WorkspaceCreated {
@@ -115,6 +123,9 @@ pub enum EventMatch {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         label: Option<String>,
     },
+    WorkspaceMoved {
+        workspace_id: String,
+    },
     WorkspaceFocused {
         workspace_id: String,
     },
@@ -131,6 +142,9 @@ pub enum EventMatch {
         tab_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         label: Option<String>,
+    },
+    TabMoved {
+        tab_id: String,
     },
     TabFocused {
         tab_id: String,
@@ -169,13 +183,14 @@ pub enum EventMatch {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum EventKind {
     WorkspaceCreated,
     WorkspaceUpdated,
     WorkspaceClosed,
     WorkspaceRenamed,
+    WorkspaceMoved,
     WorkspaceFocused,
     WorktreeCreated,
     WorktreeOpened,
@@ -183,6 +198,7 @@ pub enum EventKind {
     TabCreated,
     TabClosed,
     TabRenamed,
+    TabMoved,
     TabFocused,
     PaneCreated,
     PaneClosed,
@@ -192,6 +208,7 @@ pub enum EventKind {
     PaneExited,
     PaneAgentDetected,
     PaneAgentStatusChanged,
+    LayoutUpdated,
 }
 
 impl EventKind {
@@ -201,6 +218,7 @@ impl EventKind {
             EventKind::WorkspaceUpdated => "workspace.updated",
             EventKind::WorkspaceClosed => "workspace.closed",
             EventKind::WorkspaceRenamed => "workspace.renamed",
+            EventKind::WorkspaceMoved => "workspace.moved",
             EventKind::WorkspaceFocused => "workspace.focused",
             EventKind::WorktreeCreated => "worktree.created",
             EventKind::WorktreeOpened => "worktree.opened",
@@ -208,6 +226,7 @@ impl EventKind {
             EventKind::TabCreated => "tab.created",
             EventKind::TabClosed => "tab.closed",
             EventKind::TabRenamed => "tab.renamed",
+            EventKind::TabMoved => "tab.moved",
             EventKind::TabFocused => "tab.focused",
             EventKind::PaneCreated => "pane.created",
             EventKind::PaneClosed => "pane.closed",
@@ -217,6 +236,7 @@ impl EventKind {
             EventKind::PaneExited => "pane.exited",
             EventKind::PaneAgentDetected => "pane.agent_detected",
             EventKind::PaneAgentStatusChanged => "pane.agent_status_changed",
+            EventKind::LayoutUpdated => "layout.updated",
         }
     }
 }
@@ -227,6 +247,7 @@ pub const KNOWN_EVENT_KINDS: &[EventKind] = &[
     EventKind::WorkspaceUpdated,
     EventKind::WorkspaceClosed,
     EventKind::WorkspaceRenamed,
+    EventKind::WorkspaceMoved,
     EventKind::WorkspaceFocused,
     EventKind::WorktreeCreated,
     EventKind::WorktreeOpened,
@@ -234,6 +255,7 @@ pub const KNOWN_EVENT_KINDS: &[EventKind] = &[
     EventKind::TabCreated,
     EventKind::TabClosed,
     EventKind::TabRenamed,
+    EventKind::TabMoved,
     EventKind::TabFocused,
     EventKind::PaneCreated,
     EventKind::PaneClosed,
@@ -243,6 +265,7 @@ pub const KNOWN_EVENT_KINDS: &[EventKind] = &[
     EventKind::PaneExited,
     EventKind::PaneAgentDetected,
     EventKind::PaneAgentStatusChanged,
+    EventKind::LayoutUpdated,
 ];
 
 pub const PLUGIN_HOOK_EVENT_KINDS: &[EventKind] = &[
@@ -250,6 +273,7 @@ pub const PLUGIN_HOOK_EVENT_KINDS: &[EventKind] = &[
     EventKind::WorkspaceUpdated,
     EventKind::WorkspaceClosed,
     EventKind::WorkspaceRenamed,
+    EventKind::WorkspaceMoved,
     EventKind::WorkspaceFocused,
     EventKind::WorktreeCreated,
     EventKind::WorktreeOpened,
@@ -257,6 +281,7 @@ pub const PLUGIN_HOOK_EVENT_KINDS: &[EventKind] = &[
     EventKind::TabCreated,
     EventKind::TabClosed,
     EventKind::TabRenamed,
+    EventKind::TabMoved,
     EventKind::TabFocused,
     EventKind::PaneCreated,
     EventKind::PaneClosed,
@@ -307,48 +332,52 @@ mod known_event_name_tests {
     }
 
     #[test]
-    fn plugin_hook_event_names_exclude_unemitted_output_change() {
+    fn plugin_hook_event_names_exclude_high_volume_events() {
         let names = plugin_hook_event_names();
         assert!(!names.contains(&"pane.output_changed"));
+        assert!(!names.contains(&"layout.updated"));
         assert!(names.contains(&"pane.moved"));
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct EventEnvelope {
     pub event: EventKind,
     pub data: EventData,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub enum SubscriptionEventKind {
     #[serde(rename = "pane.output_matched")]
     PaneOutputMatched,
     #[serde(rename = "pane.agent_status_changed")]
     PaneAgentStatusChanged,
+    #[serde(rename = "pane.scroll_changed")]
+    ScrollChanged,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SubscriptionEventEnvelope {
     pub event: SubscriptionEventKind,
     pub data: SubscriptionEventData,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(untagged)]
 pub enum SubscriptionEventData {
     PaneOutputMatched(PaneOutputMatchedEvent),
     PaneAgentStatusChanged(PaneAgentStatusChangedEvent),
+    ScrollChanged(PaneScrollChangedEvent),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneOutputMatchedEvent {
     pub pane_id: String,
     pub matched_line: String,
     pub read: PaneReadResult,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneAgentStatusChangedEvent {
     pub pane_id: String,
     pub workspace_id: String,
@@ -365,7 +394,14 @@ pub struct PaneAgentStatusChangedEvent {
     pub state_labels: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PaneScrollChangedEvent {
+    pub pane_id: String,
+    pub workspace_id: String,
+    pub scroll: PaneScrollInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EventData {
     WorkspaceCreated {
@@ -382,6 +418,11 @@ pub enum EventData {
     WorkspaceRenamed {
         workspace_id: String,
         label: String,
+    },
+    WorkspaceMoved {
+        workspace_id: String,
+        insert_index: usize,
+        workspaces: Vec<WorkspaceInfo>,
     },
     WorkspaceFocused {
         workspace_id: String,
@@ -413,6 +454,12 @@ pub enum EventData {
         tab_id: String,
         workspace_id: String,
         label: String,
+    },
+    TabMoved {
+        tab_id: String,
+        workspace_id: String,
+        insert_index: usize,
+        tabs: Vec<TabInfo>,
     },
     TabFocused {
         tab_id: String,
@@ -472,5 +519,8 @@ pub enum EventData {
         custom_status: Option<String>,
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         state_labels: HashMap<String, String>,
+    },
+    LayoutUpdated {
+        layout: super::panes::PaneLayoutSnapshot,
     },
 }

--- a/vendor/herdr-compat/src/api/schema/integrations.rs
+++ b/vendor/herdr-compat/src/api/schema/integrations.rs
@@ -1,16 +1,16 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct IntegrationInstallParams {
     pub target: IntegrationTarget,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct IntegrationUninstallParams {
     pub target: IntegrationTarget,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IntegrationTarget {
     Pi,
@@ -26,14 +26,15 @@ pub enum IntegrationTarget {
     Hermes,
     Qodercli,
     Cursor,
+    Mastracode,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct IntegrationInstallResult {
     pub messages: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct IntegrationUninstallResult {
     pub messages: Vec<String>,
 }

--- a/vendor/herdr-compat/src/api/schema/panes.rs
+++ b/vendor/herdr-compat/src/api/schema/panes.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::agents::AgentSessionInfo;
 use super::common::{AgentStatus, PaneAgentState, ReadFormat, ReadSource, SplitDirection};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneSplitParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
@@ -22,7 +22,7 @@ pub struct PaneSplitParams {
     pub env: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PaneDirection {
     Left,
@@ -31,7 +31,7 @@ pub enum PaneDirection {
     Down,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PaneSwapParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
@@ -43,7 +43,7 @@ pub struct PaneSwapParams {
     pub target_pane_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneMoveParams {
     pub pane_id: String,
     pub destination: PaneMoveDestination,
@@ -51,7 +51,7 @@ pub struct PaneMoveParams {
     pub focus: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PaneMoveDestination {
     Tab {
@@ -76,7 +76,7 @@ pub enum PaneMoveDestination {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PaneZoomParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
@@ -84,7 +84,9 @@ pub struct PaneZoomParams {
     pub mode: PaneZoomMode,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum PaneZoomMode {
     #[default]
@@ -93,19 +95,19 @@ pub enum PaneZoomMode {
     Off,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PaneLayoutParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PaneProcessInfoParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct LayoutExportParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tab_id: Option<String>,
@@ -113,7 +115,7 @@ pub struct LayoutExportParams {
     pub pane_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct LayoutApplyParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
@@ -126,7 +128,17 @@ pub struct LayoutApplyParams {
     pub root: LayoutNode,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct LayoutSetSplitRatioParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_id: Option<String>,
+    pub path: Vec<bool>,
+    pub ratio: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct LayoutDescription {
     pub workspace_id: String,
     pub tab_id: String,
@@ -135,7 +147,7 @@ pub struct LayoutDescription {
     pub root: LayoutNode,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LayoutNode {
     Pane {
@@ -150,7 +162,7 @@ pub enum LayoutNode {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct LayoutPane {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
@@ -164,27 +176,27 @@ pub struct LayoutPane {
     pub env: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneNeighborParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
     pub direction: PaneDirection,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PaneEdgesParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneFocusDirectionParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
     pub direction: PaneDirection,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneResizeParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane_id: Option<String>,
@@ -193,38 +205,38 @@ pub struct PaneResizeParams {
     pub amount: Option<f32>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PaneListParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PaneCurrentParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub caller_pane_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneRenameParams {
     pub pane_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneSendTextParams {
     pub pane_id: String,
     pub text: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneSendKeysParams {
     pub pane_id: String,
     pub keys: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneSendInputParams {
     pub pane_id: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -233,7 +245,7 @@ pub struct PaneSendInputParams {
     pub keys: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneReadParams {
     pub pane_id: String,
     pub source: ReadSource,
@@ -245,7 +257,7 @@ pub struct PaneReadParams {
     pub strip_ansi: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneReportAgentParams {
     pub pane_id: String,
     pub source: String,
@@ -263,7 +275,7 @@ pub struct PaneReportAgentParams {
     pub agent_session_path: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneReportAgentSessionParams {
     pub pane_id: String,
     pub source: String,
@@ -278,7 +290,7 @@ pub struct PaneReportAgentSessionParams {
     pub session_start_source: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneReportMetadataParams {
     pub pane_id: String,
     pub source: String,
@@ -308,7 +320,7 @@ pub struct PaneReportMetadataParams {
     pub ttl_ms: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneClearAgentAuthorityParams {
     pub pane_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -317,7 +329,7 @@ pub struct PaneClearAgentAuthorityParams {
     pub seq: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneReleaseAgentParams {
     pub pane_id: String,
     pub source: String,
@@ -326,7 +338,7 @@ pub struct PaneReleaseAgentParams {
     pub seq: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneInfo {
     pub pane_id: String,
     pub terminal_id: String,
@@ -352,10 +364,19 @@ pub struct PaneInfo {
     pub state_labels: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_session: Option<AgentSessionInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scroll: Option<PaneScrollInfo>,
     pub revision: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PaneScrollInfo {
+    pub offset_from_bottom: u64,
+    pub max_offset_from_bottom: u64,
+    pub viewport_rows: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneProcessInfo {
     pub pane_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -368,7 +389,7 @@ pub struct PaneProcessInfo {
     pub foreground_processes: Vec<PaneProcessInfoProcess>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneProcessInfoProcess {
     pub pid: u32,
     pub name: String,
@@ -382,7 +403,7 @@ pub struct PaneProcessInfoProcess {
     pub cwd: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneSwapResult {
     pub changed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -394,7 +415,7 @@ pub struct PaneSwapResult {
     pub layout: PaneLayoutSnapshot,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PaneSwapReason {
     NoNeighbor,
@@ -403,7 +424,7 @@ pub enum PaneSwapReason {
     CrossTab,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneMoveResult {
     pub changed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -426,14 +447,14 @@ pub struct PaneMoveResult {
     pub focused_pane_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PaneMoveReason {
     SameTab,
     ZoomedTab,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneZoomResult {
     pub changed: bool,
     pub zoom_changed: bool,
@@ -446,7 +467,7 @@ pub struct PaneZoomResult {
     pub layout: PaneLayoutSnapshot,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PaneZoomReason {
     SinglePane,
@@ -454,7 +475,7 @@ pub enum PaneZoomReason {
     AlreadyUnzoomed,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneLayoutSnapshot {
     pub workspace_id: String,
     pub tab_id: String,
@@ -465,7 +486,7 @@ pub struct PaneLayoutSnapshot {
     pub splits: Vec<PaneLayoutSplit>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneLayoutRect {
     pub x: u16,
     pub y: u16,
@@ -473,14 +494,14 @@ pub struct PaneLayoutRect {
     pub height: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneLayoutPane {
     pub pane_id: String,
     pub focused: bool,
     pub rect: PaneLayoutRect,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneLayoutSplit {
     pub id: String,
     pub direction: SplitDirection,
@@ -488,7 +509,7 @@ pub struct PaneLayoutSplit {
     pub rect: PaneLayoutRect,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneNeighborResult {
     pub pane_id: String,
     pub direction: PaneDirection,
@@ -497,7 +518,7 @@ pub struct PaneNeighborResult {
     pub layout: PaneLayoutSnapshot,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneEdgesResult {
     pub pane_id: String,
     pub left: bool,
@@ -507,7 +528,7 @@ pub struct PaneEdgesResult {
     pub layout: PaneLayoutSnapshot,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneFocusDirectionResult {
     pub changed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -518,13 +539,13 @@ pub struct PaneFocusDirectionResult {
     pub layout: PaneLayoutSnapshot,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PaneFocusDirectionReason {
     NoNeighbor,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneResizeResult {
     pub changed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -534,13 +555,13 @@ pub struct PaneResizeResult {
     pub layout: PaneLayoutSnapshot,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PaneResizeReason {
     Unchanged,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneReadResult {
     pub pane_id: String,
     pub workspace_id: String,

--- a/vendor/herdr-compat/src/api/schema/plugins.rs
+++ b/vendor/herdr-compat/src/api/schema/plugins.rs
@@ -7,7 +7,7 @@ use super::common::SplitDirection;
 use super::panes::PaneInfo;
 use super::workspaces::WorkspaceWorktreeInfo;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginLinkParams {
     pub path: String,
     #[serde(default = "super::common::default_true")]
@@ -16,23 +16,23 @@ pub struct PluginLinkParams {
     pub source: Option<PluginSourceInfo>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PluginListParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugin_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginUnlinkParams {
     pub plugin_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginSetEnabledParams {
     pub plugin_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct InstalledPluginInfo {
     pub plugin_id: String,
     pub name: String,
@@ -64,7 +64,7 @@ pub struct InstalledPluginInfo {
     pub warnings: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginSourceInfo {
     #[serde(default)]
     pub kind: PluginSourceKind,
@@ -99,7 +99,9 @@ impl Default for PluginSourceInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginSourceKind {
     #[default]
@@ -221,14 +223,14 @@ mod tests {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginManifestBuild {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub platforms: Option<Vec<PluginPlatform>>,
     pub command: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginManifestAction {
     pub id: String,
     pub title: String,
@@ -241,7 +243,7 @@ pub struct PluginManifestAction {
     pub command: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginManifestEventHook {
     pub on: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -249,7 +251,7 @@ pub struct PluginManifestEventHook {
     pub command: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginManifestPane {
     pub id: String,
     pub title: String,
@@ -262,7 +264,7 @@ pub struct PluginManifestPane {
     pub command: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginManifestLinkHandler {
     pub id: String,
     pub title: String,
@@ -272,13 +274,13 @@ pub struct PluginManifestLinkHandler {
     pub platforms: Option<Vec<PluginPlatform>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PluginActionListParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugin_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PluginLogListParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugin_id: Option<String>,
@@ -286,7 +288,7 @@ pub struct PluginLogListParams {
     pub limit: Option<usize>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginActionInvokeParams {
     pub action_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -295,7 +297,7 @@ pub struct PluginActionInvokeParams {
     pub context: Option<PluginInvocationContext>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginCommandLogInfo {
     pub log_id: String,
     pub plugin_id: String,
@@ -318,7 +320,7 @@ pub struct PluginCommandLogInfo {
     pub error: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginCommandStatus {
     Running,
@@ -326,7 +328,7 @@ pub enum PluginCommandStatus {
     Failed,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginPlatform {
     Linux,
@@ -334,7 +336,7 @@ pub enum PluginPlatform {
     Windows,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginActionContext {
     Global,
@@ -344,7 +346,7 @@ pub enum PluginActionContext {
     Selection,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginInvocationContext {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
@@ -378,7 +380,7 @@ pub struct PluginInvocationContext {
     pub link_handler_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginActionInfo {
     pub plugin_id: String,
     pub action_id: String,
@@ -398,7 +400,7 @@ impl PluginActionInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginPaneOpenParams {
     pub plugin_id: String,
     pub entrypoint: String,
@@ -418,7 +420,9 @@ pub struct PluginPaneOpenParams {
     pub env: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginPanePlacement {
     #[default]
@@ -428,17 +432,17 @@ pub enum PluginPanePlacement {
     Zoomed,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginPaneFocusParams {
     pub pane_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginPaneCloseParams {
     pub pane_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginPaneInfo {
     pub plugin_id: String,
     pub entrypoint: String,

--- a/vendor/herdr-compat/src/api/schema/response.rs
+++ b/vendor/herdr-compat/src/api/schema/response.rs
@@ -16,29 +16,30 @@ use super::plugins::{
     PluginPaneInfo,
 };
 use super::server::ServerCapabilities;
+use super::session::SessionSnapshot;
 use super::tabs::TabInfo;
 use super::workspaces::WorkspaceInfo;
 use super::worktrees::{WorktreeInfo, WorktreeSourceInfo};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SuccessResponse {
     pub id: String,
     pub result: ResponseResult,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ErrorResponse {
     pub id: String,
     pub error: ErrorBody,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ErrorBody {
     pub code: String,
     pub message: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResponseResult {
     Pong {
@@ -46,6 +47,9 @@ pub enum ResponseResult {
         protocol: u32,
         #[serde(default)]
         capabilities: Option<ServerCapabilities>,
+    },
+    SessionSnapshot {
+        snapshot: Box<SessionSnapshot>,
     },
     WorkspaceInfo {
         workspace: WorkspaceInfo,
@@ -128,6 +132,9 @@ pub enum ResponseResult {
         layout: LayoutDescription,
     },
     LayoutApply {
+        layout: LayoutDescription,
+    },
+    LayoutSplitRatioSet {
         layout: LayoutDescription,
     },
     PaneNeighbor {
@@ -227,7 +234,7 @@ pub enum ResponseResult {
     Ok {},
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentManifestInfo {
     pub agent: String,
     pub source: String,

--- a/vendor/herdr-compat/src/api/schema/server.rs
+++ b/vendor/herdr-compat/src/api/schema/server.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct PingParams {}
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ServerLiveHandoffParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub import_exe: Option<String>,
@@ -13,7 +13,9 @@ pub struct ServerLiveHandoffParams {
     pub expected_version: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ServerCapabilities {
     pub live_handoff: bool,
+    #[serde(default)]
+    pub detached_server_daemon: bool,
 }

--- a/vendor/herdr-compat/src/api/schema/session.rs
+++ b/vendor/herdr-compat/src/api/schema/session.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+use super::agents::AgentInfo;
+use super::panes::{PaneInfo, PaneLayoutSnapshot};
+use super::tabs::TabInfo;
+use super::workspaces::WorkspaceInfo;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SessionSnapshot {
+    pub version: String,
+    pub protocol: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub focused_workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub focused_tab_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub focused_pane_id: Option<String>,
+    pub workspaces: Vec<WorkspaceInfo>,
+    pub tabs: Vec<TabInfo>,
+    pub panes: Vec<PaneInfo>,
+    pub layouts: Vec<PaneLayoutSnapshot>,
+    pub agents: Vec<AgentInfo>,
+}

--- a/vendor/herdr-compat/src/api/schema/tabs.rs
+++ b/vendor/herdr-compat/src/api/schema/tabs.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::common::AgentStatus;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct TabCreateParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
@@ -18,20 +18,26 @@ pub struct TabCreateParams {
     pub env: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct TabListParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct TabRenameParams {
     pub tab_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct TabMoveParams {
+    pub tab_id: String,
+    pub insert_index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct TabInfo {
     pub tab_id: String,
     pub workspace_id: String,

--- a/vendor/herdr-compat/src/api/schema/tests.rs
+++ b/vendor/herdr-compat/src/api/schema/tests.rs
@@ -41,8 +41,11 @@ fn pong_response_json_fixture_matches_reviewed_snapshot() {
         id: "api-client:status".into(),
         result: ResponseResult::Pong {
             version: "0.7.0".into(),
-            protocol: 14,
-            capabilities: Some(ServerCapabilities { live_handoff: true }),
+            protocol: 16,
+            capabilities: Some(ServerCapabilities {
+                live_handoff: true,
+                detached_server_daemon: true,
+            }),
         },
     };
 
@@ -53,9 +56,10 @@ fn pong_response_json_fixture_matches_reviewed_snapshot() {
             "result": {
                 "type": "pong",
                 "version": "0.7.0",
-                "protocol": 14,
+                "protocol": 16,
                 "capabilities": {
-                    "live_handoff": true
+                    "live_handoff": true,
+                    "detached_server_daemon": true
                 }
             }
         })
@@ -327,6 +331,10 @@ fn subscribe_request_parses_parameterized_subscriptions() {
                     "type": "pane.agent_status_changed",
                     "pane_id": "p_1_1",
                     "agent_status": "done"
+                },
+                {
+                    "type": "pane.scroll_changed",
+                    "pane_id": "p_1_1"
                 }
             ]
         }
@@ -337,7 +345,7 @@ fn subscribe_request_parses_parameterized_subscriptions() {
     let Method::EventsSubscribe(params) = request.method else {
         panic!("wrong method parsed");
     };
-    assert_eq!(params.subscriptions.len(), 2);
+    assert_eq!(params.subscriptions.len(), 3);
     assert!(matches!(
         &params.subscriptions[0],
         Subscription::PaneOutputMatched {
@@ -354,6 +362,10 @@ fn subscribe_request_parses_parameterized_subscriptions() {
             pane_id,
             agent_status: Some(AgentStatus::Done),
         } if pane_id == "p_1_1"
+    ));
+    assert!(matches!(
+        &params.subscriptions[2],
+        Subscription::PaneScrollChanged { pane_id } if pane_id == "p_1_1"
     ));
 }
 
@@ -384,17 +396,165 @@ fn subscription_event_envelope_round_trips() {
 }
 
 #[test]
+fn scroll_changed_subscription_event_round_trips() {
+    let event = SubscriptionEventEnvelope {
+        event: SubscriptionEventKind::ScrollChanged,
+        data: SubscriptionEventData::ScrollChanged(PaneScrollChangedEvent {
+            pane_id: "p_1_1".into(),
+            workspace_id: "w_1".into(),
+            scroll: PaneScrollInfo {
+                offset_from_bottom: 12,
+                max_offset_from_bottom: 240,
+                viewport_rows: 30,
+            },
+        }),
+    };
+
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains("\"event\":\"pane.scroll_changed\""));
+    let restored: SubscriptionEventEnvelope = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored, event);
+}
+
+#[test]
 fn success_response_round_trips() {
     let response = SuccessResponse {
         id: "req_1".into(),
         result: ResponseResult::Pong {
             version: "0.1.2".into(),
             protocol: 6,
-            capabilities: Some(ServerCapabilities { live_handoff: true }),
+            capabilities: Some(ServerCapabilities {
+                live_handoff: true,
+                detached_server_daemon: true,
+            }),
         },
     };
 
     let json = serde_json::to_string(&response).unwrap();
+    let restored: SuccessResponse = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored, response);
+}
+
+#[test]
+fn session_snapshot_request_and_response_round_trip() {
+    let request = Request {
+        id: "req_snapshot".into(),
+        method: Method::SessionSnapshot(EmptyParams::default()),
+    };
+    let json = serde_json::to_string(&request).unwrap();
+    assert!(json.contains("\"method\":\"session.snapshot\""));
+    let restored: Request = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored, request);
+
+    let response = SuccessResponse {
+        id: "req_snapshot".into(),
+        result: ResponseResult::SessionSnapshot {
+            snapshot: Box::new(SessionSnapshot {
+                version: "0.7.2".into(),
+                protocol: 16,
+                focused_workspace_id: Some("w_1".into()),
+                focused_tab_id: Some("t_1".into()),
+                focused_pane_id: Some("p_1".into()),
+                workspaces: vec![WorkspaceInfo {
+                    workspace_id: "w_1".into(),
+                    number: 1,
+                    label: "herdr".into(),
+                    focused: true,
+                    pane_count: 1,
+                    tab_count: 1,
+                    active_tab_id: "t_1".into(),
+                    agent_status: AgentStatus::Working,
+                    worktree: None,
+                }],
+                tabs: vec![TabInfo {
+                    tab_id: "t_1".into(),
+                    workspace_id: "w_1".into(),
+                    number: 1,
+                    label: "1".into(),
+                    focused: true,
+                    pane_count: 1,
+                    agent_status: AgentStatus::Working,
+                }],
+                panes: vec![PaneInfo {
+                    pane_id: "p_1".into(),
+                    terminal_id: "term_1".into(),
+                    workspace_id: "w_1".into(),
+                    tab_id: "t_1".into(),
+                    focused: true,
+                    cwd: Some("/work/herdr".into()),
+                    foreground_cwd: Some("/work/herdr".into()),
+                    label: Some("Review".into()),
+                    agent: Some("codex".into()),
+                    title: Some("Codex".into()),
+                    display_agent: Some("Codex".into()),
+                    agent_status: AgentStatus::Working,
+                    custom_status: Some("reviewing".into()),
+                    state_labels: HashMap::from([("phase".into(), "review".into())]),
+                    agent_session: None,
+                    scroll: Some(PaneScrollInfo {
+                        offset_from_bottom: 4,
+                        max_offset_from_bottom: 80,
+                        viewport_rows: 24,
+                    }),
+                    revision: 7,
+                }],
+                layouts: vec![PaneLayoutSnapshot {
+                    workspace_id: "w_1".into(),
+                    tab_id: "t_1".into(),
+                    zoomed: false,
+                    area: PaneLayoutRect {
+                        x: 0,
+                        y: 0,
+                        width: 120,
+                        height: 40,
+                    },
+                    focused_pane_id: "p_1".into(),
+                    panes: vec![PaneLayoutPane {
+                        pane_id: "p_1".into(),
+                        focused: true,
+                        rect: PaneLayoutRect {
+                            x: 0,
+                            y: 0,
+                            width: 120,
+                            height: 40,
+                        },
+                    }],
+                    splits: vec![PaneLayoutSplit {
+                        id: "root".into(),
+                        direction: SplitDirection::Right,
+                        ratio: 1.0,
+                        rect: PaneLayoutRect {
+                            x: 0,
+                            y: 0,
+                            width: 120,
+                            height: 40,
+                        },
+                    }],
+                }],
+                agents: vec![AgentInfo {
+                    terminal_id: "term_1".into(),
+                    name: Some("codex".into()),
+                    agent: Some("codex".into()),
+                    title: Some("Codex".into()),
+                    display_agent: Some("Codex".into()),
+                    agent_status: AgentStatus::Working,
+                    screen_detection_skipped: false,
+                    custom_status: Some("reviewing".into()),
+                    state_labels: HashMap::from([("phase".into(), "review".into())]),
+                    agent_session: None,
+                    workspace_id: "w_1".into(),
+                    tab_id: "t_1".into(),
+                    pane_id: "p_1".into(),
+                    focused: true,
+                    cwd: Some("/work/herdr".into()),
+                    foreground_cwd: Some("/work/herdr".into()),
+                    revision: 7,
+                }],
+            }),
+        },
+    };
+    let json = serde_json::to_string(&response).unwrap();
+    assert!(json.contains("\"type\":\"session_snapshot\""));
     let restored: SuccessResponse = serde_json::from_str(&json).unwrap();
     assert_eq!(restored, response);
 }
@@ -460,6 +620,7 @@ fn worktree_request_and_response_round_trip() {
                 custom_status: None,
                 state_labels: HashMap::new(),
                 agent_session: None,
+                scroll: None,
                 revision: 0,
             },
             worktree: WorktreeInfo {
@@ -776,6 +937,7 @@ fn create_response_round_trips_with_root_pane() {
                 custom_status: None,
                 state_labels: HashMap::new(),
                 agent_session: None,
+                scroll: None,
                 revision: 0,
             },
         },

--- a/vendor/herdr-compat/src/api/schema/workspaces.rs
+++ b/vendor/herdr-compat/src/api/schema/workspaces.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::common::AgentStatus;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkspaceCreateParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
@@ -16,14 +16,20 @@ pub struct WorkspaceCreateParams {
     pub env: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkspaceRenameParams {
     pub workspace_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct WorkspaceMoveParams {
+    pub workspace_id: String,
+    pub insert_index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkspaceInfo {
     pub workspace_id: String,
     pub number: usize,
@@ -37,7 +43,7 @@ pub struct WorkspaceInfo {
     pub worktree: Option<WorkspaceWorktreeInfo>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkspaceWorktreeInfo {
     pub repo_key: String,
     pub repo_name: String,

--- a/vendor/herdr-compat/src/api/schema/worktrees.rs
+++ b/vendor/herdr-compat/src/api/schema/worktrees.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct WorktreeListParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
@@ -8,7 +8,7 @@ pub struct WorktreeListParams {
     pub cwd: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct WorktreeCreateParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
@@ -26,7 +26,7 @@ pub struct WorktreeCreateParams {
     pub focus: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct WorktreeOpenParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
@@ -42,14 +42,14 @@ pub struct WorktreeOpenParams {
     pub focus: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorktreeRemoveParams {
     pub workspace_id: String,
     #[serde(default)]
     pub force: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorktreeSourceInfo {
     pub repo_key: String,
     pub repo_name: String,
@@ -59,7 +59,7 @@ pub struct WorktreeSourceInfo {
     pub source_workspace_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorktreeInfo {
     pub path: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/vendor/herdr-compat/src/config.rs
+++ b/vendor/herdr-compat/src/config.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum ToastHerdrPosition {
     TopLeft,
@@ -11,7 +11,7 @@ pub enum ToastHerdrPosition {
     BottomRight,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ConfigReloadStatus {
     Applied,

--- a/vendor/herdr-compat/src/protocol.rs
+++ b/vendor/herdr-compat/src/protocol.rs
@@ -8,7 +8,7 @@ mod bridge_fixture_tests {
 
     #[test]
     fn protocol_version_matches_reviewed_herdr_snapshot() {
-        assert_eq!(PROTOCOL_VERSION, 14);
+        assert_eq!(PROTOCOL_VERSION, 16);
     }
 
     #[test]
@@ -26,7 +26,7 @@ mod bridge_fixture_tests {
         let mut frame = Vec::new();
         write_message(&mut frame, &msg).unwrap();
 
-        assert_eq!(frame, vec![9, 0, 0, 0, 0, 14, 80, 24, 8, 16, 0, 0, 1]);
+        assert_eq!(frame, vec![9, 0, 0, 0, 0, 16, 80, 24, 8, 16, 0, 0, 1]);
         let decoded: ClientMessage = read_message(&mut frame.as_slice(), MAX_FRAME_SIZE).unwrap();
         assert_eq!(decoded, msg);
     }
@@ -41,7 +41,7 @@ mod bridge_fixture_tests {
         let mut frame = Vec::new();
         write_message(&mut frame, &msg).unwrap();
 
-        assert_eq!(frame, vec![4, 0, 0, 0, 0, 14, 1, 0]);
+        assert_eq!(frame, vec![4, 0, 0, 0, 0, 16, 1, 0]);
         let decoded: ServerMessage = read_message(&mut frame.as_slice(), MAX_FRAME_SIZE).unwrap();
         assert_eq!(decoded, msg);
     }

--- a/vendor/herdr-compat/src/protocol/wire.rs
+++ b/vendor/herdr-compat/src/protocol/wire.rs
@@ -2,8 +2,6 @@
 //!
 //! Defines the message types, framing, version negotiation, and safety
 //! constraints for the binary protocol over Unix domain sockets.
-//!
-//! Source reference: upstream Herdr `src/protocol/wire.rs`.
 
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
@@ -15,7 +13,7 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Current protocol version. Bumped when wire format changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 14;
+pub const PROTOCOL_VERSION: u32 = 16;
 
 /// Maximum allowed frame payload size (2 MB). Frames larger than this are
 /// rejected to prevent denial-of-service via oversized length prefixes.
@@ -383,6 +381,20 @@ pub enum ClientMessage {
 
     /// Structured input events from platform clients that do not expose Unix-style raw bytes.
     InputEvents { events: Vec<ClientInputEvent> },
+
+    /// Switch this connection into read-only terminal observe mode.
+    ObserveTerminal {
+        /// Pane, terminal, or agent target to observe.
+        target: String,
+    },
+
+    /// Switch this connection into writable terminal control mode.
+    ControlTerminal {
+        /// Pane, terminal, or agent target to control.
+        target: String,
+        /// Replace an existing writable controller for this terminal.
+        takeover: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -414,7 +426,7 @@ pub struct CellData {
     pub fg: u32,
     /// Background color as a packed u32.
     pub bg: u32,
-    /// Bitmask of style modifiers (bold, italic, etc.).
+    /// Bitmask of style modifiers (bold, italic, etc.) plus Herdr extension bits.
     pub modifier: u16,
     /// Whether this cell should be skipped during diff-based rendering.
     pub skip: bool,
@@ -644,6 +656,14 @@ pub enum ServerMessage {
         /// True when Herdr mouse UI is enabled or the focused pane app requests mouse reporting.
         enabled: bool,
     },
+
+    /// Apply the prefix-mode ASCII input-source change on the foreground client.
+    /// `active = true` → switch to an ASCII-capable source (saving the current one);
+    /// `active = false` → restore the saved source.
+    PrefixInputSource {
+        /// Whether the ASCII input source should be active.
+        active: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -717,15 +737,30 @@ fn u32_to_color(val: u32) -> ratatui::style::Color {
     }
 }
 
+const UNDERLINE_STYLE_SHIFT: u16 = 12;
+const UNDERLINE_STYLE_MASK: u16 = 0xF000;
+
 /// Converts a ratatui `Modifier` bitmask to a u16 for wire transport.
 pub(crate) fn modifier_to_u16(modifier: ratatui::style::Modifier) -> u16 {
     modifier.bits()
 }
 
+pub(crate) fn underline_style_from_modifier(modifier: u16) -> u8 {
+    ((modifier & UNDERLINE_STYLE_MASK) >> UNDERLINE_STYLE_SHIFT) as u8
+}
+
+pub(crate) fn modifier_with_underline_style(
+    modifier: ratatui::style::Modifier,
+    underline_style: u8,
+) -> ratatui::style::Modifier {
+    let bits = modifier.bits() | ((u16::from(underline_style) & 0x0F) << UNDERLINE_STYLE_SHIFT);
+    ratatui::style::Modifier::from_bits_retain(bits)
+}
+
 /// Converts a u16 back to a ratatui `Modifier`.
 #[cfg(test)]
 fn u16_to_modifier(val: u16) -> ratatui::style::Modifier {
-    ratatui::style::Modifier::from_bits_truncate(val)
+    ratatui::style::Modifier::from_bits_truncate(val & !UNDERLINE_STYLE_MASK)
 }
 
 // ---------------------------------------------------------------------------
@@ -937,7 +972,7 @@ mod tests {
     }
 
     #[test]
-    fn client_message_wire_tags_preserve_protocol_14_order() {
+    fn client_message_wire_tags_preserve_protocol_15_order() {
         fn tag(msg: &ClientMessage) -> u8 {
             *bincode::serde::encode_to_vec(msg, bincode::config::standard())
                 .unwrap()
@@ -995,6 +1030,19 @@ mod tests {
             6
         );
         assert_eq!(tag(&ClientMessage::InputEvents { events: Vec::new() }), 7);
+        assert_eq!(
+            tag(&ClientMessage::ObserveTerminal {
+                target: "w1:p1".to_owned(),
+            }),
+            8
+        );
+        assert_eq!(
+            tag(&ClientMessage::ControlTerminal {
+                target: "w1:p1".to_owned(),
+                takeover: false,
+            }),
+            9
+        );
     }
 
     #[test]
@@ -1114,6 +1162,29 @@ mod tests {
     fn client_attach_terminal_roundtrip() {
         let msg = ClientMessage::AttachTerminal {
             terminal_id: "term_123".to_owned(),
+            takeover: true,
+        };
+        let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
+        let (decoded, _): (ClientMessage, _) =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn client_observe_terminal_roundtrip() {
+        let msg = ClientMessage::ObserveTerminal {
+            target: "w1:p1".to_owned(),
+        };
+        let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
+        let (decoded, _): (ClientMessage, _) =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn client_control_terminal_roundtrip() {
+        let msg = ClientMessage::ControlTerminal {
+            target: "w1:p1".to_owned(),
             takeover: true,
         };
         let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
@@ -1339,6 +1410,17 @@ mod tests {
         let (decoded, _): (ServerMessage, _) =
             bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
         assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn server_prefix_input_source_roundtrip() {
+        for active in [true, false] {
+            let msg = ServerMessage::PrefixInputSource { active };
+            let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
+            let (decoded, _): (ServerMessage, _) =
+                bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
+            assert_eq!(msg, decoded);
+        }
     }
 
     // ---- Framing ----


### PR DESCRIPTION
## Summary
- refresh the Herdr compatibility baseline to v0.7.2/protocol 16
- switch /api/snapshot to native session.snapshot while preserving the existing web Snapshot shape and bridge side effects
- update protocol/event handling, docs, changelog, and focused adapter/schema tests

## Validation
- npm run check
- HERDR_SRC=/home/kevin/worktrees/herdr-web/attempt/herdr-0.7.2 scripts/check-vendor.sh
- Keel iterative-review with claude-default/Claude Opus: clean
