### PR TITLE
Support Herdr protocol 17 and fix mobile Send prompt prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ### Changed
 
+- Refreshed the vendored Herdr compatibility baseline to `v0.7.5`, including protocol `17`, so the
+  bridge accepts current Herdr daemons while still allowing protocol `16` (`v0.7.2`–`v0.7.4`).
+- Adapted launcher agent splits to Herdr's pane-first `agent.start` API (split an existing pane,
+  then start the agent in it) after `agent.start` stopped creating topology itself.
+- Stopped reading removed pane `custom_status` fields; activity updates keep a null `custom_status`
+  for older web clients and rely on `state_labels` / title / display agent instead.
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@
 ### Fixed
 
 - Remounted and cleared the mobile terminal command field on Send/Stage so a stale native prefix cannot be appended onto the next keystrokes and resubmitted.
+  [PR #38](https://github.com/kcosr/herdr-web/pull/38)
 - Sent mobile Send as one PTY frame (`text` + Enter) instead of two delayed frames, so agent prompts no longer keep staged text for the next Send to prepend.
+  [PR #38](https://github.com/kcosr/herdr-web/pull/38)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@
 
 - Refreshed the vendored Herdr compatibility baseline to `v0.7.5`, including protocol `17`, so the
   bridge accepts current Herdr daemons while still allowing protocol `16` (`v0.7.2`–`v0.7.4`).
+  [PR #38](https://github.com/kcosr/herdr-web/pull/38)
 - Adapted launcher agent splits to Herdr's pane-first `agent.start` API (split an existing pane,
   then start the agent in it) after `agent.start` stopped creating topology itself.
+  [PR #38](https://github.com/kcosr/herdr-web/pull/38)
 - Stopped reading removed pane `custom_status` fields; activity updates keep a null `custom_status`
   for older web clients and rely on `state_labels` / title / display agent instead.
+  [PR #38](https://github.com/kcosr/herdr-web/pull/38)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ### Fixed
 
+- Remounted and cleared the mobile terminal command field on Send/Stage so a stale native prefix cannot be appended onto the next keystrokes and resubmitted.
+- Sent mobile Send as one PTY frame (`text` + Enter) instead of two delayed frames, so agent prompts no longer keep staged text for the next Send to prepend.
+
 ### Removed
 
 ## [0.3.3] - 2026-07-19

--- a/bridge/src/agent_activity.rs
+++ b/bridge/src/agent_activity.rs
@@ -254,7 +254,7 @@ fn pane_key(pane: &PaneInfo) -> PaneKey {
 fn is_agent_like(pane: &PaneInfo) -> bool {
     pane.agent.is_some()
         || pane.display_agent.is_some()
-        || pane.custom_status.is_some()
+        || !pane.state_labels.is_empty()
         || pane.title.is_some()
         || pane.agent_status != AgentStatus::Unknown
 }
@@ -492,10 +492,12 @@ mod tests {
             agent: None,
             agent_session: None,
             title: None,
+            terminal_title: None,
+            terminal_title_stripped: None,
             display_agent: None,
             agent_status: AgentStatus::Unknown,
-            custom_status: None,
             state_labels: HashMap::new(),
+            tokens: HashMap::new(),
             scroll: None,
             revision: 1,
         }

--- a/bridge/src/agent_pins.rs
+++ b/bridge/src/agent_pins.rs
@@ -423,10 +423,12 @@ mod tests {
             agent: Some("codex".to_string()),
             agent_session: None,
             title: None,
+            terminal_title: None,
+            terminal_title_stripped: None,
             display_agent: Some("Codex".to_string()),
             agent_status: AgentStatus::Idle,
-            custom_status: None,
             state_labels: HashMap::new(),
+            tokens: HashMap::new(),
             scroll: None,
             revision: 1,
         }

--- a/bridge/src/notes.rs
+++ b/bridge/src/notes.rs
@@ -1014,6 +1014,7 @@ fn default_notes_dir() -> PathBuf {
 mod tests {
     use super::*;
     use herdr_compat::api::schema::AgentStatus;
+    use std::collections::HashMap;
 
     #[test]
     fn creates_and_lists_linked_note() {
@@ -1391,10 +1392,12 @@ mod tests {
             label: None,
             agent: None,
             title: None,
+            terminal_title: None,
+            terminal_title_stripped: None,
             display_agent: None,
             agent_status: AgentStatus::Unknown,
-            custom_status: None,
             state_labels: Default::default(),
+            tokens: HashMap::new(),
             agent_session: None,
             scroll: None,
             revision,

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -1924,7 +1924,7 @@ fn launch_preset_blocking(
             if preset.is_builtin_shell() {
                 launch_builtin_shell_split(api, preset, title, target_pane_id, direction)
             } else if preset.agent_hint.is_some() {
-                launch_agent_split(api, preset, title, tab_id, direction)
+                launch_agent_split(api, preset, title, target_pane_id, direction)
             } else {
                 launch_layout_split(api, preset, title, tab_id, target_pane_id, direction)
             }
@@ -2014,29 +2014,53 @@ fn launch_agent_split(
     api: &ApiClient,
     preset: &ResolvedLauncherPreset,
     title: &str,
-    tab_id: String,
+    target_pane_id: String,
     direction: SplitDirection,
 ) -> Result<LauncherPresetLaunchResponse, LauncherPresetError> {
+    let kind = preset
+        .agent_hint
+        .clone()
+        .ok_or_else(|| LauncherPresetError::invalid("preset agent_hint is required"))?;
     let argv = preset
         .argv
         .clone()
         .ok_or_else(|| LauncherPresetError::invalid("preset argv is required"))?;
-    let result = api_request(
+    let args = agent_start_args_from_argv(&kind, argv);
+
+    let split = api_request(
         api,
-        "herdr-web:launcher:agent-split",
-        Method::AgentStart(AgentStartParams {
-            name: title.into(),
-            cwd: preset.cwd.clone(),
+        "herdr-web:launcher:agent-split-pane",
+        Method::PaneSplit(PaneSplitParams {
             workspace_id: None,
-            tab_id: Some(tab_id),
-            split: Some(direction),
+            target_pane_id: Some(target_pane_id),
+            direction,
+            ratio: None,
+            cwd: preset.cwd.clone(),
             focus: true,
-            argv,
             env: preset.launch_env(),
         }),
     )
     .map_err(|err| LauncherPresetError::launch_failed(err.to_string()))?;
-    let ResponseResult::AgentStarted { agent, .. } = result else {
+    let ResponseResult::PaneInfo { pane } = split else {
+        return Err(LauncherPresetError::launch_failed(
+            "unexpected response for agent split pane",
+        ));
+    };
+    rename_launched_pane(api, &pane.pane_id, title)?;
+
+    let started = api_request(
+        api,
+        "herdr-web:launcher:agent-start",
+        Method::AgentStart(AgentStartParams {
+            name: title.into(),
+            kind,
+            pane_id: pane.pane_id.clone(),
+            args,
+            timeout_ms: None,
+        }),
+    )
+    .map_err(|err| LauncherPresetError::launch_failed(err.to_string()))?;
+    let ResponseResult::AgentStarted { agent, .. } = started else {
         return Err(LauncherPresetError::launch_failed(
             "unexpected response for agent split launch",
         ));
@@ -2048,6 +2072,21 @@ fn launch_agent_split(
         tab_id: agent.tab_id,
         pane_id: agent.pane_id,
     })
+}
+
+fn agent_start_args_from_argv(kind: &str, argv: Vec<String>) -> Vec<String> {
+    match argv.split_first() {
+        Some((exe, rest))
+            if exe == kind
+                || exe
+                    .rsplit('/')
+                    .next()
+                    .is_some_and(|name| name == kind || name.trim_end_matches(".exe") == kind) =>
+        {
+            rest.to_vec()
+        }
+        _ => argv,
+    }
 }
 
 fn launch_layout_tab(
@@ -3682,7 +3721,8 @@ fn activity_message_from_subscription_value(value: serde_json::Value) -> Option<
         agent: event.agent,
         title: event.title,
         display_agent: event.display_agent,
-        custom_status: event.custom_status,
+        // Herdr ≥0.7.5 dropped custom_status; keep the wire field for older web clients.
+        custom_status: None,
         state_labels: event.state_labels,
     })
 }
@@ -4882,6 +4922,7 @@ mod tests {
             tab_count,
             active_tab_id: active_tab_id.to_string(),
             agent_status: AgentStatus::Idle,
+            tokens: HashMap::new(),
             worktree: None,
         }
     }
@@ -4969,10 +5010,12 @@ mod tests {
             label: None,
             agent: None,
             title: None,
+            terminal_title: None,
+            terminal_title_stripped: None,
             display_agent: None,
             agent_status: AgentStatus::Idle,
-            custom_status: None,
             state_labels: HashMap::new(),
+            tokens: HashMap::new(),
             agent_session: None,
             scroll: None,
             revision: 1,

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -10,6 +10,7 @@ Rust crate containing copied or lightly pruned compatibility code needed by `her
 
 - JSON API client, status, request, response, and event schema types.
 - Terminal attach wire protocol messages, framing, protocol constants, and frame data types.
+- Popup size helpers shared with plugin pane schema fields.
 - Local socket connection helpers.
 - Client socket path derivation helpers.
 - Small dependent model shims needed by copied schema/protocol modules.
@@ -32,7 +33,7 @@ The browser app is not vendored into Herdr. It lives at `web/`, and `herdr-web-b
 ## Current Reference
 
 - Upstream checkout: a clean Herdr source checkout outside this repository
-- Upstream release baseline: `v0.7.2`
+- Upstream release baseline: `v0.7.5`
 
 Use the upstream checkout as an external reference for audits and refreshes. It is not required to
 build `herdr-web`.
@@ -84,6 +85,7 @@ src/api/status.rs          -> vendor/herdr-compat/src/api/status.rs
 src/api/schema.rs          -> vendor/herdr-compat/src/api/schema.rs
 src/api/schema/*.rs        -> vendor/herdr-compat/src/api/schema/*.rs
 src/protocol/wire.rs       -> vendor/herdr-compat/src/protocol/wire.rs
+src/popup_size.rs          -> vendor/herdr-compat/src/popup_size.rs
 src/ipc.rs                 -> vendor/herdr-compat/src/ipc.rs
 src/logging.rs             -> vendor/herdr-compat/src/logging.rs
 src/server/socket_paths.rs -> vendor/herdr-compat/src/server/socket_paths.rs
@@ -130,10 +132,11 @@ the refit button after changing browser sizes.
 
 ## Compatibility Policy
 
-The bridge pings Herdr's status API at startup and requires daemon protocol `16` or newer. The
-`v0.7.2` baseline provides the native `session.snapshot` bootstrap API used by `/api/snapshot`, so
-older daemons are rejected before serving the web app. This is not a complete stability guarantee
-because the bridge mirrors private APIs.
+The bridge pings Herdr's status API at startup and requires daemon protocol `16` through the
+vendored `PROTOCOL_VERSION` (`17` as of the `v0.7.5` baseline). The `v0.7.2` floor still applies
+for the native `session.snapshot` bootstrap API used by `/api/snapshot`, so older daemons are
+rejected before serving the web app. This is not a complete stability guarantee because the bridge
+mirrors private APIs.
 
 When updating Herdr:
 

--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -18,6 +18,7 @@ required=(
   "$COMPAT/src/api/schema"
   "$COMPAT/src/ipc.rs"
   "$COMPAT/src/logging.rs"
+  "$COMPAT/src/popup_size.rs"
   "$COMPAT/src/protocol.rs"
   "$COMPAT/src/protocol/wire.rs"
   "$COMPAT/src/server/socket_paths.rs"
@@ -91,6 +92,7 @@ if [[ -n "${HERDR_SRC:-}" ]]; then
   }
 
   compare_exact "src/api/schema.rs" "src/api/schema.rs"
+  compare_exact "src/popup_size.rs" "src/popup_size.rs"
   while IFS= read -r -d '' upstream_schema_file; do
     file_name="$(basename "$upstream_schema_file")"
     case "$file_name" in

--- a/vendor/herdr-compat/src/api/schema.rs
+++ b/vendor/herdr-compat/src/api/schema.rs
@@ -75,6 +75,8 @@ pub enum Method {
     WorkspaceRename(WorkspaceRenameParams),
     #[serde(rename = "workspace.move")]
     WorkspaceMove(WorkspaceMoveParams),
+    #[serde(rename = "workspace.report_metadata")]
+    WorkspaceReportMetadata(WorkspaceReportMetadataParams),
     #[serde(rename = "workspace.close")]
     WorkspaceClose(WorkspaceTarget),
     #[serde(rename = "worktree.list")]
@@ -107,14 +109,22 @@ pub enum Method {
     AgentRead(AgentReadParams),
     #[serde(rename = "agent.explain")]
     AgentExplain(AgentTarget),
-    #[serde(rename = "agent.send")]
-    AgentSend(AgentSendParams),
+    #[serde(rename = "agent.send_keys")]
+    AgentSendKeys(AgentSendKeysParams),
     #[serde(rename = "agent.rename")]
     AgentRename(AgentRenameParams),
+    #[serde(rename = "agent.view.set")]
+    AgentViewSet(AgentViewSetParams),
+    #[serde(rename = "agent.view.clear")]
+    AgentViewClear(AgentViewClearParams),
     #[serde(rename = "agent.focus")]
     AgentFocus(AgentTarget),
     #[serde(rename = "agent.start")]
     AgentStart(AgentStartParams),
+    #[serde(rename = "agent.prompt")]
+    AgentPrompt(AgentPromptParams),
+    #[serde(rename = "agent.wait")]
+    AgentWait(AgentWaitParams),
     #[serde(rename = "pane.split")]
     PaneSplit(PaneSplitParams),
     #[serde(rename = "pane.swap")]
@@ -159,6 +169,24 @@ pub enum Method {
     PaneSendInput(PaneSendInputParams),
     #[serde(rename = "pane.read")]
     PaneRead(PaneReadParams),
+    #[serde(rename = "pane.graphics.set")]
+    PaneGraphicsSet(PaneGraphicsSetParams),
+    #[serde(rename = "pane.graphics.clear")]
+    PaneGraphicsClear(PaneGraphicsClearParams),
+    #[serde(rename = "pane.graphics.info")]
+    PaneGraphicsInfo(PaneTarget),
+    #[serde(rename = "pane.graphics.stream")]
+    #[schemars(skip)]
+    PaneGraphicsStream(PaneGraphicsStreamParams),
+    #[serde(skip)]
+    #[schemars(skip)]
+    PaneGraphicsStreamSet(PaneGraphicsSetParams),
+    #[serde(skip)]
+    #[schemars(skip)]
+    PaneGraphicsStreamOpen(PaneGraphicsStreamParams),
+    #[serde(skip)]
+    #[schemars(skip)]
+    PaneGraphicsStreamClose(PaneGraphicsStreamParams),
     #[serde(rename = "pane.report_agent")]
     PaneReportAgent(PaneReportAgentParams),
     #[serde(rename = "pane.report_agent_session")]
@@ -171,6 +199,8 @@ pub enum Method {
     PaneReleaseAgent(PaneReleaseAgentParams),
     #[serde(rename = "pane.close")]
     PaneClose(PaneTarget),
+    #[serde(rename = "popup.close")]
+    PopupClose(EmptyParams),
     #[serde(rename = "events.subscribe")]
     EventsSubscribe(EventsSubscribeParams),
     #[serde(rename = "events.wait")]

--- a/vendor/herdr-compat/src/api/schema/agents.rs
+++ b/vendor/herdr-compat/src/api/schema/agents.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use super::common::{AgentStatus, ReadFormat, ReadSource, SplitDirection};
+use super::common::{AgentStatus, ReadFormat, ReadSource};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentReadParams {
@@ -17,9 +17,26 @@ pub struct AgentReadParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct AgentSendParams {
+pub struct AgentSendKeysParams {
     pub target: String,
-    pub text: String,
+    pub keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentWaitParams {
+    pub target: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub until: Vec<AgentStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentPromptWaitOptions {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub until: Vec<AgentStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
@@ -30,21 +47,137 @@ pub struct AgentRenameParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentViewSetParams {
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter: Option<AgentViewFilter>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sort: Vec<AgentViewSort>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
+pub struct AgentViewClearParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum AgentViewFilter {
+    All {
+        filters: Vec<AgentViewFilter>,
+    },
+    Any {
+        filters: Vec<AgentViewFilter>,
+    },
+    Not {
+        filter: Box<AgentViewFilter>,
+    },
+    Eq {
+        field: AgentViewField,
+        value: AgentViewValue,
+    },
+    In {
+        field: AgentViewField,
+        values: Vec<AgentViewValue>,
+    },
+    Exists {
+        field: AgentViewField,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum AgentViewField {
+    Builtin(AgentViewBuiltinField),
+    Token { token: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentViewBuiltinField {
+    Status,
+    WorkspaceId,
+    TabId,
+    PaneId,
+    Agent,
+    Seen,
+    StateChangeSeq,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum AgentViewValue {
+    String(String),
+    Bool(bool),
+    Number(u64),
+    Context { context: AgentViewContext },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentViewContext {
+    CurrentWorkspaceId,
+    CurrentTabId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentViewSort {
+    pub field: AgentViewSortField,
+    #[serde(default)]
+    pub order: AgentViewSortOrder,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum AgentViewSortField {
+    Builtin(AgentViewBuiltinSortField),
+    Token { token: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentViewBuiltinSortField {
+    WorkspaceOrder,
+    TabOrder,
+    PaneOrder,
+    Attention,
+    Status,
+    Agent,
+    Seen,
+    StateChangeSeq,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentViewSortOrder {
+    #[default]
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentStartParams {
     pub name: String,
+    pub kind: String,
+    pub pane_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    /// Startup timeout in milliseconds. Values must be greater than 3000 and at most 300000.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cwd: Option<String>,
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentPromptParams {
+    pub target: String,
+    pub text: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tab_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub split: Option<SplitDirection>,
-    #[serde(default)]
-    pub focus: bool,
-    pub argv: Vec<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub env: HashMap<String, String>,
+    pub wait: Option<AgentPromptWaitOptions>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
@@ -57,20 +190,31 @@ pub struct AgentInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_title_stripped: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_agent: Option<String>,
     pub agent_status: AgentStatus,
     #[serde(default, skip_serializing_if = "super::is_false")]
     pub screen_detection_skipped: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_status: Option<String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub state_labels: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[schemars(schema_with = "super::common::metadata_token_values_schema")]
+    pub tokens: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_session: Option<AgentSessionInfo>,
     pub workspace_id: String,
     pub tab_id: String,
     pub pane_id: String,
     pub focused: bool,
+    #[serde(default, skip_serializing_if = "super::is_false")]
+    pub launch_pending: bool,
+    #[serde(default, skip_serializing_if = "super::is_false")]
+    pub interactive_ready: bool,
+    #[serde(default)]
+    pub state_change_seq: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/vendor/herdr-compat/src/api/schema/common.rs
+++ b/vendor/herdr-compat/src/api/schema/common.rs
@@ -1,5 +1,27 @@
 use serde::{Deserialize, Serialize};
 
+pub(super) fn metadata_token_patch_schema(
+    _generator: &mut schemars::SchemaGenerator,
+) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "object",
+        "maxProperties": 16,
+        "propertyNames": { "pattern": "^[A-Za-z0-9_-]{1,32}$" },
+        "additionalProperties": { "type": ["string", "null"] }
+    })
+}
+
+pub(super) fn metadata_token_values_schema(
+    _generator: &mut schemars::SchemaGenerator,
+) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "object",
+        "maxProperties": 32,
+        "propertyNames": { "pattern": "^[A-Za-z0-9_-]{1,32}$" },
+        "additionalProperties": { "type": "string" }
+    })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct EmptyParams {}
 

--- a/vendor/herdr-compat/src/api/schema/events.rs
+++ b/vendor/herdr-compat/src/api/schema/events.rs
@@ -20,6 +20,8 @@ pub enum Subscription {
     WorkspaceCreated {},
     #[serde(rename = "workspace.updated")]
     WorkspaceUpdated {},
+    #[serde(rename = "workspace.metadata_updated")]
+    WorkspaceMetadataUpdated {},
     #[serde(rename = "workspace.renamed")]
     WorkspaceRenamed {},
     #[serde(rename = "workspace.moved")]
@@ -48,6 +50,8 @@ pub enum Subscription {
     PaneCreated {},
     #[serde(rename = "pane.closed")]
     PaneClosed {},
+    #[serde(rename = "pane.updated")]
+    PaneUpdated {},
     #[serde(rename = "pane.focused")]
     PaneFocused {},
     #[serde(rename = "pane.moved")]
@@ -188,6 +192,7 @@ pub enum EventMatch {
 pub enum EventKind {
     WorkspaceCreated,
     WorkspaceUpdated,
+    WorkspaceMetadataUpdated,
     WorkspaceClosed,
     WorkspaceRenamed,
     WorkspaceMoved,
@@ -202,6 +207,7 @@ pub enum EventKind {
     TabFocused,
     PaneCreated,
     PaneClosed,
+    PaneUpdated,
     PaneFocused,
     PaneMoved,
     PaneOutputChanged,
@@ -216,6 +222,7 @@ impl EventKind {
         match self {
             EventKind::WorkspaceCreated => "workspace.created",
             EventKind::WorkspaceUpdated => "workspace.updated",
+            EventKind::WorkspaceMetadataUpdated => "workspace.metadata_updated",
             EventKind::WorkspaceClosed => "workspace.closed",
             EventKind::WorkspaceRenamed => "workspace.renamed",
             EventKind::WorkspaceMoved => "workspace.moved",
@@ -230,6 +237,7 @@ impl EventKind {
             EventKind::TabFocused => "tab.focused",
             EventKind::PaneCreated => "pane.created",
             EventKind::PaneClosed => "pane.closed",
+            EventKind::PaneUpdated => "pane.updated",
             EventKind::PaneFocused => "pane.focused",
             EventKind::PaneMoved => "pane.moved",
             EventKind::PaneOutputChanged => "pane.output_changed",
@@ -245,6 +253,7 @@ impl EventKind {
 pub const KNOWN_EVENT_KINDS: &[EventKind] = &[
     EventKind::WorkspaceCreated,
     EventKind::WorkspaceUpdated,
+    EventKind::WorkspaceMetadataUpdated,
     EventKind::WorkspaceClosed,
     EventKind::WorkspaceRenamed,
     EventKind::WorkspaceMoved,
@@ -259,6 +268,7 @@ pub const KNOWN_EVENT_KINDS: &[EventKind] = &[
     EventKind::TabFocused,
     EventKind::PaneCreated,
     EventKind::PaneClosed,
+    EventKind::PaneUpdated,
     EventKind::PaneFocused,
     EventKind::PaneMoved,
     EventKind::PaneOutputChanged,
@@ -336,6 +346,8 @@ mod known_event_name_tests {
         let names = plugin_hook_event_names();
         assert!(!names.contains(&"pane.output_changed"));
         assert!(!names.contains(&"layout.updated"));
+        assert!(!names.contains(&"workspace.metadata_updated"));
+        assert!(!names.contains(&"pane.updated"));
         assert!(names.contains(&"pane.moved"));
     }
 }
@@ -385,8 +397,6 @@ pub struct PaneAgentStatusChangedEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_status: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_agent: Option<String>,
@@ -408,6 +418,9 @@ pub enum EventData {
         workspace: WorkspaceInfo,
     },
     WorkspaceUpdated {
+        workspace: WorkspaceInfo,
+    },
+    WorkspaceMetadataUpdated {
         workspace: WorkspaceInfo,
     },
     WorkspaceClosed {
@@ -472,6 +485,9 @@ pub enum EventData {
         pane_id: String,
         workspace_id: String,
     },
+    PaneUpdated {
+        pane: PaneInfo,
+    },
     PaneFocused {
         pane_id: String,
         workspace_id: String,
@@ -504,6 +520,10 @@ pub enum EventData {
         workspace_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         agent: Option<String>,
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        released: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        final_status: Option<AgentStatus>,
     },
     PaneAgentStatusChanged {
         pane_id: String,
@@ -515,8 +535,6 @@ pub enum EventData {
         title: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         display_agent: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        custom_status: Option<String>,
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         state_labels: HashMap<String, String>,
     },

--- a/vendor/herdr-compat/src/api/schema/integrations.rs
+++ b/vendor/herdr-compat/src/api/schema/integrations.rs
@@ -29,6 +29,25 @@ pub enum IntegrationTarget {
     Mastracode,
 }
 
+impl IntegrationTarget {
+    pub(crate) const ALL: [Self; 14] = [
+        Self::Pi,
+        Self::Omp,
+        Self::Claude,
+        Self::Codex,
+        Self::Copilot,
+        Self::Devin,
+        Self::Droid,
+        Self::Kimi,
+        Self::Opencode,
+        Self::Kilo,
+        Self::Hermes,
+        Self::Qodercli,
+        Self::Cursor,
+        Self::Mastracode,
+    ];
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct IntegrationInstallResult {
     pub messages: Vec<String>,

--- a/vendor/herdr-compat/src/api/schema/panes.rs
+++ b/vendor/herdr-compat/src/api/schema/panes.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+pub(crate) const PANE_GRAPHICS_SET_MAX_BYTES: usize = 512 * 1024;
+pub(crate) const PANE_GRAPHICS_STREAM_MAX_BYTES: usize = 16 * 1024 * 1024;
+
 use super::agents::AgentSessionInfo;
 use super::common::{AgentStatus, PaneAgentState, ReadFormat, ReadSource, SplitDirection};
 
@@ -257,6 +260,58 @@ pub struct PaneReadParams {
     pub strip_ansi: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PaneGraphicsFormat {
+    Png,
+    Rgb,
+    Rgba,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PaneGraphicsSetParams {
+    pub pane_id: String,
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub owner: String,
+    pub format: PaneGraphicsFormat,
+    pub image_width: u32,
+    pub image_height: u32,
+    #[serde(skip)]
+    pub data: Option<Vec<u8>>,
+    #[serde(default)]
+    pub data_base64: String,
+    #[serde(default)]
+    pub placement: PaneGraphicsPlacementParams,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default,
+)]
+pub struct PaneGraphicsPlacementParams {
+    #[serde(default)]
+    pub viewport_col: i32,
+    #[serde(default)]
+    pub viewport_row: i32,
+    #[serde(default)]
+    pub grid_cols: u32,
+    #[serde(default)]
+    pub grid_rows: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PaneGraphicsClearParams {
+    pub pane_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PaneGraphicsStreamParams {
+    pub pane_id: String,
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub owner: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaneReportAgentParams {
     pub pane_id: String,
@@ -265,8 +320,6 @@ pub struct PaneReportAgentParams {
     pub state: PaneAgentState,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_status: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seq: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -302,21 +355,21 @@ pub struct PaneReportMetadataParams {
     pub title: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_agent: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_status: Option<String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub state_labels: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[schemars(schema_with = "super::common::metadata_token_patch_schema")]
+    pub tokens: HashMap<String, Option<String>>,
     #[serde(default)]
     pub clear_title: bool,
     #[serde(default)]
     pub clear_display_agent: bool,
     #[serde(default)]
-    pub clear_custom_status: bool,
-    #[serde(default)]
     pub clear_state_labels: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seq: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1, max = 86_400_000))]
     pub ttl_ms: Option<u64>,
 }
 
@@ -356,12 +409,17 @@ pub struct PaneInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_title_stripped: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_agent: Option<String>,
     pub agent_status: AgentStatus,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_status: Option<String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub state_labels: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[schemars(schema_with = "super::common::metadata_token_values_schema")]
+    pub tokens: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_session: Option<AgentSessionInfo>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/vendor/herdr-compat/src/api/schema/plugins.rs
+++ b/vendor/herdr-compat/src/api/schema/plugins.rs
@@ -6,6 +6,7 @@ use super::common::AgentStatus;
 use super::common::SplitDirection;
 use super::panes::PaneInfo;
 use super::workspaces::WorkspaceWorktreeInfo;
+use crate::popup_size::PopupSize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginLinkParams {
@@ -48,6 +49,8 @@ pub struct InstalledPluginInfo {
     pub platforms: Option<Vec<PluginPlatform>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub build: Vec<PluginManifestBuild>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub startup: Vec<PluginManifestStartup>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub actions: Vec<PluginManifestAction>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -231,6 +234,13 @@ pub struct PluginManifestBuild {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PluginManifestStartup {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platforms: Option<Vec<PluginPlatform>>,
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PluginManifestAction {
     pub id: String,
     pub title: String,
@@ -261,6 +271,10 @@ pub struct PluginManifestPane {
     pub platforms: Option<Vec<PluginPlatform>>,
     #[serde(default)]
     pub placement: PluginPanePlacement,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<PopupSize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<PopupSize>,
     pub command: Vec<String>,
 }
 
@@ -407,6 +421,10 @@ pub struct PluginPaneOpenParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub placement: Option<PluginPanePlacement>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<PopupSize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<PopupSize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_pane_id: Option<String>,
@@ -427,6 +445,7 @@ pub struct PluginPaneOpenParams {
 pub enum PluginPanePlacement {
     #[default]
     Overlay,
+    Popup,
     Split,
     Tab,
     Zoomed,

--- a/vendor/herdr-compat/src/api/schema/response.rs
+++ b/vendor/herdr-compat/src/api/schema/response.rs
@@ -101,8 +101,18 @@ pub enum ResponseResult {
         agent: AgentInfo,
         argv: Vec<String>,
     },
+    AgentPrompted {
+        agent: AgentInfo,
+    },
     AgentList {
         agents: Vec<AgentInfo>,
+    },
+    AgentView {
+        active: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
     },
     PaneInfo {
         pane: PaneInfo,
@@ -151,6 +161,10 @@ pub enum ResponseResult {
     },
     PaneRead {
         read: PaneReadResult,
+    },
+    PaneGraphicsInfo {
+        cell_width_px: u32,
+        cell_height_px: u32,
     },
     AgentExplain {
         explain: serde_json::Value,

--- a/vendor/herdr-compat/src/api/schema/tests.rs
+++ b/vendor/herdr-compat/src/api/schema/tests.rs
@@ -2,6 +2,49 @@ use std::collections::HashMap;
 
 use super::*;
 
+fn protocol_schema_entry<T: schemars::JsonSchema>(name: &str) -> serde_json::Value {
+    let mut schema = serde_json::to_value(schemars::schema_for!(T)).unwrap();
+    rewrite_schema_refs(&mut schema, name);
+    schema
+}
+
+fn rewrite_schema_refs(value: &mut serde_json::Value, schema_name: &str) {
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(serde_json::Value::String(reference)) = object.get_mut("$ref") {
+                if let Some(path) = reference.strip_prefix("#/") {
+                    *reference = format!("#/schemas/{schema_name}/{path}");
+                }
+            }
+            for child in object.values_mut() {
+                rewrite_schema_refs(child, schema_name);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                rewrite_schema_refs(item, schema_name);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn protocol_schema_document() -> serde_json::Value {
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "Herdr API",
+        "schema_version": 1,
+        "protocol": crate::protocol::PROTOCOL_VERSION,
+        "schemas": {
+            "request": protocol_schema_entry::<Request>("request"),
+            "success_response": protocol_schema_entry::<SuccessResponse>("success_response"),
+            "error_response": protocol_schema_entry::<ErrorResponse>("error_response"),
+            "event": protocol_schema_entry::<EventEnvelope>("event"),
+            "subscription_event": protocol_schema_entry::<SubscriptionEventEnvelope>("subscription_event"),
+        },
+    })
+}
+
 #[test]
 fn request_uses_dot_method_names() {
     let request = Request {
@@ -19,51 +62,91 @@ fn request_uses_dot_method_names() {
 }
 
 #[test]
-fn ping_request_json_fixture_matches_reviewed_snapshot() {
-    let request = Request {
-        id: "api-client:status".into(),
-        method: Method::Ping(PingParams::default()),
+fn agent_start_and_prompt_requests_round_trip() {
+    let start = Request {
+        id: "start".into(),
+        method: Method::AgentStart(AgentStartParams {
+            name: "reviewer".into(),
+            kind: "pi".into(),
+            pane_id: "w1:p2".into(),
+            args: vec!["--no-session".into()],
+            timeout_ms: Some(30_000),
+        }),
     };
-
+    let start_json = serde_json::to_value(&start).unwrap();
+    assert_eq!(start_json["method"], "agent.start");
+    assert_eq!(start_json["params"]["pane_id"], "w1:p2");
     assert_eq!(
-        serde_json::to_value(&request).unwrap(),
-        serde_json::json!({
-            "id": "api-client:status",
-            "method": "ping",
-            "params": {}
-        })
+        serde_json::from_value::<Request>(start_json).unwrap(),
+        start
+    );
+
+    let prompt = Request {
+        id: "prompt".into(),
+        method: Method::AgentPrompt(AgentPromptParams {
+            target: "reviewer".into(),
+            text: "review this".into(),
+            wait: None,
+        }),
+    };
+    let prompt_json = serde_json::to_value(&prompt).unwrap();
+    assert_eq!(prompt_json["method"], "agent.prompt");
+    assert_eq!(
+        serde_json::from_value::<Request>(prompt_json).unwrap(),
+        prompt
+    );
+
+    let prompt_and_wait = Request {
+        id: "prompt-and-wait".into(),
+        method: Method::AgentPrompt(AgentPromptParams {
+            target: "reviewer".into(),
+            text: "review this".into(),
+            wait: Some(AgentPromptWaitOptions {
+                until: vec![AgentStatus::Idle, AgentStatus::Done],
+                timeout_ms: Some(120_000),
+            }),
+        }),
+    };
+    let prompt_and_wait_json = serde_json::to_value(&prompt_and_wait).unwrap();
+    assert_eq!(
+        prompt_and_wait_json["params"]["wait"]["until"],
+        serde_json::json!(["idle", "done"])
+    );
+    assert_eq!(
+        prompt_and_wait_json["params"]["wait"]["timeout_ms"],
+        120_000
+    );
+    assert_eq!(
+        serde_json::from_value::<Request>(prompt_and_wait_json).unwrap(),
+        prompt_and_wait
     );
 }
 
 #[test]
-fn pong_response_json_fixture_matches_reviewed_snapshot() {
-    let response = SuccessResponse {
-        id: "api-client:status".into(),
-        result: ResponseResult::Pong {
-            version: "0.7.0".into(),
-            protocol: 16,
-            capabilities: Some(ServerCapabilities {
-                live_handoff: true,
-                detached_server_daemon: true,
-            }),
-        },
-    };
-
-    assert_eq!(
-        serde_json::to_value(&response).unwrap(),
-        serde_json::json!({
-            "id": "api-client:status",
-            "result": {
-                "type": "pong",
-                "version": "0.7.0",
-                "protocol": 16,
-                "capabilities": {
-                    "live_handoff": true,
-                    "detached_server_daemon": true
+fn bundled_protocol_schema_refs_resolve_inside_bundle() {
+    fn assert_no_standalone_refs(value: &serde_json::Value) {
+        match value {
+            serde_json::Value::Object(object) => {
+                if let Some(serde_json::Value::String(reference)) = object.get("$ref") {
+                    assert!(
+                        !reference.starts_with("#/$defs/"),
+                        "schema bundle contains standalone ref {reference}"
+                    );
+                }
+                for child in object.values() {
+                    assert_no_standalone_refs(child);
                 }
             }
-        })
-    );
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    assert_no_standalone_refs(item);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    assert_no_standalone_refs(&protocol_schema_document());
 }
 
 #[test]
@@ -185,6 +268,49 @@ fn client_window_title_requests_round_trip() {
 }
 
 #[test]
+fn agent_view_requests_round_trip() {
+    let set_json = serde_json::json!({
+        "id": "view-set",
+        "method": "agent.view.set",
+        "params": {
+            "source": "example.views",
+            "label": "current + attention",
+            "filter": {
+                "op": "any",
+                "filters": [
+                    {
+                        "op": "eq",
+                        "field": "workspace_id",
+                        "value": {"context": "current_workspace_id"}
+                    },
+                    {
+                        "op": "in",
+                        "field": "status",
+                        "values": ["blocked", "done"]
+                    }
+                ]
+            },
+            "sort": [
+                {"field": "attention", "order": "desc"},
+                {"field": "state_change_seq", "order": "desc"}
+            ]
+        }
+    });
+    let request: Request = serde_json::from_value(set_json.clone()).unwrap();
+    assert!(matches!(request.method, Method::AgentViewSet(_)));
+    assert_eq!(serde_json::to_value(request).unwrap(), set_json);
+
+    let clear_json = serde_json::json!({
+        "id": "view-clear",
+        "method": "agent.view.clear",
+        "params": {"source": "example.views"}
+    });
+    let request: Request = serde_json::from_value(clear_json.clone()).unwrap();
+    assert!(matches!(request.method, Method::AgentViewClear(_)));
+    assert_eq!(serde_json::to_value(request).unwrap(), clear_json);
+}
+
+#[test]
 fn unknown_method_is_rejected() {
     let json = r#"{"id":"req_1","method":"nope","params":{}}"#;
     let err = serde_json::from_str::<Request>(json)
@@ -298,18 +424,67 @@ fn pane_process_info_request_round_trips() {
 
 #[test]
 fn event_envelope_round_trips() {
-    let event = EventEnvelope {
-        event: EventKind::PaneOutputChanged,
-        data: EventData::PaneOutputChanged {
-            pane_id: "p_1".into(),
-            workspace_id: "w_1".into(),
-            revision: 42,
+    let events = [
+        EventEnvelope {
+            event: EventKind::PaneOutputChanged,
+            data: EventData::PaneOutputChanged {
+                pane_id: "p_1".into(),
+                workspace_id: "w_1".into(),
+                revision: 42,
+            },
         },
-    };
+        EventEnvelope {
+            event: EventKind::WorkspaceMoved,
+            data: EventData::WorkspaceMoved {
+                workspace_id: "w_1".into(),
+                insert_index: 2,
+                workspaces: vec![],
+            },
+        },
+        EventEnvelope {
+            event: EventKind::TabMoved,
+            data: EventData::TabMoved {
+                tab_id: "w_1:1".into(),
+                workspace_id: "w_1".into(),
+                insert_index: 1,
+                tabs: vec![],
+            },
+        },
+        EventEnvelope {
+            event: EventKind::LayoutUpdated,
+            data: EventData::LayoutUpdated {
+                layout: PaneLayoutSnapshot {
+                    workspace_id: "w_1".into(),
+                    tab_id: "w_1:1".into(),
+                    zoomed: false,
+                    area: PaneLayoutRect {
+                        x: 0,
+                        y: 0,
+                        width: 100,
+                        height: 24,
+                    },
+                    focused_pane_id: "w_1-1".into(),
+                    panes: vec![PaneLayoutPane {
+                        pane_id: "w_1-1".into(),
+                        focused: true,
+                        rect: PaneLayoutRect {
+                            x: 0,
+                            y: 0,
+                            width: 100,
+                            height: 24,
+                        },
+                    }],
+                    splits: vec![],
+                },
+            },
+        },
+    ];
 
-    let json = serde_json::to_string(&event).unwrap();
-    let restored: EventEnvelope = serde_json::from_str(&json).unwrap();
-    assert_eq!(restored, event);
+    for event in events {
+        let json = serde_json::to_string(&event).unwrap();
+        let restored: EventEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, event);
+    }
 }
 
 #[test]
@@ -450,106 +625,16 @@ fn session_snapshot_request_and_response_round_trip() {
         id: "req_snapshot".into(),
         result: ResponseResult::SessionSnapshot {
             snapshot: Box::new(SessionSnapshot {
-                version: "0.7.2".into(),
+                version: "0.1.2".into(),
                 protocol: 16,
-                focused_workspace_id: Some("w_1".into()),
-                focused_tab_id: Some("t_1".into()),
-                focused_pane_id: Some("p_1".into()),
-                workspaces: vec![WorkspaceInfo {
-                    workspace_id: "w_1".into(),
-                    number: 1,
-                    label: "herdr".into(),
-                    focused: true,
-                    pane_count: 1,
-                    tab_count: 1,
-                    active_tab_id: "t_1".into(),
-                    agent_status: AgentStatus::Working,
-                    worktree: None,
-                }],
-                tabs: vec![TabInfo {
-                    tab_id: "t_1".into(),
-                    workspace_id: "w_1".into(),
-                    number: 1,
-                    label: "1".into(),
-                    focused: true,
-                    pane_count: 1,
-                    agent_status: AgentStatus::Working,
-                }],
-                panes: vec![PaneInfo {
-                    pane_id: "p_1".into(),
-                    terminal_id: "term_1".into(),
-                    workspace_id: "w_1".into(),
-                    tab_id: "t_1".into(),
-                    focused: true,
-                    cwd: Some("/work/herdr".into()),
-                    foreground_cwd: Some("/work/herdr".into()),
-                    label: Some("Review".into()),
-                    agent: Some("codex".into()),
-                    title: Some("Codex".into()),
-                    display_agent: Some("Codex".into()),
-                    agent_status: AgentStatus::Working,
-                    custom_status: Some("reviewing".into()),
-                    state_labels: HashMap::from([("phase".into(), "review".into())]),
-                    agent_session: None,
-                    scroll: Some(PaneScrollInfo {
-                        offset_from_bottom: 4,
-                        max_offset_from_bottom: 80,
-                        viewport_rows: 24,
-                    }),
-                    revision: 7,
-                }],
-                layouts: vec![PaneLayoutSnapshot {
-                    workspace_id: "w_1".into(),
-                    tab_id: "t_1".into(),
-                    zoomed: false,
-                    area: PaneLayoutRect {
-                        x: 0,
-                        y: 0,
-                        width: 120,
-                        height: 40,
-                    },
-                    focused_pane_id: "p_1".into(),
-                    panes: vec![PaneLayoutPane {
-                        pane_id: "p_1".into(),
-                        focused: true,
-                        rect: PaneLayoutRect {
-                            x: 0,
-                            y: 0,
-                            width: 120,
-                            height: 40,
-                        },
-                    }],
-                    splits: vec![PaneLayoutSplit {
-                        id: "root".into(),
-                        direction: SplitDirection::Right,
-                        ratio: 1.0,
-                        rect: PaneLayoutRect {
-                            x: 0,
-                            y: 0,
-                            width: 120,
-                            height: 40,
-                        },
-                    }],
-                }],
-                agents: vec![AgentInfo {
-                    terminal_id: "term_1".into(),
-                    name: Some("codex".into()),
-                    agent: Some("codex".into()),
-                    title: Some("Codex".into()),
-                    display_agent: Some("Codex".into()),
-                    agent_status: AgentStatus::Working,
-                    screen_detection_skipped: false,
-                    custom_status: Some("reviewing".into()),
-                    state_labels: HashMap::from([("phase".into(), "review".into())]),
-                    agent_session: None,
-                    workspace_id: "w_1".into(),
-                    tab_id: "t_1".into(),
-                    pane_id: "p_1".into(),
-                    focused: true,
-                    cwd: Some("/work/herdr".into()),
-                    foreground_cwd: Some("/work/herdr".into()),
-                    revision: 7,
-                }],
+                focused_workspace_id: None,
+                focused_tab_id: None,
+                focused_pane_id: None,
+                workspaces: Vec::new(),
+                tabs: Vec::new(),
+                panes: Vec::new(),
+                layouts: Vec::new(),
+                agents: Vec::new(),
             }),
         },
     };
@@ -587,6 +672,7 @@ fn worktree_request_and_response_round_trip() {
                 tab_count: 1,
                 active_tab_id: "w_1:1".into(),
                 agent_status: AgentStatus::Unknown,
+                tokens: HashMap::new(),
                 worktree: Some(WorkspaceWorktreeInfo {
                     repo_key: "/repo/herdr/.git".into(),
                     repo_name: "herdr".into(),
@@ -615,10 +701,12 @@ fn worktree_request_and_response_round_trip() {
                 label: None,
                 agent: None,
                 title: None,
+                terminal_title: None,
+                terminal_title_stripped: None,
                 display_agent: None,
                 agent_status: AgentStatus::Unknown,
-                custom_status: None,
                 state_labels: HashMap::new(),
+                tokens: HashMap::new(),
                 agent_session: None,
                 scroll: None,
                 revision: 0,
@@ -670,6 +758,7 @@ fn worktree_lifecycle_events_round_trip() {
         tab_count: 1,
         active_tab_id: "w_2:1".into(),
         agent_status: AgentStatus::Unknown,
+        tokens: HashMap::new(),
         worktree: Some(WorkspaceWorktreeInfo {
             repo_key: "/repo/herdr/.git".into(),
             repo_name: "herdr".into(),
@@ -709,7 +798,7 @@ fn worktree_lifecycle_events_round_trip() {
             event: EventKind::WorktreeRemoved,
             data: EventData::WorktreeRemoved {
                 workspace_id: "w_2".into(),
-                workspace: None,
+                workspace: Some(workspace.clone()),
                 worktree: WorktreeInfo {
                     open_workspace_id: None,
                     ..worktree.clone()
@@ -782,6 +871,7 @@ fn plugin_link_list_unlink_round_trip() {
             platforms: None,
             command: vec!["bun".into(), "install".into()],
         }],
+        startup: vec![],
         actions: vec![PluginManifestAction {
             id: "bootstrap".into(),
             title: "Bootstrap worktree".into(),
@@ -801,6 +891,8 @@ fn plugin_link_list_unlink_round_trip() {
             description: None,
             platforms: None,
             placement: PluginPanePlacement::Overlay,
+            width: None,
+            height: None,
             command: vec!["bun".into(), "run".into(), "board.ts".into()],
         }],
         link_handlers: vec![PluginManifestLinkHandler {
@@ -905,6 +997,97 @@ fn layout_export_apply_round_trip() {
     let json = serde_json::to_string(&response).unwrap();
     let restored: SuccessResponse = serde_json::from_str(&json).unwrap();
     assert_eq!(restored, response);
+
+    let response = SuccessResponse {
+        id: "layout_ratio".into(),
+        result: ResponseResult::LayoutSplitRatioSet {
+            layout: LayoutDescription {
+                workspace_id: "w1".into(),
+                tab_id: "w1:1".into(),
+                zoomed: false,
+                focused_pane_id: "w1-1".into(),
+                root: LayoutNode::Pane {
+                    pane: LayoutPane {
+                        pane_id: Some("w1-1".into()),
+                        ..Default::default()
+                    },
+                },
+            },
+        },
+    };
+    let json = serde_json::to_string(&response).unwrap();
+    assert!(json.contains("\"type\":\"layout_split_ratio_set\""));
+    let restored: SuccessResponse = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored, response);
+}
+
+#[test]
+fn authority_mutation_requests_round_trip() {
+    let workspace_move = Request {
+        id: "move_ws".into(),
+        method: Method::WorkspaceMove(WorkspaceMoveParams {
+            workspace_id: "w1".into(),
+            insert_index: 2,
+        }),
+    };
+    let json = serde_json::to_value(&workspace_move).unwrap();
+    assert_eq!(json["method"], "workspace.move");
+    let restored: Request = serde_json::from_value(json).unwrap();
+    assert_eq!(restored, workspace_move);
+
+    let tab_move = Request {
+        id: "move_tab".into(),
+        method: Method::TabMove(TabMoveParams {
+            tab_id: "w1:1".into(),
+            insert_index: 1,
+        }),
+    };
+    let json = serde_json::to_value(&tab_move).unwrap();
+    assert_eq!(json["method"], "tab.move");
+    let restored: Request = serde_json::from_value(json).unwrap();
+    assert_eq!(restored, tab_move);
+
+    let pane_focus = Request {
+        id: "focus_pane".into(),
+        method: Method::PaneFocus(PaneTarget {
+            pane_id: "w1:1".into(),
+        }),
+    };
+    let json = serde_json::to_value(&pane_focus).unwrap();
+    assert_eq!(json["method"], "pane.focus");
+    let restored: Request = serde_json::from_value(json).unwrap();
+    assert_eq!(restored, pane_focus);
+
+    let split_ratio = Request {
+        id: "set_ratio".into(),
+        method: Method::LayoutSetSplitRatio(LayoutSetSplitRatioParams {
+            tab_id: Some("w1:1".into()),
+            pane_id: None,
+            path: vec![false, true],
+            ratio: 0.6,
+        }),
+    };
+    let json = serde_json::to_value(&split_ratio).unwrap();
+    assert_eq!(json["method"], "layout.set_split_ratio");
+    let restored: Request = serde_json::from_value(json).unwrap();
+    assert_eq!(restored, split_ratio);
+
+    let subscription = Request {
+        id: "sub_moves".into(),
+        method: Method::EventsSubscribe(EventsSubscribeParams {
+            subscriptions: vec![
+                Subscription::WorkspaceMoved {},
+                Subscription::TabMoved {},
+                Subscription::LayoutUpdated {},
+            ],
+        }),
+    };
+    let json = serde_json::to_string(&subscription).unwrap();
+    assert!(json.contains("\"type\":\"workspace.moved\""));
+    assert!(json.contains("\"type\":\"tab.moved\""));
+    assert!(json.contains("\"type\":\"layout.updated\""));
+    let restored: Request = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored, subscription);
 }
 
 #[test]
@@ -932,10 +1115,12 @@ fn create_response_round_trips_with_root_pane() {
                 label: None,
                 agent: None,
                 title: None,
+                terminal_title: None,
+                terminal_title_stripped: None,
                 display_agent: None,
                 agent_status: AgentStatus::Unknown,
-                custom_status: None,
                 state_labels: HashMap::new(),
+                tokens: HashMap::new(),
                 agent_session: None,
                 scroll: None,
                 revision: 0,
@@ -1046,10 +1231,12 @@ fn plugin_pane_open_request_round_trips() {
         method: Method::PluginPaneOpen(PluginPaneOpenParams {
             plugin_id: "example.board".into(),
             entrypoint: "board".into(),
-            placement: Some(PluginPanePlacement::Zoomed),
+            placement: Some(PluginPanePlacement::Popup),
+            width: Some(crate::popup_size::PopupSize::Cells(90)),
+            height: Some(crate::popup_size::PopupSize::Percent(80)),
             workspace_id: None,
-            target_pane_id: Some("1-1".into()),
-            direction: Some(SplitDirection::Right),
+            target_pane_id: None,
+            direction: None,
             cwd: Some("/tmp".into()),
             focus: true,
             env: [("HERDR_ROLE".to_string(), "board".to_string())].into(),
@@ -1058,7 +1245,23 @@ fn plugin_pane_open_request_round_trips() {
 
     let json = serde_json::to_value(&request).unwrap();
     assert_eq!(json["method"], "plugin.pane.open");
+    assert_eq!(json["params"]["placement"], "popup");
+    assert_eq!(json["params"]["width"], 90);
+    assert_eq!(json["params"]["height"], "80%");
     assert_eq!(json["params"]["env"]["HERDR_ROLE"], "board");
     let restored: Request = serde_json::from_value(json).unwrap();
     assert_eq!(restored, request);
+}
+
+#[test]
+fn popup_close_request_round_trips() {
+    let request = Request {
+        id: "popup-close".into(),
+        method: Method::PopupClose(EmptyParams::default()),
+    };
+
+    let json = serde_json::to_value(request).unwrap();
+
+    assert_eq!(json["method"], "popup.close");
+    assert_eq!(json["params"], serde_json::json!({}));
 }

--- a/vendor/herdr-compat/src/api/schema/workspaces.rs
+++ b/vendor/herdr-compat/src/api/schema/workspaces.rs
@@ -30,6 +30,19 @@ pub struct WorkspaceMoveParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct WorkspaceReportMetadataParams {
+    pub workspace_id: String,
+    pub source: String,
+    #[schemars(schema_with = "super::common::metadata_token_patch_schema")]
+    pub tokens: HashMap<String, Option<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1, max = 86_400_000))]
+    pub ttl_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkspaceInfo {
     pub workspace_id: String,
     pub number: usize,
@@ -39,6 +52,9 @@ pub struct WorkspaceInfo {
     pub tab_count: usize,
     pub active_tab_id: String,
     pub agent_status: AgentStatus,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[schemars(schema_with = "super::common::metadata_token_values_schema")]
+    pub tokens: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree: Option<WorkspaceWorktreeInfo>,
 }

--- a/vendor/herdr-compat/src/lib.rs
+++ b/vendor/herdr-compat/src/lib.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod input;
 pub mod ipc;
 pub mod logging;
+pub mod popup_size;
 pub mod protocol;
 pub mod raw_input;
 pub mod server;

--- a/vendor/herdr-compat/src/popup_size.rs
+++ b/vendor/herdr-compat/src/popup_size.rs
@@ -1,0 +1,252 @@
+use std::borrow::Cow;
+
+use ratatui::layout::Rect;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PopupSize {
+    Cells(u16),
+    Percent(u8),
+}
+
+impl PopupSize {
+    pub(crate) fn resolve(self, available: u16) -> u16 {
+        match self {
+            Self::Cells(cells) => cells,
+            Self::Percent(percent) => ((available as u32 * percent as u32) / 100) as u16,
+        }
+    }
+
+    pub(crate) fn parse_cli(value: &str) -> Result<Self, String> {
+        if let Some(percent) = value.strip_suffix('%') {
+            let percent = percent
+                .parse::<u8>()
+                .map_err(|_| "must be a number of cells or a percentage like 80%".to_string())?;
+            if !(1..=100).contains(&percent) {
+                return Err("percentage must be between 1% and 100%".to_string());
+            }
+            return Ok(Self::Percent(percent));
+        }
+        value
+            .parse::<u16>()
+            .map(Self::Cells)
+            .map_err(|_| "must be a number of cells or a percentage like 80%".to_string())
+    }
+
+    fn parse_percent_string(value: &str) -> Result<Self, String> {
+        if value.ends_with('%') {
+            return Self::parse_cli(value);
+        }
+        Err("string sizes must be percentages like 80%; use a number for cells".to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PopupResolvedGeometry {
+    pub outer: Rect,
+    pub inner: Rect,
+}
+
+pub(crate) fn resolve_popup_geometry(
+    width: Option<PopupSize>,
+    height: Option<PopupSize>,
+    area: Rect,
+) -> Option<PopupResolvedGeometry> {
+    let default_width = area.width.saturating_div(2).max(6);
+    let default_height = area.height.saturating_div(2).max(4);
+    let outer_width = width
+        .map(|width| width.resolve(area.width))
+        .unwrap_or(default_width)
+        .max(6)
+        .min(area.width);
+    let outer_height = height
+        .map(|height| height.resolve(area.height))
+        .unwrap_or(default_height)
+        .max(4)
+        .min(area.height);
+    if outer_width < 6 || outer_height < 4 {
+        return None;
+    }
+
+    let outer_x = area.x + (area.width.saturating_sub(outer_width)) / 2;
+    let outer_y = area.y + (area.height.saturating_sub(outer_height)) / 2;
+    let pane_inner_width = outer_width.saturating_sub(2);
+    let pane_inner_height = outer_height.saturating_sub(2);
+    let terminal_cols = if pane_inner_width <= 4 {
+        pane_inner_width
+    } else {
+        pane_inner_width.saturating_sub(1)
+    };
+    let inner = Rect::new(
+        outer_x.saturating_add(1),
+        outer_y.saturating_add(1),
+        terminal_cols,
+        pane_inner_height,
+    );
+    Some(PopupResolvedGeometry {
+        outer: Rect::new(outer_x, outer_y, outer_width, outer_height),
+        inner,
+    })
+}
+
+impl Serialize for PopupSize {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Cells(cells) => serializer.serialize_u16(*cells),
+            Self::Percent(percent) => serializer.serialize_str(&format!("{percent}%")),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PopupSize {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PopupSizeVisitor;
+
+        impl serde::de::Visitor<'_> for PopupSizeVisitor {
+            type Value = PopupSize;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a cell count or percentage string like 80%")
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let value =
+                    u16::try_from(value).map_err(|_| E::custom("cell count must fit in u16"))?;
+                Ok(PopupSize::Cells(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let value = u16::try_from(value)
+                    .map_err(|_| E::custom("cell count must be between 0 and 65535"))?;
+                Ok(PopupSize::Cells(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                PopupSize::parse_percent_string(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(PopupSizeVisitor)
+    }
+}
+
+impl schemars::JsonSchema for PopupSize {
+    fn schema_name() -> Cow<'static, str> {
+        "PopupSize".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "oneOf": [
+                {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "description": "Outer popup size in terminal cells, including the border."
+                },
+                {
+                    "type": "string",
+                    "pattern": "^(100|[1-9][0-9]?)%$",
+                    "description": "Outer popup size as a percentage of the terminal area, for example 80%."
+                }
+            ]
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PopupSize;
+
+    #[test]
+    fn parses_cells_and_percent() {
+        assert_eq!(PopupSize::parse_cli("120"), Ok(PopupSize::Cells(120)));
+        assert_eq!(PopupSize::parse_cli("80%"), Ok(PopupSize::Percent(80)));
+        assert_eq!(PopupSize::Percent(80).resolve(100), 80);
+    }
+
+    #[test]
+    fn rejects_invalid_percent() {
+        assert!(PopupSize::parse_cli("0%").is_err());
+        assert!(PopupSize::parse_cli("101%").is_err());
+        assert!(PopupSize::parse_cli("%").is_err());
+    }
+
+    #[test]
+    fn string_deserialization_requires_percent() {
+        assert!(serde_json::from_value::<PopupSize>(serde_json::json!("120")).is_err());
+        assert_eq!(
+            serde_json::from_value::<PopupSize>(serde_json::json!("80%")).unwrap(),
+            PopupSize::Percent(80)
+        );
+    }
+
+    #[test]
+    fn serializes_percent_as_string() {
+        assert_eq!(
+            serde_json::to_value(PopupSize::Percent(80)).unwrap(),
+            serde_json::json!("80%")
+        );
+        assert_eq!(
+            serde_json::to_value(PopupSize::Cells(120)).unwrap(),
+            serde_json::json!(120)
+        );
+    }
+
+    #[test]
+    fn resolves_requested_outer_size_and_inner_terminal_area() {
+        let resolved = super::resolve_popup_geometry(
+            Some(PopupSize::Percent(80)),
+            Some(PopupSize::Percent(40)),
+            ratatui::layout::Rect::new(0, 0, 100, 30),
+        )
+        .unwrap();
+        assert_eq!(resolved.outer, ratatui::layout::Rect::new(10, 9, 80, 12));
+        assert_eq!(resolved.inner, ratatui::layout::Rect::new(11, 10, 77, 10));
+    }
+
+    #[test]
+    fn allows_full_terminal_outer_size() {
+        let resolved = super::resolve_popup_geometry(
+            Some(PopupSize::Percent(100)),
+            Some(PopupSize::Percent(100)),
+            ratatui::layout::Rect::new(4, 2, 100, 30),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.outer, ratatui::layout::Rect::new(4, 2, 100, 30));
+        assert_eq!(resolved.inner, ratatui::layout::Rect::new(5, 3, 97, 28));
+    }
+
+    #[test]
+    fn enforces_runtime_minimum_terminal_width() {
+        let resolved = super::resolve_popup_geometry(
+            Some(PopupSize::Cells(4)),
+            None,
+            ratatui::layout::Rect::new(0, 0, 80, 24),
+        )
+        .unwrap();
+        assert_eq!(resolved.outer.width, 6);
+        assert_eq!(resolved.inner.width, 4);
+
+        assert!(
+            super::resolve_popup_geometry(None, None, ratatui::layout::Rect::new(0, 0, 5, 24),)
+                .is_none()
+        );
+    }
+}

--- a/vendor/herdr-compat/src/protocol.rs
+++ b/vendor/herdr-compat/src/protocol.rs
@@ -8,7 +8,7 @@ mod bridge_fixture_tests {
 
     #[test]
     fn protocol_version_matches_reviewed_herdr_snapshot() {
-        assert_eq!(PROTOCOL_VERSION, 16);
+        assert_eq!(PROTOCOL_VERSION, 17);
     }
 
     #[test]
@@ -26,7 +26,7 @@ mod bridge_fixture_tests {
         let mut frame = Vec::new();
         write_message(&mut frame, &msg).unwrap();
 
-        assert_eq!(frame, vec![9, 0, 0, 0, 0, 16, 80, 24, 8, 16, 0, 0, 1]);
+        assert_eq!(frame, vec![9, 0, 0, 0, 0, 17, 80, 24, 8, 16, 0, 0, 1]);
         let decoded: ClientMessage = read_message(&mut frame.as_slice(), MAX_FRAME_SIZE).unwrap();
         assert_eq!(decoded, msg);
     }
@@ -41,7 +41,7 @@ mod bridge_fixture_tests {
         let mut frame = Vec::new();
         write_message(&mut frame, &msg).unwrap();
 
-        assert_eq!(frame, vec![4, 0, 0, 0, 0, 16, 1, 0]);
+        assert_eq!(frame, vec![4, 0, 0, 0, 0, 17, 1, 0]);
         let decoded: ServerMessage = read_message(&mut frame.as_slice(), MAX_FRAME_SIZE).unwrap();
         assert_eq!(decoded, msg);
     }

--- a/vendor/herdr-compat/src/protocol/wire.rs
+++ b/vendor/herdr-compat/src/protocol/wire.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Current protocol version. Bumped when wire format changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 16;
+pub const PROTOCOL_VERSION: u32 = 17;
 
 /// Maximum allowed frame payload size (2 MB). Frames larger than this are
 /// rejected to prevent denial-of-service via oversized length prefixes.

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -11,6 +11,11 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent, KeyboardEvent, RefObject } from "react";
+import {
+  mobileCommandSubmitInput,
+  nextMobileCommandFieldKey,
+  syncMobileCommandInputValue,
+} from "./mobileCommandInput";
 import { autosizeMobileCommandTextarea } from "./mobileCommandTextarea";
 import { ConfirmDialog } from "./overlays";
 import { addNativeResumeHandler } from "./native";
@@ -1323,7 +1328,9 @@ export function TerminalView({
           onTerminalFocus={() => rendererRef.current?.focusTextInput()}
           onUpload={openFilePicker}
           onStageCommand={(command) => enqueueTerminalInput([command])}
-          onSubmitCommand={(command) => enqueueTerminalInput([command, "\r"])}
+          onSubmitCommand={(command) =>
+            enqueueTerminalInput([mobileCommandSubmitInput(command)])
+          }
         />
       ) : null}
       {mobileSelectionAction ? (
@@ -1431,22 +1438,47 @@ function MobileTerminalControls({
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [value, setValue] = useState("");
+  const [fieldKey, setFieldKey] = useState(0);
   const [expanded, setExpanded] = useState(false);
   const [ctrlLatch, setCtrlLatch] = useState(false);
   const setCommandInputNode = (node: HTMLInputElement | HTMLTextAreaElement | null) => {
     commandInputRef.current = node;
   };
-  const submit = () => {
-    onSubmitCommand(value);
+  const clearCommandInput = () => {
     setValue("");
+    // Remount plus an imperative sync so a stale native value cannot prepend
+    // itself onto the next keystrokes after React clears state.
+    syncMobileCommandInputValue(commandInputRef.current, "");
+    setFieldKey((key) => nextMobileCommandFieldKey(key));
+  };
+  const submit = () => {
+    const command = value;
+    clearCommandInput();
+    onSubmitCommand(command);
   };
   const stage = () => {
     if (value.length === 0) {
       return;
     }
-    onStageCommand(value);
-    setValue("");
+    const command = value;
+    clearCommandInput();
+    onStageCommand(command);
   };
+
+  useLayoutEffect(() => {
+    if (fieldKey === 0) {
+      return;
+    }
+    const node = commandInputRef.current;
+    if (!node || node.disabled) {
+      return;
+    }
+    syncMobileCommandInputValue(node, "");
+    if (expandingInput) {
+      autosizeMobileCommandTextarea(node);
+    }
+    node.focus();
+  }, [commandInputRef, expandingInput, fieldKey]);
   const sendKey = (key: TerminalKey) => {
     onInput(ctrlLatch && key.ctrlData ? key.ctrlData : key.data);
     if (ctrlLatch) {
@@ -1615,6 +1647,7 @@ function MobileTerminalControls({
       >
         {expandingInput ? (
           <textarea
+            key={fieldKey}
             ref={setCommandInputNode}
             className="term-native-input mono"
             rows={1}
@@ -1631,6 +1664,7 @@ function MobileTerminalControls({
           />
         ) : (
           <input
+            key={fieldKey}
             ref={setCommandInputNode}
             className="term-native-input mono"
             type="text"

--- a/web/src/mobileCommandInput.test.ts
+++ b/web/src/mobileCommandInput.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mobileCommandSubmitInput,
+  nextMobileCommandFieldKey,
+  syncMobileCommandInputValue,
+} from "./mobileCommandInput";
+
+describe("syncMobileCommandInputValue", () => {
+  it("writes value and defaultValue so a cleared prefix cannot stick in the native field", () => {
+    const node = { value: "first prompt", defaultValue: "first prompt" };
+
+    syncMobileCommandInputValue(node, "");
+
+    expect(node.value).toBe("");
+    expect(node.defaultValue).toBe("");
+  });
+
+  it("ignores a missing ref while the field remounts", () => {
+    expect(() => syncMobileCommandInputValue(null, "")).not.toThrow();
+    expect(() => syncMobileCommandInputValue(undefined, "")).not.toThrow();
+  });
+});
+
+describe("nextMobileCommandFieldKey", () => {
+  it("bumps the remount key after each clear", () => {
+    expect(nextMobileCommandFieldKey(0)).toBe(1);
+    expect(nextMobileCommandFieldKey(7)).toBe(8);
+  });
+});
+
+describe("mobileCommandSubmitInput", () => {
+  it("appends Enter in the same frame as the command text", () => {
+    expect(mobileCommandSubmitInput("hello")).toBe("hello\r");
+  });
+
+  it("still sends Enter when the field is empty", () => {
+    expect(mobileCommandSubmitInput("")).toBe("\r");
+  });
+});

--- a/web/src/mobileCommandInput.ts
+++ b/web/src/mobileCommandInput.ts
@@ -1,0 +1,38 @@
+/**
+ * Helpers for the mobile terminal command field.
+ *
+ * A controlled command field can keep a stale native value after React clears
+ * state. Later keystrokes then report `event.target.value` as `previous + typed`,
+ * so Send prefixes the old prompt.
+ */
+
+export type MobileCommandInputNode = {
+  value: string;
+  defaultValue: string;
+};
+
+/** Force the native field to match React state after clear/submit. */
+export function syncMobileCommandInputValue(
+  node: MobileCommandInputNode | null | undefined,
+  next: string,
+) {
+  if (!node) {
+    return;
+  }
+  node.value = next;
+  node.defaultValue = next;
+}
+
+/** Bump after clear so the command field remounts with an empty native value. */
+export function nextMobileCommandFieldKey(key: number): number {
+  return key + 1;
+}
+
+/**
+ * Build a single PTY input frame for Send: text plus Enter together.
+ * Splitting text and `\r` across delayed frames leaves agent prompts (e.g. Cursor)
+ * with staged text that the next Send appends to.
+ */
+export function mobileCommandSubmitInput(command: string): string {
+  return `${command}\r`;
+}


### PR DESCRIPTION
## Summary
- Refresh `vendor/herdr-compat` to Herdr **v0.7.5** (protocol **17**), including schema/API updates and `popup_size` for plugin pane fields.
- Keep `MIN_TERMINAL_ATTACH_PROTOCOL = 16` so `v0.7.2`–`v0.7.4` daemons still work.
- Adapt launcher agent splits to pane-first `agent.start` (split, then start in the new pane).
- Stop reading removed pane `custom_status`; activity events keep a null field for older web clients.
- Fix mobile terminal Send so the previous prompt cannot stick as a prefix on the next Send: remount/clear the command field after Send/Stage, and submit `text` + Enter as one PTY frame instead of two delayed frames.

## Test plan
- [x] `HERDR_SRC=<herdr-v0.7.5> scripts/check-vendor.sh`
- [x] `cargo test` for `vendor/herdr-compat` and `bridge`
- [x] `npm run lint` / `npm run test` / `npm run build`
- [x] Smoke against live Herdr 0.7.5: bridge starts on `:8787`, `/` and `/api/snapshot` return 200
- [x] Mobile repro: Send `one`, then Send `two` — second prompt is only `two` (no `one` prefix)