### PR TITLE
Fix mobile terminal selection alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Kept the first selected character anchored during mobile endpoint dragging, aligned the loupe caret
   with the selected row, and centered a hollow drag handle over the anchored character.
+  [PR #35](https://github.com/kcosr/herdr-web/pull/35)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Kept the first selected character anchored during mobile endpoint dragging, aligned the loupe caret
+  with the selected row, and centered a hollow drag handle over the anchored character.
+
 ### Removed
 
 ## [0.3.2] - 2026-07-07

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1770,54 +1770,18 @@ button {
   white-space: nowrap;
 }
 
-.terminal-touch-endpoint-line {
+.terminal-touch-endpoint-ring {
   position: absolute;
-  left: 50%;
-  top: 8px;
-  width: 2px;
-  height: 18px;
-  transform: translateX(-50%);
+  left: var(--terminal-touch-endpoint-ring-left);
+  top: var(--terminal-touch-endpoint-ring-top);
+  box-sizing: border-box;
+  width: var(--terminal-touch-endpoint-ring-diameter);
+  height: var(--terminal-touch-endpoint-ring-diameter);
+  border: 3px solid color-mix(in srgb, var(--terminal-touch-marker) 82%, white);
   border-radius: 999px;
-  background: var(--terminal-touch-marker);
-  box-shadow: 0 0 0 1px rgb(0 0 0 / 26%);
+  background: color-mix(in srgb, var(--terminal-touch-marker) 8%, transparent);
+  box-shadow: 0 3px 12px rgb(0 0 0 / 24%), 0 0 0 1px rgb(0 0 0 / 20%);
   pointer-events: none;
-}
-
-.terminal-touch-endpoint-line::before {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: -2px;
-  width: 10px;
-  height: 2px;
-  transform: translateX(-50%);
-  border-radius: inherit;
-  background: inherit;
-  box-shadow: inherit;
-}
-
-.terminal-touch-endpoint-knob {
-  position: absolute;
-  left: 13px;
-  top: 22px;
-  display: grid;
-  width: 46px;
-  height: 46px;
-  place-items: center;
-  border: 1px solid color-mix(in srgb, var(--accent) 72%, white);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 78%, var(--mantle));
-  box-shadow: 0 10px 28px rgb(0 0 0 / 38%);
-  pointer-events: none;
-}
-
-.terminal-touch-endpoint-knob::after {
-  content: "";
-  width: 10px;
-  height: 10px;
-  border-radius: inherit;
-  background: var(--base);
-  box-shadow: 0 0 0 1px rgb(255 255 255 / 42%);
 }
 
 .terminal-mobile-controls {

--- a/web/src/terminalEndpointBubblePosition.test.ts
+++ b/web/src/terminalEndpointBubblePosition.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { terminalEndpointBubblePosition } from "./terminalEndpointBubblePosition";
+
+describe("terminal endpoint drag handle", () => {
+  it("centers the generous touch target on the selected cell", () => {
+    const position = terminalEndpointBubblePosition({
+      targetClientX: 150,
+      targetClientY: 100,
+      containerLeft: 0,
+      containerTop: 0,
+      containerWidth: 390,
+      containerHeight: 800,
+      bubbleWidth: 72,
+      bubbleHeight: 72,
+      ringDiameter: 42,
+    });
+
+    expect(position).toEqual({ left: 114, top: 64, ringLeft: 15, ringTop: 15 });
+  });
+
+  it("keeps the visible ring centered on a selected cell at the container edge", () => {
+    const position = terminalEndpointBubblePosition({
+      targetClientX: 3,
+      targetClientY: 8,
+      containerLeft: 0,
+      containerTop: 0,
+      containerWidth: 390,
+      containerHeight: 800,
+      bubbleWidth: 72,
+      bubbleHeight: 72,
+      ringDiameter: 42,
+    });
+
+    expect(position).toEqual({ left: 4, top: 4, ringLeft: -22, ringTop: -17 });
+    expect(position.left + position.ringLeft + 21).toBe(3);
+    expect(position.top + position.ringTop + 21).toBe(8);
+  });
+});

--- a/web/src/terminalEndpointBubblePosition.ts
+++ b/web/src/terminalEndpointBubblePosition.ts
@@ -1,0 +1,39 @@
+/** Measurements used to align a touch-selection drag bubble to a terminal cell. */
+export interface TerminalEndpointBubbleGeometryInput {
+  targetClientX: number;
+  targetClientY: number;
+  containerLeft: number;
+  containerTop: number;
+  containerWidth: number;
+  containerHeight: number;
+  bubbleWidth: number;
+  bubbleHeight: number;
+  ringDiameter: number;
+}
+
+/** Keeps the touch target in bounds while centering its visible ring on the selected cell. */
+export function terminalEndpointBubblePosition(input: TerminalEndpointBubbleGeometryInput) {
+  const targetX = input.targetClientX - input.containerLeft;
+  const targetY = input.targetClientY - input.containerTop;
+  const left = clamp(
+    targetX - input.bubbleWidth / 2,
+    4,
+    Math.max(4, input.containerWidth - input.bubbleWidth - 4),
+  );
+  const top = clamp(
+    targetY - input.bubbleHeight / 2,
+    4,
+    Math.max(4, input.containerHeight - input.bubbleHeight - 4),
+  );
+
+  return {
+    left,
+    top,
+    ringLeft: targetX - left - input.ringDiameter / 2,
+    ringTop: targetY - top - input.ringDiameter / 2,
+  };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}

--- a/web/src/terminalLoupeCursorGeometry.test.ts
+++ b/web/src/terminalLoupeCursorGeometry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { terminalLoupeCursorGeometry } from "./terminalLoupeCursorGeometry";
+
+describe("terminal loupe cursor", () => {
+  it("draws a caret before the selected cell within that cell's row", () => {
+    const cursor = terminalLoupeCursorGeometry({
+      col: 20,
+      row: 10,
+      cellWidth: 9,
+      cellHeight: 16,
+      sourceX: 149.5,
+      sourceY: 146,
+      sourceWidth: 70,
+      sourceHeight: 44,
+      loupeWidth: 132,
+      loupeHeight: 82,
+    });
+
+    expect(cursor.caretX).toBeCloseTo(57.51, 1);
+    expect(cursor.caretTop).toBeCloseTo(26.09, 1);
+    expect(cursor.caretBottom).toBeCloseTo(55.91, 1);
+    expect(cursor.caretTop).toBeLessThan(cursor.caretBottom);
+  });
+
+  it("keeps the caret visible when the selected row touches the loupe crop", () => {
+    const top = terminalLoupeCursorGeometry({
+      col: 0,
+      row: 0,
+      cellWidth: 9,
+      cellHeight: 16,
+      sourceX: 0,
+      sourceY: 0,
+      sourceWidth: 70,
+      sourceHeight: 44,
+      loupeWidth: 132,
+      loupeHeight: 82,
+    });
+    const bottom = terminalLoupeCursorGeometry({
+      col: 20,
+      row: 39,
+      cellWidth: 9,
+      cellHeight: 16,
+      sourceX: 149.5,
+      sourceY: 596,
+      sourceWidth: 70,
+      sourceHeight: 44,
+      loupeWidth: 132,
+      loupeHeight: 82,
+    });
+
+    expect(top.caretX).toBe(4);
+    expect(top.caretTop).toBe(4);
+    expect(top.caretTop).toBeLessThan(top.caretBottom);
+    expect(bottom.caretTop).toBeLessThan(bottom.caretBottom);
+    expect(bottom.caretBottom).toBe(78);
+  });
+});

--- a/web/src/terminalLoupeCursorGeometry.ts
+++ b/web/src/terminalLoupeCursorGeometry.ts
@@ -1,0 +1,32 @@
+/** Measurements needed to place a cursor over a magnified terminal cell. */
+export interface TerminalLoupeGeometryInput {
+  col: number;
+  row: number;
+  cellWidth: number;
+  cellHeight: number;
+  sourceX: number;
+  sourceY: number;
+  sourceWidth: number;
+  sourceHeight: number;
+  loupeWidth: number;
+  loupeHeight: number;
+}
+
+/** Places a vertical caret immediately before the selected cell and within its row. */
+export function terminalLoupeCursorGeometry(input: TerminalLoupeGeometryInput) {
+  const targetLeft = ((input.col * input.cellWidth - input.sourceX) / input.sourceWidth) * input.loupeWidth;
+  const targetTop =
+    ((input.row * input.cellHeight - input.sourceY) / input.sourceHeight) * input.loupeHeight;
+  const targetBottom =
+    (((input.row + 1) * input.cellHeight - input.sourceY) / input.sourceHeight) * input.loupeHeight;
+
+  return {
+    caretX: clamp(targetLeft, 4, input.loupeWidth - 4),
+    caretTop: clamp(targetTop, 4, input.loupeHeight - 4),
+    caretBottom: clamp(targetBottom, 4, input.loupeHeight - 4),
+  };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -6,6 +6,8 @@ import {
   trimUrlPunctuation,
 } from "./terminalSelection";
 import type { TerminalSelectionPoint } from "./terminalSelection";
+import { terminalEndpointBubblePosition } from "./terminalEndpointBubblePosition";
+import { terminalLoupeCursorGeometry } from "./terminalLoupeCursorGeometry";
 import { terminalTapFocusAction } from "./terminalTapFocus";
 import type { TerminalTapFocusResult } from "./terminalTapFocus";
 import {
@@ -16,6 +18,7 @@ import {
   moveTouchSelectionEndpoint,
   moveTouchSelectionPlacement,
   startTouchSelectionPlacement,
+  terminalTouchSelectionEndpointFromDrag,
 } from "./terminalTouchSelection";
 import type { TerminalTouchSelectionState } from "./terminalTouchSelection";
 import { DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS } from "./mobileTerminalPrefs";
@@ -41,7 +44,7 @@ const TOUCH_LOUPE_OFFSET_Y_PX = 132;
 const TOUCH_LOUPE_TARGET_OFFSET_Y_PX = 48;
 const TOUCH_ENDPOINT_HIT_WIDTH_PX = 72;
 const TOUCH_ENDPOINT_HIT_HEIGHT_PX = 72;
-const TOUCH_ENDPOINT_HANDLE_OFFSET_Y_PX = TOUCH_LOUPE_TARGET_OFFSET_Y_PX;
+const TOUCH_ENDPOINT_RING_DIAMETER_PX = 42;
 const TAP_URL_PATTERN = /\bhttps?:\/\/[^\s"'<>`]+/giu;
 
 type GhosttyModule = typeof import("ghostty-web");
@@ -460,8 +463,27 @@ export class GhosttyRenderer implements TerminalRenderer {
       touchCellPosition(terminal, clientX, clientY - TOUCH_LOUPE_TARGET_OFFSET_Y_PX);
     const loupePositionFromTouch = (touch: Touch) =>
       loupePositionFromClient(touch.clientX, touch.clientY);
-    const endpointPositionFromTouch = (touch: Touch) =>
-      touchCellPosition(terminal, touch.clientX, touch.clientY - TOUCH_ENDPOINT_HANDLE_OFFSET_Y_PX);
+    const endpointPositionFromDrag = (touch: Touch) => {
+      if (
+        selectionState.phase !== "dragging-endpoint" ||
+        endpointDragStartX === null ||
+        endpointDragStartY === null
+      ) {
+        return selectionState.phase === "idle" ? { col: 0, row: 0 } : selectionState.endpoint;
+      }
+      const metrics = terminal.renderer?.getMetrics();
+      return terminalTouchSelectionEndpointFromDrag(
+        selectionState.start,
+        { clientX: endpointDragStartX, clientY: endpointDragStartY },
+        clientFromTouch(touch),
+        {
+          cellWidth: metrics?.width ?? 9,
+          cellHeight: metrics?.height ?? 16,
+          cols: terminal.cols,
+          rows: terminal.rows,
+        },
+      );
+    };
     const updateSimpleTouchSelection = (touch: Touch) => {
       if (!simpleSelectionStart) {
         return;
@@ -559,35 +581,35 @@ export class GhosttyRenderer implements TerminalRenderer {
         TOUCH_LOUPE_WIDTH_PX,
         TOUCH_LOUPE_HEIGHT_PX,
       );
-      const markerLeft = ((point.col * cellWidth - sxCss) / sourceWidth) * TOUCH_LOUPE_WIDTH_PX;
-      const markerRight = (((point.col + 1) * cellWidth - sxCss) / sourceWidth) * TOUCH_LOUPE_WIDTH_PX;
-      const markerY = (((point.row + 1) * cellHeight - syCss) / sourceHeight) * TOUCH_LOUPE_HEIGHT_PX - 2;
-      const anchorLeft = clampNumber(markerLeft, 4, TOUCH_LOUPE_WIDTH_PX - 4);
-      const anchorRight = clampNumber(markerRight, 4, TOUCH_LOUPE_WIDTH_PX - 4);
-      const anchorY = clampNumber(markerY, 8, TOUCH_LOUPE_HEIGHT_PX - 18);
-      const anchorCenter = (anchorLeft + anchorRight) / 2;
-      const markerBottom = TOUCH_LOUPE_HEIGHT_PX - 2;
+      const cursor = terminalLoupeCursorGeometry({
+        col: point.col,
+        row: point.row,
+        cellWidth,
+        cellHeight,
+        sourceX: sxCss,
+        sourceY: syCss,
+        sourceWidth,
+        sourceHeight,
+        loupeWidth: TOUCH_LOUPE_WIDTH_PX,
+        loupeHeight: TOUCH_LOUPE_HEIGHT_PX,
+      });
       const markerColor = cssColor(
         container,
         "--terminal-touch-marker",
         cssColor(container, "--accent", "#b4befe"),
       );
-      ctx.lineCap = "round";
+      ctx.lineCap = "butt";
       ctx.strokeStyle = "rgba(17, 17, 27, 0.78)";
       ctx.lineWidth = 4;
       ctx.beginPath();
-      ctx.moveTo(anchorLeft, anchorY + 1);
-      ctx.lineTo(anchorRight, anchorY + 1);
-      ctx.moveTo(anchorCenter, anchorY + 1);
-      ctx.lineTo(anchorCenter, markerBottom);
+      ctx.moveTo(cursor.caretX, cursor.caretTop);
+      ctx.lineTo(cursor.caretX, cursor.caretBottom);
       ctx.stroke();
       ctx.strokeStyle = markerColor;
       ctx.lineWidth = 2;
       ctx.beginPath();
-      ctx.moveTo(anchorLeft, anchorY);
-      ctx.lineTo(anchorRight, anchorY);
-      ctx.moveTo(anchorCenter, anchorY);
-      ctx.lineTo(anchorCenter, markerBottom);
+      ctx.moveTo(cursor.caretX, cursor.caretTop);
+      ctx.lineTo(cursor.caretX, cursor.caretBottom);
       ctx.stroke();
       ctx.lineCap = "butt";
       ctx.strokeStyle = "rgba(17, 17, 27, 0.85)";
@@ -614,11 +636,13 @@ export class GhosttyRenderer implements TerminalRenderer {
       endpointBubble.className = "terminal-touch-endpoint";
       endpointBubble.setAttribute("aria-hidden", "true");
       endpointBubble.setAttribute("data-hint", "Drag");
-      const line = document.createElement("span");
-      line.className = "terminal-touch-endpoint-line";
-      const knob = document.createElement("span");
-      knob.className = "terminal-touch-endpoint-knob";
-      endpointBubble.append(line, knob);
+      endpointBubble.style.setProperty(
+        "--terminal-touch-endpoint-ring-diameter",
+        `${TOUCH_ENDPOINT_RING_DIAMETER_PX}px`,
+      );
+      const ring = document.createElement("span");
+      ring.className = "terminal-touch-endpoint-ring";
+      endpointBubble.append(ring);
       container.append(endpointBubble);
       return endpointBubble;
     };
@@ -632,14 +656,21 @@ export class GhosttyRenderer implements TerminalRenderer {
       const bubble = ensureEndpointBubble();
       delete bubble.dataset.dragging;
       bubble.setAttribute("data-hint", "Drag");
-      positionOverlay(
-        bubble,
-        client.clientX,
-        client.clientY,
-        TOUCH_ENDPOINT_HIT_WIDTH_PX,
-        TOUCH_ENDPOINT_HIT_HEIGHT_PX,
-        0,
-      );
+      const rect = container.getBoundingClientRect();
+      const position = terminalEndpointBubblePosition({
+        targetClientX: client.clientX,
+        targetClientY: client.clientY,
+        containerLeft: rect.left,
+        containerTop: rect.top,
+        containerWidth: rect.width,
+        containerHeight: rect.height,
+        bubbleWidth: TOUCH_ENDPOINT_HIT_WIDTH_PX,
+        bubbleHeight: TOUCH_ENDPOINT_HIT_HEIGHT_PX,
+        ringDiameter: TOUCH_ENDPOINT_RING_DIAMETER_PX,
+      });
+      bubble.style.setProperty("--terminal-touch-endpoint-ring-left", `${position.ringLeft}px`);
+      bubble.style.setProperty("--terminal-touch-endpoint-ring-top", `${position.ringTop}px`);
+      bubble.style.transform = `translate(${position.left}px, ${position.top}px)`;
     };
     const startTouchSelection = () => {
       selectionTimer = null;
@@ -707,9 +738,8 @@ export class GhosttyRenderer implements TerminalRenderer {
       endpointDragStartX = touch.clientX;
       endpointDragStartY = touch.clientY;
       endpointDragMoved = false;
-      const position = endpointPositionFromTouch(touch);
       const client = clientFromTouch(touch);
-      selectionState = beginTouchSelectionEndpointDrag(selectionState, position, client);
+      selectionState = beginTouchSelectionEndpointDrag(selectionState, client);
       if (selectionState.phase !== "dragging-endpoint") {
         return;
       }
@@ -730,7 +760,7 @@ export class GhosttyRenderer implements TerminalRenderer {
         }
         endpointDragMoved = true;
       }
-      const position = endpointPositionFromTouch(touch);
+      const position = endpointPositionFromDrag(touch);
       const client = clientFromTouch(touch);
       selectionState = moveTouchSelectionEndpoint(selectionState, position, client);
       selectCurrentTouchRange();

--- a/web/src/terminalTouchSelection.test.ts
+++ b/web/src/terminalTouchSelection.test.ts
@@ -6,6 +6,7 @@ import {
   moveTouchSelectionEndpoint,
   moveTouchSelectionPlacement,
   startTouchSelectionPlacement,
+  terminalTouchSelectionEndpointFromDrag,
 } from "./terminalTouchSelection";
 
 describe("terminal touch selection flow", () => {
@@ -24,13 +25,54 @@ describe("terminal touch selection flow", () => {
     });
   });
 
+  it("anchors the endpoint to the committed start when dragging begins", () => {
+    const waiting = commitTouchSelectionStart(
+      startTouchSelectionPlacement({ col: 2, row: 1 }, { clientX: 18, clientY: 30 }),
+    );
+    const dragging = beginTouchSelectionEndpointDrag(waiting, { clientX: 63, clientY: 30 });
+
+    expect(dragging).toMatchObject({
+      phase: "dragging-endpoint",
+      start: { col: 2, row: 1 },
+      endpoint: { col: 2, row: 1 },
+    });
+  });
+
+  it("derives the moving endpoint from finger displacement without a transition jump", () => {
+    const start = { col: 2, row: 1 };
+    const dragStart = { clientX: 63, clientY: 30 };
+    const grid = { cellWidth: 9, cellHeight: 16, cols: 10, rows: 4 };
+
+    expect(terminalTouchSelectionEndpointFromDrag(start, dragStart, dragStart, grid)).toEqual(start);
+    expect(
+      terminalTouchSelectionEndpointFromDrag(
+        start,
+        dragStart,
+        { clientX: 108, clientY: 14 },
+        grid,
+      ),
+    ).toEqual({ col: 7, row: 0 });
+  });
+
+  it("clamps endpoint displacement to the terminal grid", () => {
+    expect(
+      terminalTouchSelectionEndpointFromDrag(
+        { col: 2, row: 1 },
+        { clientX: 63, clientY: 30 },
+        { clientX: -100, clientY: 200 },
+        { cellWidth: 9, cellHeight: 16, cols: 10, rows: 4 },
+      ),
+    ).toEqual({ col: 0, row: 3 });
+  });
+
   it("completes forward endpoint drags", () => {
     const waiting = commitTouchSelectionStart(
       startTouchSelectionPlacement({ col: 2, row: 1 }, { clientX: 18, clientY: 30 }),
     );
-    const dragging = beginTouchSelectionEndpointDrag(waiting, { col: 7, row: 1 }, { clientX: 63, clientY: 30 });
+    const dragging = beginTouchSelectionEndpointDrag(waiting, { clientX: 63, clientY: 30 });
+    const moved = moveTouchSelectionEndpoint(dragging, { col: 7, row: 1 }, { clientX: 108, clientY: 30 });
 
-    expect(completeTouchSelection(dragging)).toEqual({
+    expect(completeTouchSelection(moved)).toEqual({
       start: { col: 2, row: 1 },
       end: { col: 7, row: 1 },
     });
@@ -40,7 +82,7 @@ describe("terminal touch selection flow", () => {
     const waiting = commitTouchSelectionStart(
       startTouchSelectionPlacement({ col: 8, row: 3 }, { clientX: 72, clientY: 58 }),
     );
-    const dragging = beginTouchSelectionEndpointDrag(waiting, { col: 4, row: 2 }, { clientX: 36, clientY: 42 });
+    const dragging = beginTouchSelectionEndpointDrag(waiting, { clientX: 36, clientY: 42 });
     const moved = moveTouchSelectionEndpoint(dragging, { col: 1, row: 2 }, { clientX: 9, clientY: 42 });
 
     expect(completeTouchSelection(moved)).toEqual({

--- a/web/src/terminalTouchSelection.ts
+++ b/web/src/terminalTouchSelection.ts
@@ -1,9 +1,17 @@
 import type { TerminalSelectionPoint } from "./terminalSelection";
 
-export type TerminalTouchClientPoint = {
+export interface TerminalTouchClientPoint {
   clientX: number;
   clientY: number;
-};
+}
+
+/** Terminal cell measurements and bounds used to translate touch displacement. */
+export interface TerminalTouchGridGeometry {
+  cellWidth: number;
+  cellHeight: number;
+  cols: number;
+  rows: number;
+}
 
 export type TerminalTouchSelectionState =
   | { phase: "idle" }
@@ -62,13 +70,33 @@ export function commitTouchSelectionStart(
 
 export function beginTouchSelectionEndpointDrag(
   state: TerminalTouchSelectionState,
-  point: TerminalSelectionPoint,
   client: TerminalTouchClientPoint,
 ): TerminalTouchSelectionState {
   if (state.phase !== "waiting-endpoint") {
     return state;
   }
-  return { phase: "dragging-endpoint", start: state.start, endpoint: point, client };
+  return { phase: "dragging-endpoint", start: state.start, endpoint: state.start, client };
+}
+
+/** Derives the moving endpoint from finger displacement relative to the fixed start. */
+export function terminalTouchSelectionEndpointFromDrag(
+  start: TerminalSelectionPoint,
+  dragStart: TerminalTouchClientPoint,
+  current: TerminalTouchClientPoint,
+  grid: TerminalTouchGridGeometry,
+): TerminalSelectionPoint {
+  return {
+    col: clamp(
+      start.col + Math.round((current.clientX - dragStart.clientX) / grid.cellWidth),
+      0,
+      Math.max(0, grid.cols - 1),
+    ),
+    row: clamp(
+      start.row + Math.round((current.clientY - dragStart.clientY) / grid.cellHeight),
+      0,
+      Math.max(0, grid.rows - 1),
+    ),
+  };
 }
 
 export function moveTouchSelectionEndpoint(
@@ -87,4 +115,8 @@ export function completeTouchSelection(state: TerminalTouchSelectionState) {
     return null;
   }
   return { start: state.start, end: state.endpoint };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
 }


### PR DESCRIPTION
## Problem

PR #15 introduced the mobile long-press selection flow, and PR #16 merged its polished form. Follow-up Android testing found three alignment problems:

- Grabbing the endpoint could jump the moving end away from the character placed with the loupe.
- The loupe cursor appeared below the row Ghostty Web actually selected.
- The below-row drag handle looked detached from the anchored character.

The selection coordinates themselves were correct. The problems were the drag transition and overlay geometry.

## Fix

- Keep the placed start fixed and derive the moving endpoint from finger displacement, avoiding the transition jump.
- Draw a vertical loupe caret immediately before the selected cell and keep it within that row.
- Center a hollow ring on the anchored character inside the existing 72px touch target. Keep the ring aligned at terminal edges and hide the handle during active dragging.

## Prior work and hardware evidence

This is the production extraction of phone-tested work from:

- kcosr/herdr-web #15 and #16
- Whamp/herdr-web [#10](https://github.com/Whamp/herdr-web/issues/10), [#17](https://github.com/Whamp/herdr-web/issues/17), and [#18](https://github.com/Whamp/herdr-web/issues/18)

The caret and hollow-ring designs were selected after testing alternatives on an Android phone.

## Scope

This PR does not change copy or URL semantics. Complete HTTP(S) links across visual soft wraps remain blocked because Herdr's rendered attach frames do not preserve row-continuation metadata; that limitation is documented in Whamp/herdr-web [#19](https://github.com/Whamp/herdr-web/issues/19) and [#20](https://github.com/Whamp/herdr-web/issues/20).

## Checks

- `npm run check`
- `npm run android:build:debug`
- 186 web tests
- 102 vendored compatibility tests
- 114 bridge tests
