### PR TITLE
Add Grok and OpenCode launcher icons and presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Added
 
+- Added Grok and OpenCode agent icons in the Agents sidebar and create-menu launch choices.
+- Added built-in launcher presets for Grok and OpenCode (`builtin:grok`, `builtin:opencode`).
+- Added optional `builtins` allowlist/order in `launcher-presets.json` so the create menu can show a
+  subset of built-ins without PATH probing. Omitting `builtins` keeps the full default set; `[]`
+  hides all built-ins (custom presets still appear). Short names (`shell`) and full ids
+  (`builtin:shell`) are accepted; unknown entries warn and are ignored.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@
 ### Added
 
 - Added Grok and OpenCode agent icons in the Agents sidebar and create-menu launch choices.
+  [PR #36](https://github.com/kcosr/herdr-web/pull/36)
 - Added built-in launcher presets for Grok and OpenCode (`builtin:grok`, `builtin:opencode`).
+  [PR #36](https://github.com/kcosr/herdr-web/pull/36)
 - Added optional `builtins` allowlist/order in `launcher-presets.json` so the create menu can show a
   subset of built-ins without PATH probing. Omitting `builtins` keeps the full default set; `[]`
   hides all built-ins (custom presets still appear). Short names (`shell`) and full ids
   (`builtin:shell`) are accepted; unknown entries warn and are ignored.
+  [PR #36](https://github.com/kcosr/herdr-web/pull/36)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ navigation, multi-client viewing, mobile input controls, and synchronized pane s
 - Shared browser terminal viewing with synchronized pane selection across desktop and mobile.
 - Mobile-friendly text input with stage/send actions, configurable tap focus, and extended
   terminal key controls.
-- Agent-focused sidebar with styled icons for detected Codex/OpenAI, Claude, and Pi panes.
+- Agent-focused sidebar with styled icons for detected Codex/OpenAI, Claude, Pi, Grok, and OpenCode panes.
 - Image and file uploads from the terminal toolbar, paste, or drag/drop, with uploaded paths inserted
   into the active terminal input.
 - Context menus for renaming, closing, splitting, and moving panes between tabs or spaces.
@@ -163,6 +163,10 @@ flushed early once the pending UTF-8 input reaches 32 bytes, so paste-like input
 
 ## Launcher Presets
 
+The create menu is owned by the bridge. By default it shows these built-ins, in order:
+
+`Shell`, `Codex`, `Claude`, `pi`, `Grok`, `OpenCode`.
+
 The bridge can load local launcher presets from:
 
 ```text
@@ -171,11 +175,18 @@ ${XDG_CONFIG_HOME:-~/.config}/herdr-web/launcher-presets.json
 
 Override the path with `--launcher-presets PATH` or `HERDR_WEB_LAUNCHER_PRESETS=PATH`.
 
+Optional `builtins` is an allowlist that chooses which built-ins appear and in what order. Omit it to
+show every built-in. Use `[]` to hide all built-ins and keep only custom presets. Entries may be short
+names (`shell`) or full ids (`builtin:shell`). Unknown names are ignored with a warning. Bridges that
+do not yet understand `builtins` reject the whole file (unknown field); upgrade the bridge before
+adding this key.
+
 Example:
 
 ```json
 {
   "version": 1,
+  "builtins": ["shell", "claude", "grok", "opencode"],
   "presets": [
     {
       "id": "codex-gpt5",

--- a/bridge/src/launcher_presets.rs
+++ b/bridge/src/launcher_presets.rs
@@ -14,6 +14,8 @@ const BUILTIN_SHELL_ID: &str = "builtin:shell";
 const BUILTIN_CODEX_ID: &str = "builtin:codex";
 const BUILTIN_CLAUDE_ID: &str = "builtin:claude";
 const BUILTIN_PI_ID: &str = "builtin:pi";
+const BUILTIN_GROK_ID: &str = "builtin:grok";
+const BUILTIN_OPENCODE_ID: &str = "builtin:opencode";
 
 const KNOWN_AGENT_HINTS: &[&str] = &[
     "amp",
@@ -91,6 +93,12 @@ pub struct LauncherPresetDisplay {
 struct LauncherPresetFile {
     #[serde(default)]
     version: Option<u32>,
+    /// Optional allowlist/order of built-in launcher entries.
+    /// When omitted, every built-in is shown in the default order.
+    /// When present (including empty), only the listed built-ins are shown.
+    /// Accepts short names (`shell`) or full ids (`builtin:shell`).
+    #[serde(default)]
+    builtins: Option<Vec<String>>,
     #[serde(default)]
     presets: Vec<serde_json::Value>,
 }
@@ -128,7 +136,6 @@ impl LauncherPresetStore {
     }
 
     fn load_from_path_with_mode(path: &Path, explicit: bool) -> Result<Self, String> {
-        let mut presets = builtin_presets();
         let mut warnings = Vec::new();
         if !path.exists() {
             if explicit {
@@ -137,7 +144,10 @@ impl LauncherPresetStore {
                     path.display()
                 ));
             }
-            return Ok(Self { presets, warnings });
+            return Ok(Self {
+                presets: builtin_presets(),
+                warnings,
+            });
         }
         let text = match fs::read_to_string(path) {
             Ok(text) => text,
@@ -147,7 +157,10 @@ impl LauncherPresetStore {
                     return Err(message);
                 }
                 warnings.push(message);
-                return Ok(Self { presets, warnings });
+                return Ok(Self {
+                    presets: builtin_presets(),
+                    warnings,
+                });
             }
         };
         let config: LauncherPresetFile = match serde_json::from_str(&text) {
@@ -158,7 +171,10 @@ impl LauncherPresetStore {
                     return Err(message);
                 }
                 warnings.push(message);
-                return Ok(Self { presets, warnings });
+                return Ok(Self {
+                    presets: builtin_presets(),
+                    warnings,
+                });
             }
         };
         if config.version.unwrap_or(1) != 1 {
@@ -170,8 +186,12 @@ impl LauncherPresetStore {
                 return Err(message);
             }
             warnings.push(message);
-            return Ok(Self { presets, warnings });
+            return Ok(Self {
+                presets: builtin_presets(),
+                warnings,
+            });
         }
+        let mut presets = select_builtin_presets(config.builtins.as_deref(), &mut warnings);
         let mut ids: HashSet<String> = presets.iter().map(|preset| preset.id.clone()).collect();
         for config_preset in config.presets {
             let config_preset = match serde_json::from_value::<LauncherPresetConfig>(config_preset)
@@ -329,7 +349,61 @@ fn builtin_presets() -> Vec<ResolvedLauncherPreset> {
             Some(vec!["claude".into()]),
         ),
         builtin(BUILTIN_PI_ID, "pi", Some("pi"), Some(vec!["pi".into()])),
+        builtin(
+            BUILTIN_GROK_ID,
+            "Grok",
+            Some("grok"),
+            Some(vec!["grok".into()]),
+        ),
+        builtin(
+            BUILTIN_OPENCODE_ID,
+            "OpenCode",
+            Some("opencode"),
+            Some(vec!["opencode".into()]),
+        ),
     ]
+}
+
+fn select_builtin_presets(
+    selection: Option<&[String]>,
+    warnings: &mut Vec<String>,
+) -> Vec<ResolvedLauncherPreset> {
+    let all = builtin_presets();
+    let Some(selection) = selection else {
+        return all;
+    };
+    let by_key: HashMap<String, &ResolvedLauncherPreset> = all
+        .iter()
+        .flat_map(|preset| {
+            let short = builtin_short_name(&preset.id)
+                .map(str::to_string)
+                .unwrap_or_else(|| preset.id.clone());
+            [(preset.id.clone(), preset), (short, preset)]
+        })
+        .collect();
+    let mut selected = Vec::new();
+    let mut seen = HashSet::new();
+    for entry in selection {
+        let key = entry.trim().to_ascii_lowercase();
+        if key.is_empty() {
+            warnings.push("invalid builtins entry: empty name".to_string());
+            continue;
+        }
+        let Some(preset) = by_key.get(&key).copied() else {
+            warnings.push(format!(
+                "unknown builtin launcher entry {entry:?}; expected shell, codex, claude, pi, grok, opencode, or builtin:<name>"
+            ));
+            continue;
+        };
+        if seen.insert(preset.id.clone()) {
+            selected.push(preset.clone());
+        }
+    }
+    selected
+}
+
+fn builtin_short_name(id: &str) -> Option<&str> {
+    id.strip_prefix("builtin:")
 }
 
 fn builtin(
@@ -359,7 +433,9 @@ fn resolve_config_preset(
         .trim()
         .to_string();
     validate_slug(&id, "preset id").map_err(|err| format!("invalid preset {id:?}: {err}"))?;
-    if used_ids.contains(&id) {
+    // Always reserve the builtin: namespace so filtered-out built-ins cannot be
+    // reclaimed as customs (e.g. builtin:shell must not become a plain shell launch).
+    if id.starts_with("builtin:") || used_ids.contains(&id) {
         return Err(format!("invalid preset {id}: duplicate or reserved id"));
     }
     let label = preset
@@ -487,8 +563,22 @@ mod tests {
         let store =
             LauncherPresetStore::load_from_path(Path::new("/definitely/missing.json")).unwrap();
         let response = store.response();
-        assert_eq!(response.presets.len(), 4);
-        assert_eq!(response.presets[0].id, "builtin:shell");
+        assert_eq!(response.presets.len(), 6);
+        assert_eq!(
+            response
+                .presets
+                .iter()
+                .map(|preset| preset.id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "builtin:shell",
+                "builtin:codex",
+                "builtin:claude",
+                "builtin:pi",
+                "builtin:grok",
+                "builtin:opencode",
+            ]
+        );
     }
 
     #[test]
@@ -499,7 +589,7 @@ mod tests {
         )
         .unwrap();
         let response = store.response();
-        assert_eq!(response.presets.len(), 4);
+        assert_eq!(response.presets.len(), 6);
         assert_eq!(response.warnings.len(), 1);
         assert!(response.warnings[0].contains("file not found"));
     }
@@ -514,10 +604,118 @@ mod tests {
         let store = LauncherPresetStore::load_from_path(&path).unwrap();
         let response = store.response();
 
-        assert_eq!(response.presets.len(), 4);
+        assert_eq!(response.presets.len(), 6);
         assert_eq!(response.presets[0].id, "builtin:shell");
         assert_eq!(response.warnings.len(), 1);
         assert!(response.warnings[0].contains("parse error"));
+    }
+
+    #[test]
+    fn builtins_allowlist_filters_and_orders_built_ins() {
+        let root = unique_test_dir("launcher-presets-builtins-filter");
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("presets.json");
+        fs::write(
+            &path,
+            r#"{"version":1,"builtins":["opencode","shell","unknown","grok","shell"],"presets":[
+                {"id":"team","label":"Team","argv":["team-agent"]}
+            ]}"#,
+        )
+        .unwrap();
+
+        let store = LauncherPresetStore::load_from_path(&path).unwrap();
+        let response = store.response();
+        assert_eq!(
+            response
+                .presets
+                .iter()
+                .map(|preset| preset.id.as_str())
+                .collect::<Vec<_>>(),
+            ["builtin:opencode", "builtin:shell", "builtin:grok", "team"]
+        );
+        assert_eq!(response.warnings.len(), 1);
+        assert!(response.warnings[0].contains("unknown"));
+    }
+
+    #[test]
+    fn empty_builtins_list_hides_all_built_ins() {
+        let root = unique_test_dir("launcher-presets-builtins-empty");
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("presets.json");
+        fs::write(
+            &path,
+            r#"{"version":1,"builtins":[],"presets":[
+                {"id":"team","label":"Team","argv":["team-agent"]}
+            ]}"#,
+        )
+        .unwrap();
+
+        let store = LauncherPresetStore::load_from_path(&path).unwrap();
+        let response = store.response();
+        assert_eq!(
+            response
+                .presets
+                .iter()
+                .map(|preset| preset.id.as_str())
+                .collect::<Vec<_>>(),
+            ["team"]
+        );
+        assert!(response.warnings.is_empty());
+    }
+
+    #[test]
+    fn builtins_accept_full_builtin_ids() {
+        let root = unique_test_dir("launcher-presets-builtins-full-id");
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("presets.json");
+        fs::write(
+            &path,
+            r#"{"version":1,"builtins":["builtin:claude","builtin:pi"]}"#,
+        )
+        .unwrap();
+
+        let store = LauncherPresetStore::load_from_path(&path).unwrap();
+        let response = store.response();
+        assert_eq!(
+            response
+                .presets
+                .iter()
+                .map(|preset| preset.id.as_str())
+                .collect::<Vec<_>>(),
+            ["builtin:claude", "builtin:pi"]
+        );
+    }
+
+    #[test]
+    fn custom_presets_cannot_claim_filtered_out_builtin_ids() {
+        let root = unique_test_dir("launcher-presets-reserved-builtin-id");
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("presets.json");
+        fs::write(
+            &path,
+            r#"{"version":1,"builtins":["claude"],"presets":[
+                {"id":"builtin:shell","label":"My Tool","argv":["my-tool"]},
+                {"id":"ok","label":"OK","argv":["ok"]}
+            ]}"#,
+        )
+        .unwrap();
+
+        let store = LauncherPresetStore::load_from_path(&path).unwrap();
+        let response = store.response();
+        assert!(store.preset("builtin:shell").is_none());
+        assert!(store.preset("ok").is_some());
+        assert_eq!(
+            response
+                .presets
+                .iter()
+                .map(|preset| preset.id.as_str())
+                .collect::<Vec<_>>(),
+            ["builtin:claude", "ok"]
+        );
+        assert!(response
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("reserved")));
     }
 
     #[test]

--- a/web/src/AgentIcon.test.ts
+++ b/web/src/AgentIcon.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { agentIconKindFromHint, agentIconKindFromValues } from "./AgentIcon";
+
+describe("agentIconKindFromValues", () => {
+  it("matches known agent labels", () => {
+    expect(agentIconKindFromValues(["claude"])).toBe("claude");
+    expect(agentIconKindFromValues(["codex"])).toBe("codex");
+    expect(agentIconKindFromValues(["pi"])).toBe("pi");
+    expect(agentIconKindFromValues(["grok"])).toBe("grok");
+    expect(agentIconKindFromValues(["opencode"])).toBe("opencode");
+    expect(agentIconKindFromValues(["open-code"])).toBe("opencode");
+  });
+
+  it("matches grok in compound labels without a separate grok-build kind", () => {
+    expect(agentIconKindFromValues(["grok-build"])).toBe("grok");
+  });
+
+  it("prefers structured fields earlier in the list", () => {
+    expect(agentIconKindFromValues(["codex", "claude session"])).toBe("codex");
+  });
+
+  it("returns null for unknown labels", () => {
+    expect(agentIconKindFromValues([null, undefined, "", "shell"])).toBeNull();
+  });
+});
+
+describe("agentIconKindFromHint", () => {
+  it("maps launcher agent hints", () => {
+    expect(agentIconKindFromHint("claude")).toBe("claude");
+    expect(agentIconKindFromHint("codex")).toBe("codex");
+    expect(agentIconKindFromHint("pi")).toBe("pi");
+    expect(agentIconKindFromHint("grok")).toBe("grok");
+    expect(agentIconKindFromHint("grok-build")).toBe("grok");
+    expect(agentIconKindFromHint("opencode")).toBe("opencode");
+    expect(agentIconKindFromHint("open-code")).toBe("opencode");
+    expect(agentIconKindFromHint("claude-code")).toBe("claude");
+  });
+
+  it("ignores unknown or empty hints", () => {
+    expect(agentIconKindFromHint(null)).toBeNull();
+    expect(agentIconKindFromHint("")).toBeNull();
+    expect(agentIconKindFromHint("unknown")).toBeNull();
+  });
+});

--- a/web/src/AgentIcon.tsx
+++ b/web/src/AgentIcon.tsx
@@ -1,13 +1,15 @@
 import type { PaneInfo } from "./types";
 
-export type AgentIconKind = "claude" | "codex" | "pi";
+export type AgentIconKind = "claude" | "codex" | "pi" | "grok" | "opencode";
 
 export function agentIconKind(pane: PaneInfo): AgentIconKind | null {
   // Best-effort cosmetic match: prefer structured agent fields before user labels.
   return agentIconKindFromValues([pane.agent, pane.display_agent, pane.label, pane.title]);
 }
 
-export function agentIconKindFromValues(values: readonly (string | null | undefined)[]): AgentIconKind | null {
+export function agentIconKindFromValues(
+  values: readonly (string | null | undefined)[],
+): AgentIconKind | null {
   for (const value of values) {
     const label = value?.toLowerCase().trim();
     if (!label) {
@@ -19,9 +21,39 @@ export function agentIconKindFromValues(values: readonly (string | null | undefi
     if (label.includes("codex")) {
       return "codex";
     }
+    if (label.includes("opencode") || label.includes("open-code")) {
+      return "opencode";
+    }
+    if (label.includes("grok")) {
+      return "grok";
+    }
     if (/(^|[^a-z0-9])pi([^a-z0-9]|$)/u.test(label)) {
       return "pi";
     }
+  }
+  return null;
+}
+
+export function agentIconKindFromHint(agentHint: string | null | undefined): AgentIconKind | null {
+  if (!agentHint) {
+    return null;
+  }
+  const hint = agentHint.toLowerCase().trim();
+  if (hint === "claude" || hint === "claude-code") {
+    return "claude";
+  }
+  if (hint === "codex") {
+    return "codex";
+  }
+  if (hint === "pi") {
+    return "pi";
+  }
+  if (hint === "grok" || hint === "grok-build") {
+    // grok-build is a known Herdr hint; icon kind remains "grok".
+    return "grok";
+  }
+  if (hint === "opencode" || hint === "open-code") {
+    return "opencode";
   }
   return null;
 }
@@ -38,6 +70,33 @@ export function AgentIcon({ kind }: { kind: AgentIconKind }) {
     return (
       <svg className="agent-icon agent-icon-codex" viewBox="0 0 256 260" aria-hidden="true">
         <path d="M239.184 106.203a64.716 64.716 0 0 0-5.576-53.103C219.452 28.459 191 15.784 163.213 21.74A65.586 65.586 0 0 0 52.096 45.22a64.716 64.716 0 0 0-43.23 31.36c-14.31 24.602-11.061 55.634 8.033 76.74a64.665 64.665 0 0 0 5.525 53.102c14.174 24.65 42.644 37.324 70.446 31.36a64.72 64.72 0 0 0 48.754 21.744c28.481.025 53.714-18.361 62.414-45.481a64.767 64.767 0 0 0 43.229-31.36c14.137-24.558 10.875-55.423-8.083-76.483Zm-97.56 136.338a48.397 48.397 0 0 1-31.105-11.255l1.535-.87 51.67-29.825a8.595 8.595 0 0 0 4.247-7.367v-72.85l21.845 12.636c.218.111.37.32.409.563v60.367c-.056 26.818-21.783 48.545-48.601 48.601Zm-104.466-44.61a48.345 48.345 0 0 1-5.781-32.589l1.534.921 51.722 29.826a8.339 8.339 0 0 0 8.441 0l63.181-36.425v25.221a.87.87 0 0 1-.358.665l-52.335 30.184c-23.257 13.398-52.97 5.431-66.404-17.803ZM23.549 85.38a48.499 48.499 0 0 1 25.58-21.333v61.39a8.288 8.288 0 0 0 4.195 7.316l62.874 36.272-21.845 12.636a.819.819 0 0 1-.767 0L41.353 151.53c-23.211-13.454-31.171-43.144-17.804-66.405v.256Zm179.466 41.695-63.08-36.63L161.73 77.86a.819.819 0 0 1 .768 0l52.233 30.184a48.6 48.6 0 0 1-7.316 87.635v-61.391a8.544 8.544 0 0 0-4.4-7.213Zm21.742-32.69-1.535-.922-51.619-30.081a8.39 8.39 0 0 0-8.492 0L99.98 99.808V74.587a.716.716 0 0 1 .307-.665l52.233-30.133a48.652 48.652 0 0 1 72.236 50.391v.205ZM88.061 139.097l-21.845-12.585a.87.87 0 0 1-.41-.614V65.685a48.652 48.652 0 0 1 79.757-37.346l-1.535.87-51.67 29.825a8.595 8.595 0 0 0-4.246 7.367l-.051 72.697Zm11.868-25.58 28.138-16.217 28.188 16.218v32.434l-28.086 16.218-28.188-16.218-.052-32.434Z" />
+      </svg>
+    );
+  }
+  if (kind === "grok") {
+    return (
+      <svg className="agent-icon agent-icon-grok" viewBox="0 0 24 24" aria-hidden="true" fill="none">
+        <path
+          fill="currentColor"
+          d="M9.26905 15.284L17.2479 9.36086C17.6391 9.07047 18.1981 9.18374 18.3845 9.63478C19.3655 12.0135 18.9272 14.8721 16.9755 16.8349C15.0238 18.7976 12.3082 19.228 9.8261 18.2477L7.1146 19.5102C11.0037 22.1834 15.7263 21.5223 18.6774 18.5525C21.0182 16.1985 21.7432 12.9897 21.0653 10.0961L21.0714 10.1023C20.0884 5.85143 21.3131 4.15233 23.8218 0.677913C23.8812 0.595532 23.9406 0.513151 24 0.428711L20.6987 3.74866V3.73836L9.267 15.2861"
+        />
+        <path
+          fill="currentColor"
+          d="M7.62249 16.7237C4.83113 14.0422 5.3124 9.89222 7.69417 7.49905C9.45541 5.72786 12.341 5.00497 14.86 6.06768L17.5653 4.81138C17.0779 4.45714 16.4533 4.07613 15.7365 3.80839C12.4966 2.46764 8.6178 3.13492 5.98413 5.78141C3.45081 8.32904 2.65415 12.2463 4.02219 15.5889C5.04412 18.0871 3.36889 19.8541 1.68137 21.6377C1.08337 22.2699 0.483318 22.9022 0 23.5716L7.62045 16.7257"
+        />
+      </svg>
+    );
+  }
+  if (kind === "opencode") {
+    return (
+      <svg
+        className="agent-icon agent-icon-opencode"
+        viewBox="0 0 32 40"
+        aria-hidden="true"
+        fill="none"
+      >
+        <path d="M24 32H8V16H24V32Z" fill="currentColor" opacity="0.45" />
+        <path d="M24 8H8V32H24V8ZM32 40H0V0H32V40Z" fill="currentColor" />
       </svg>
     );
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1017,15 +1017,39 @@ export function App() {
       ? launcherPresetStates[launchRuntime.id]
       : null;
   const launchOptions = useMemo(() => {
-    if (
-      launchRuntime &&
-      supportsLauncherPresets(launchRuntime.capabilities) &&
-      launchPresetState?.response
-    ) {
+    if (!launchRuntime || !supportsLauncherPresets(launchRuntime.capabilities)) {
+      return FALLBACK_LAUNCHER_PRESETS;
+    }
+    if (launchPresetState?.response) {
+      // Use the bridge list even when empty (e.g. builtins: [] with no customs).
       return launchPresetState.response.presets;
     }
-    return FALLBACK_LAUNCHER_PRESETS;
-  }, [launchPresetState?.response, launchRuntime?.capabilities]);
+    if (launchPresetState?.loadState === "error") {
+      return FALLBACK_LAUNCHER_PRESETS;
+    }
+    // First load: do not flash the full default set when the bridge may filter builtins.
+    return [];
+  }, [
+    launchPresetState?.loadState,
+    launchPresetState?.response,
+    launchRuntime?.capabilities,
+  ]);
+  const launchEmptyMessage = useMemo(() => {
+    if (!launchRuntime || !supportsLauncherPresets(launchRuntime.capabilities)) {
+      return null;
+    }
+    if (launchPresetState?.response && launchPresetState.response.presets.length === 0) {
+      return "No launcher presets available. Adjust builtins or add custom presets.";
+    }
+    if (launchPresetState?.loadState === "loading" || !launchPresetState?.response) {
+      return "Loading launchers…";
+    }
+    return null;
+  }, [
+    launchPresetState?.loadState,
+    launchPresetState?.response,
+    launchRuntime?.capabilities,
+  ]);
 
   useEffect(() => {
     launcherPresetStatesRef.current = launcherPresetStates;
@@ -3657,6 +3681,7 @@ export function App() {
           target={launchTarget}
           busy={busy}
           options={launchOptions}
+          emptyMessage={launchEmptyMessage}
           onCancel={() => setLaunchTarget(null)}
           onSubmit={submitLaunch}
         />

--- a/web/src/LaunchDialog.test.tsx
+++ b/web/src/LaunchDialog.test.tsx
@@ -87,9 +87,81 @@ describe("LaunchDialog", () => {
     expect(options[0].getAttribute("aria-checked")).toBe("true");
     expect(document.activeElement).toBe(options[0]);
   });
+
+  it("disables create and shows an empty message when there are no options", async () => {
+    const { container } = await renderDialog([], "Loading launchers…");
+
+    expect(launchOptions(container)).toHaveLength(0);
+    expect(container.querySelector(".launch-empty")?.textContent).toBe("Loading launchers…");
+    expect(createButton(container).disabled).toBe(true);
+  });
+
+  it("reselects the first option when the current preset disappears from the list", async () => {
+    const { container, root } = await renderDialog([
+      preset("builtin:shell", "Shell", null, true),
+      preset("builtin:codex", "Codex", "codex", true),
+    ]);
+
+    await act(async () => {
+      launchOptions(container)[1].click();
+    });
+    expect(titleInput(container).value).toBe("Codex");
+    expect(launchOptions(container)[1].getAttribute("aria-checked")).toBe("true");
+
+    await act(async () => {
+      root.render(
+        <LaunchDialog
+          target={{ mode: "tab", workspaceId: "space-1" }}
+          options={[
+            preset("builtin:grok", "Grok", "grok", true),
+            preset("builtin:opencode", "OpenCode", "opencode", true),
+          ]}
+          onCancel={vi.fn()}
+          onSubmit={vi.fn()}
+        />,
+      );
+    });
+
+    const options = launchOptions(container);
+    expect(options.map((option) => option.textContent)).toEqual(["Grok", "OpenCode"]);
+    expect(options[0].getAttribute("aria-checked")).toBe("true");
+    expect(titleInput(container).value).toBe("Grok");
+  });
+
+  it("preserves a custom title when options change", async () => {
+    const { container, root } = await renderDialog([
+      preset("builtin:shell", "Shell", null, true),
+      preset("builtin:codex", "Codex", "codex", true),
+    ]);
+
+    await act(async () => {
+      const input = titleInput(container);
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+      setter?.call(input, "reviewer");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(titleInput(container).value).toBe("reviewer");
+
+    await act(async () => {
+      root.render(
+        <LaunchDialog
+          target={{ mode: "tab", workspaceId: "space-1" }}
+          options={[
+            preset("builtin:grok", "Grok", "grok", true),
+            preset("builtin:opencode", "OpenCode", "opencode", true),
+          ]}
+          onCancel={vi.fn()}
+          onSubmit={vi.fn()}
+        />,
+      );
+    });
+
+    expect(titleInput(container).value).toBe("reviewer");
+    expect(launchOptions(container)[0].getAttribute("aria-checked")).toBe("true");
+  });
 });
 
-async function renderDialog(options: LauncherPresetOption[]) {
+async function renderDialog(options: LauncherPresetOption[], emptyMessage?: string) {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -101,13 +173,14 @@ async function renderDialog(options: LauncherPresetOption[]) {
       <LaunchDialog
         target={{ mode: "tab", workspaceId: "space-1" }}
         options={options}
+        emptyMessage={emptyMessage}
         onCancel={vi.fn()}
         onSubmit={onSubmit}
       />,
     );
   });
 
-  return { container, onSubmit };
+  return { container, onSubmit, root };
 }
 
 function launchOptions(container: HTMLElement) {

--- a/web/src/LaunchDialog.tsx
+++ b/web/src/LaunchDialog.tsx
@@ -1,7 +1,7 @@
 import { Terminal } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
-import { AgentIcon } from "./AgentIcon";
+import { AgentIcon, agentIconKindFromHint } from "./AgentIcon";
 import { launchPresetLabel } from "./launch";
 import type { LaunchSpec, LaunchTarget } from "./launch";
 import type { LauncherPresetOption } from "./launcherPresets";
@@ -10,12 +10,14 @@ export function LaunchDialog({
   target,
   busy,
   options,
+  emptyMessage,
   onCancel,
   onSubmit,
 }: {
   target: LaunchTarget;
   busy?: boolean;
   options: readonly LauncherPresetOption[];
+  emptyMessage?: string | null;
   onCancel: () => void;
   onSubmit: (spec: LaunchSpec) => void;
 }) {
@@ -29,13 +31,32 @@ export function LaunchDialog({
   const [title, setTitle] = useState(() => firstOption.label);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const optionRefs = useRef(new Map<string, HTMLButtonElement>());
+  const selectedLabelRef = useRef(firstOption.label);
 
-  const selectedOption = options.find((option) => option.id === presetId) ?? firstOption;
+  const matchedOption = options.find((option) => option.id === presetId) ?? null;
+  const selectedOption = matchedOption ?? firstOption;
+  if (matchedOption) {
+    selectedLabelRef.current = matchedOption.label;
+  }
 
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
   }, []);
+
+  useEffect(() => {
+    if (options.length === 0 || matchedOption) {
+      return;
+    }
+    const next = options[0];
+    const previousLabel = selectedLabelRef.current;
+    setPresetId(next.id);
+    setTitle((current) => {
+      const trimmed = current.trim();
+      return trimmed === "" || trimmed === previousLabel ? next.label : current;
+    });
+    selectedLabelRef.current = next.label;
+  }, [matchedOption, options]);
 
   const choosePreset = (nextPresetId: string) => {
     setTitle((current) => {
@@ -83,56 +104,62 @@ export function LaunchDialog({
       >
         <div className="modal-title">{launchTitle(target)}</div>
         <div className="launch-grid" role="radiogroup" aria-label="Launch type">
-          {options.map((option, index) => (
-            <button
-              key={option.id}
-              ref={(button) => {
-                if (button) {
-                  optionRefs.current.set(option.id, button);
-                } else {
-                  optionRefs.current.delete(option.id);
-                }
-              }}
-              type="button"
-              className="launch-option"
-              role="radio"
-              aria-checked={presetId === option.id}
-              data-active={presetId === option.id}
-              disabled={busy}
-              tabIndex={presetId === option.id ? 0 : -1}
-              onClick={() => choosePreset(option.id)}
-              onKeyDown={(event) => {
-                if (
-                  event.key !== "ArrowRight" &&
-                  event.key !== "ArrowDown" &&
-                  event.key !== "ArrowLeft" &&
-                  event.key !== "ArrowUp" &&
-                  event.key !== "Home" &&
-                  event.key !== "End"
-                ) {
-                  return;
-                }
-                event.preventDefault();
-                const lastIndex = options.length - 1;
-                const nextIndex =
-                  event.key === "Home"
-                    ? 0
-                    : event.key === "End"
-                      ? lastIndex
-                      : event.key === "ArrowRight" || event.key === "ArrowDown"
-                        ? index === lastIndex
-                          ? 0
-                          : index + 1
-                        : index === 0
-                          ? lastIndex
-                          : index - 1;
-                chooseAndFocusPreset(options[nextIndex].id);
-              }}
-            >
-              <LaunchOptionIcon option={option} />
-              <span>{option.label}</span>
-            </button>
-          ))}
+          {options.length === 0 ? (
+            <div className="launch-empty mono" role="status">
+              {emptyMessage ?? "No launcher presets available."}
+            </div>
+          ) : (
+            options.map((option, index) => (
+              <button
+                key={option.id}
+                ref={(button) => {
+                  if (button) {
+                    optionRefs.current.set(option.id, button);
+                  } else {
+                    optionRefs.current.delete(option.id);
+                  }
+                }}
+                type="button"
+                className="launch-option"
+                role="radio"
+                aria-checked={presetId === option.id}
+                data-active={presetId === option.id}
+                disabled={busy}
+                tabIndex={presetId === option.id ? 0 : -1}
+                onClick={() => choosePreset(option.id)}
+                onKeyDown={(event) => {
+                  if (
+                    event.key !== "ArrowRight" &&
+                    event.key !== "ArrowDown" &&
+                    event.key !== "ArrowLeft" &&
+                    event.key !== "ArrowUp" &&
+                    event.key !== "Home" &&
+                    event.key !== "End"
+                  ) {
+                    return;
+                  }
+                  event.preventDefault();
+                  const lastIndex = options.length - 1;
+                  const nextIndex =
+                    event.key === "Home"
+                      ? 0
+                      : event.key === "End"
+                        ? lastIndex
+                        : event.key === "ArrowRight" || event.key === "ArrowDown"
+                          ? index === lastIndex
+                            ? 0
+                            : index + 1
+                          : index === 0
+                            ? lastIndex
+                            : index - 1;
+                  chooseAndFocusPreset(options[nextIndex].id);
+                }}
+              >
+                <LaunchOptionIcon option={option} />
+                <span>{option.label}</span>
+              </button>
+            ))
+          )}
         </div>
         <label className="field-label">
           <span>title</span>
@@ -151,7 +178,11 @@ export function LaunchDialog({
           <button type="button" className="btn" onClick={onCancel}>
             Cancel
           </button>
-          <button type="submit" className="btn btn-primary" disabled={busy || !title.trim()}>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={busy || !title.trim() || options.length === 0}
+          >
             Create
           </button>
         </div>
@@ -161,18 +192,11 @@ export function LaunchDialog({
 }
 
 function LaunchOptionIcon({ option }: { option: LauncherPresetOption }) {
-  const kind = agentIconKindForHint(option.agent_hint);
+  const kind = agentIconKindFromHint(option.agent_hint);
   if (kind) {
     return <AgentIcon kind={kind} />;
   }
   return <Terminal size={15} />;
-}
-
-function agentIconKindForHint(agentHint: string | null): "claude" | "codex" | "pi" | null {
-  if (agentHint === "claude" || agentHint === "codex" || agentHint === "pi") {
-    return agentHint;
-  }
-  return null;
 }
 
 function launchTitle(target: LaunchTarget) {

--- a/web/src/launch.test.ts
+++ b/web/src/launch.test.ts
@@ -21,6 +21,8 @@ describe("launch helpers", () => {
     expect(agentArgv("codex")).toEqual(["codex"]);
     expect(agentArgv("claude")).toEqual(["claude"]);
     expect(agentArgv("pi")).toEqual(["pi"]);
+    expect(agentArgv("grok")).toEqual(["grok"]);
+    expect(agentArgv("opencode")).toEqual(["opencode"]);
   });
 
   it("keeps custom launch titles", () => {

--- a/web/src/launch.ts
+++ b/web/src/launch.ts
@@ -1,9 +1,9 @@
 import type { PaneInfo } from "./types";
-import type { LauncherPresetOption } from "./launcherPresets";
+import type { LauncherPresetOption, LegacyLaunchKind } from "./launcherPresets";
 import { FALLBACK_LAUNCHER_PRESETS, legacyKindForPresetId } from "./launcherPresets";
 
 export type SplitDirection = "right" | "down";
-export type LaunchKind = "shell" | "codex" | "claude" | "pi";
+export type LaunchKind = LegacyLaunchKind;
 
 export type LaunchSpec = {
   presetId: string;
@@ -20,12 +20,16 @@ export const LAUNCH_OPTIONS: { kind: LaunchKind; label: string }[] = [
   { kind: "codex", label: "Codex" },
   { kind: "claude", label: "Claude" },
   { kind: "pi", label: "pi" },
+  { kind: "grok", label: "Grok" },
+  { kind: "opencode", label: "OpenCode" },
 ];
 
 const AGENT_ARGV: Record<Exclude<LaunchKind, "shell">, string[]> = {
   codex: ["codex"],
   claude: ["claude"],
   pi: ["pi"],
+  grok: ["grok"],
+  opencode: ["opencode"],
 };
 
 export function launchLabel(kind: LaunchKind) {

--- a/web/src/launcherPresets.test.ts
+++ b/web/src/launcherPresets.test.ts
@@ -45,9 +45,27 @@ describe("launcher presets", () => {
     expect(parseLauncherPresetsResponse({}).presets).toEqual(FALLBACK_LAUNCHER_PRESETS);
   });
 
+  it("preserves an intentionally empty preset list", () => {
+    expect(
+      parseLauncherPresetsResponse({
+        version: 1,
+        presets: [],
+        warnings: [],
+      }),
+    ).toEqual({
+      version: 1,
+      presets: [],
+      warnings: [],
+    });
+  });
+
   it("maps built-in preset ids to legacy launch kinds", () => {
     expect(legacyKindForPresetId("builtin:shell")).toBe("shell");
     expect(legacyKindForPresetId("builtin:codex")).toBe("codex");
+    expect(legacyKindForPresetId("builtin:claude")).toBe("claude");
+    expect(legacyKindForPresetId("builtin:pi")).toBe("pi");
+    expect(legacyKindForPresetId("builtin:grok")).toBe("grok");
+    expect(legacyKindForPresetId("builtin:opencode")).toBe("opencode");
     expect(legacyKindForPresetId("custom")).toBeNull();
   });
 });

--- a/web/src/launcherPresets.ts
+++ b/web/src/launcherPresets.ts
@@ -15,6 +15,8 @@ export type LauncherPresetsResponse = {
   warnings: string[];
 };
 
+export type LegacyLaunchKind = "shell" | "codex" | "claude" | "pi" | "grok" | "opencode";
+
 export const FALLBACK_LAUNCHER_PRESETS: LauncherPresetOption[] = [
   {
     id: "builtin:shell",
@@ -40,6 +42,18 @@ export const FALLBACK_LAUNCHER_PRESETS: LauncherPresetOption[] = [
     agent_hint: "pi",
     built_in: true,
   },
+  {
+    id: "builtin:grok",
+    label: "Grok",
+    agent_hint: "grok",
+    built_in: true,
+  },
+  {
+    id: "builtin:opencode",
+    label: "OpenCode",
+    agent_hint: "opencode",
+    built_in: true,
+  },
 ];
 
 export function supportsLauncherPresets(capabilities: BridgeCapabilities | null | undefined) {
@@ -60,23 +74,27 @@ export function parseLauncherPresetsResponse(value: unknown): LauncherPresetsRes
   if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.presets)) {
     return { version: 1, presets: FALLBACK_LAUNCHER_PRESETS, warnings: [] };
   }
+  // Preserve an intentionally empty list (e.g. builtins: [] with no customs).
+  // Only fall back when the response shape itself is unusable.
   const presets = value.presets
     .map(parseLauncherPreset)
     .filter((preset): preset is LauncherPresetOption => Boolean(preset));
   return {
     version: 1,
-    presets: presets.length > 0 ? presets : FALLBACK_LAUNCHER_PRESETS,
+    presets,
     warnings: Array.isArray(value.warnings)
       ? value.warnings.filter((warning): warning is string => typeof warning === "string")
       : [],
   };
 }
 
-export function legacyKindForPresetId(id: string): "shell" | "codex" | "claude" | "pi" | null {
+export function legacyKindForPresetId(id: string): LegacyLaunchKind | null {
   if (id === "builtin:shell") return "shell";
   if (id === "builtin:codex") return "codex";
   if (id === "builtin:claude") return "claude";
   if (id === "builtin:pi") return "pi";
+  if (id === "builtin:grok") return "grok";
+  if (id === "builtin:opencode") return "opencode";
   return null;
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2302,6 +2302,15 @@ button {
   white-space: nowrap;
 }
 
+.launch-empty {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 8px 4px;
+  color: var(--subtext0);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
 .backend-modal {
   width: min(840px, 100%);
 }


### PR DESCRIPTION
## Summary

- Add Grok and OpenCode agent icons in the Agents sidebar and create-menu choices.
- Add built-in launcher presets for Grok and OpenCode (`builtin:grok`, `builtin:opencode`).
- Add optional `builtins` allowlist/order in `launcher-presets.json` so the create menu can show a curated subset of built-ins (omit = all; `[]` = none). No PATH probing.
- Preserve intentionally empty bridge preset lists, avoid flashing unfiltered fallbacks while loading, and reserve the `builtin:` id namespace for real built-ins.

## Test plan

- [x] `npm run test:web`
- [x] `npm run bridge:test`
- [x] `npm run lint:web`
- [x] `cargo fmt --check` (bridge)
- [x] Local deploy: restart `herdr-web.service`; confirm `/api/launcher-presets` includes Grok and OpenCode
- [x] Android debug APK built on `pc` and staged under downloads
- [ ] Smoke create menu: icons for Grok/OpenCode, launch both kinds
- [ ] Smoke Agents sidebar icons for detected Grok/OpenCode panes
- [ ] Optional: set `builtins: ["shell", "grok"]` and confirm filter/order

