### PR TITLE
feat(bridge): add multi-bridge proxy support for remote herdr instances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,11 @@ This is a lightweight internal onboarding note for agents working in this repo.
 - Keep generated outputs out of commits: `web/dist/`, `bridge/target/`, and
   `vendor/herdr-compat/target/`, `dist-packages/`, and Android build outputs.
 - The bridge is local-first and currently has no full browser authentication. Treat LAN binding and upload behavior as security-sensitive.
+- Remote bridges (`--remote-bridge <url>`, proxied under `/api/remote/{bridge_id}/...` and
+  `/ws/remote/{bridge_id}/terminal`) are only reachable if the local bridge process was started with
+  that URL — bridge ids are derived server-side from the URL hostname. Any client-side UI for adding
+  remote bridges must either mirror what the server actually has configured or call a registration
+  API; a purely client-local list of URLs cannot work standalone.
 
 ## Testing
 
@@ -75,3 +80,10 @@ This is a lightweight internal onboarding note for agents working in this repo.
   `docs/packaging.md` and `docs/release.md`; do not commit `dist-packages/`, APKs, or generated
   Android outputs.
 - Do not bump npm package versions until package publishing is defined.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Added
 
+- Added a `--remote-bridge <url>` bridge CLI flag (repeatable) to register other herdr-web bridge
+  instances (e.g. reached over Tailscale) as remote bridges. `/api/snapshot` now includes a
+  `bridges` array describing each configured remote bridge (id, label, url). The bridge proxies
+  REST reads (`/api/remote/{bridge_id}/...`) and terminal WebSocket connections
+  (`/ws/remote/{bridge_id}/terminal`) to the corresponding remote bridge.
+
 ### Changed
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -284,6 +284,22 @@ HOST=0.0.0.0 scripts/run-bridge.sh --allow-host host-a --allow-connect-origin ht
 HOST=0.0.0.0 scripts/run-bridge.sh --allow-host host-b --allow-origin http://host-a:8787
 ```
 
+As an alternative to that browser-side CORS setup, a bridge can proxy another herdr-web bridge
+server-side with a repeatable `--remote-bridge URL` flag (for example, reaching other machines over
+Tailscale):
+
+```bash
+scripts/run-bridge.sh --remote-bridge http://mini2:8787 --remote-bridge http://mini3:8787
+```
+
+Each `--remote-bridge` URL must use `http://` (Tailscale traffic is plain HTTP; the bridge's outbound
+client has no TLS backend). The bridge derives a stable id from each URL's hostname, disambiguating
+collisions and dropping exact duplicates, and lists the configured remote bridges (id, label, url) in
+`/api/snapshot`'s `bridges` array. `/api/remote/{bridge_id}/...` and
+`/ws/remote/{bridge_id}/terminal` then proxy REST reads and terminal WebSocket sessions through to
+that remote bridge. Only bridges the process was actually started with are reachable this way; the
+web app does not yet have UI to add or manage remote bridges.
+
 ## Keyboard Shortcuts
 
 These app shortcuts are ignored while dialogs, menus, and normal text inputs are active. They still
@@ -307,17 +323,22 @@ work when the terminal's hidden keyboard input has focus. OS-reserved shortcuts 
 The bridge exposes:
 
 - `GET /api/capabilities`: bridge feature flags and allow-listed browser commands
-- `GET /api/snapshot`: workspaces, tabs, panes, layouts, and shared web selection
+- `GET /api/snapshot`: workspaces, tabs, panes, layouts, shared web selection, and configured
+  remote bridges
 - `POST /api/command`: allow-listed workspace/tab/pane commands
 - `POST /api/selection`: bridge-owned selected pane for syncing browser clients
 - `GET /api/notes` and `POST /api/notes...`: bridge-owned pane notes
 - `GET /api/agent-activity`: bridge-tracked agent status transition activity
 - `GET /api/agent-pins` and `POST /api/agent-pins/{pane_id}/pin|unpin`: bridge-owned agent pins
 - `POST /api/uploads`: save uploaded files into the configured upload directory
+- `GET|POST /api/remote/{bridge_id}/{*rest}`: proxies REST reads to a `--remote-bridge`-configured
+  remote bridge's `/api/{rest}`
 - `GET /ws/activity`: bridge-owned pane activity deltas
 - `GET /ws/events`: Herdr structural events
 - `GET /ws/ui-events`: bridge-local UI events such as selection changes
 - `GET /ws/terminal`: terminal attach stream
+- `GET /ws/remote/{bridge_id}/terminal`: proxies a terminal attach stream to a `--remote-bridge`-
+  configured remote bridge
 
 Herdr core currently allows only one terminal attach owner per terminal. The bridge works around
 that by opening one Herdr terminal attach per `terminal_id` and broadcasting output to all browser

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -429,6 +429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,9 +726,11 @@ dependencies = [
  "libc",
  "png",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-http",
  "tracing",
@@ -801,6 +814,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -809,13 +823,103 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -829,6 +933,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -876,6 +1001,12 @@ dependencies = [
  "widestring",
  "windows-sys",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -958,6 +1089,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1335,6 +1472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1734,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +2010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,6 +2075,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "terminfo"
@@ -2026,6 +2224,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,8 +2322,10 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2193,6 +2403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,6 +2484,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,6 +2590,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2413,6 +2666,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2625,6 +2888,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +2930,60 @@ name = "zerocopy-derive"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -16,9 +16,11 @@ herdr-compat = { path = "../vendor/herdr-compat" }
 libc = "0.2"
 png = "0.17"
 regex = "1"
+reqwest = { version = "0.12", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
+tokio-tungstenite = "0.29"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "compression-gzip"] }
 tracing = "0.1.44"

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -927,12 +927,19 @@ fn parse_options(args: &[String]) -> Result<Option<BridgeOptions>, String> {
     }))
 }
 
-/// Normalizes a `--remote-bridge` value into a canonical `scheme://host[:port]` origin
+/// Normalizes a `--remote-bridge` value into a canonical `http://host[:port]` origin
 /// (adding `http://` when no scheme is given, matching the frontend's bridge URL convention).
+///
+/// Only `http://` is accepted: remote bridges are reached over Tailscale (plain HTTP), and the
+/// bridge's outbound HTTP/WS clients have no TLS backend, so an accepted `https://` URL would
+/// fail every proxy request at runtime instead of failing fast at startup.
 fn normalize_remote_bridge_url(value: &str) -> Result<String, String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Err("remote bridge URL must not be empty".into());
+    }
+    if trimmed.to_ascii_lowercase().starts_with("https://") {
+        return Err("remote bridge URL must use http:// (https is not supported)".into());
     }
     let with_scheme = if trimmed.contains("://") {
         trimmed.to_string()
@@ -940,10 +947,10 @@ fn normalize_remote_bridge_url(value: &str) -> Result<String, String> {
         format!("http://{trimmed}")
     };
     let normalized = with_scheme.trim_end_matches('/').to_ascii_lowercase();
-    let Some(authority) = origin_authority(&normalized) else {
-        return Err("remote bridge URL must be an http or https origin without a path".into());
+    let Some(authority) = normalized.strip_prefix("http://") else {
+        return Err("remote bridge URL must use http:// (https is not supported)".into());
     };
-    if authority.is_empty() || authority.contains('@') {
+    if authority.is_empty() || authority.contains('/') || authority.contains('@') {
         return Err("remote bridge URL must include a host and no credentials".into());
     }
     Ok(normalized)
@@ -5492,6 +5499,108 @@ mod tests {
         assert!(value.contains("connect-src 'self' data: http://srv:8787 ws://srv:8787;"));
         assert!(value.contains("img-src 'self' data: blob:;"));
         assert!(value.contains("frame-ancestors 'none'"));
+    }
+
+    #[test]
+    fn normalize_remote_bridge_url_accepts_http_and_adds_scheme_when_missing() {
+        assert_eq!(
+            normalize_remote_bridge_url("mini2:8787").unwrap(),
+            "http://mini2:8787"
+        );
+        assert_eq!(
+            normalize_remote_bridge_url("HTTP://Mini2:8787/").unwrap(),
+            "http://mini2:8787"
+        );
+    }
+
+    #[test]
+    fn normalize_remote_bridge_url_rejects_https() {
+        let err = normalize_remote_bridge_url("https://mini2:8787").unwrap_err();
+        assert!(err.contains("http://"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn normalize_remote_bridge_url_rejects_unsupported_scheme() {
+        assert!(normalize_remote_bridge_url("ws://mini2:8787").is_err());
+    }
+
+    #[test]
+    fn normalize_remote_bridge_url_rejects_empty_and_missing_host() {
+        assert!(normalize_remote_bridge_url("").is_err());
+        assert!(normalize_remote_bridge_url("   ").is_err());
+        assert!(normalize_remote_bridge_url("http://").is_err());
+    }
+
+    #[test]
+    fn normalize_remote_bridge_url_rejects_credentials() {
+        assert!(normalize_remote_bridge_url("http://user:pass@mini2:8787").is_err());
+    }
+
+    #[test]
+    fn build_remote_bridges_dedups_exact_duplicate_urls() {
+        let urls = vec![
+            "http://mini2:8787".to_string(),
+            "http://mini2:8787".to_string(),
+        ];
+        let bridges = build_remote_bridges(&urls);
+        assert_eq!(bridges.len(), 1);
+        assert_eq!(bridges[0].id, "mini2");
+    }
+
+    #[test]
+    fn build_remote_bridges_disambiguates_id_collisions() {
+        let urls = vec![
+            "http://mini.2:8787".to_string(),
+            "http://mini-2:8787".to_string(),
+            "http://mini_2:8787".to_string(),
+        ];
+        let bridges = build_remote_bridges(&urls);
+        let ids: Vec<&str> = bridges.iter().map(|bridge| bridge.id.as_str()).collect();
+        assert_eq!(ids, vec!["mini-2", "mini-2-2", "mini-2-3"]);
+    }
+
+    #[test]
+    fn axum_and_tungstenite_messages_round_trip() {
+        let text = Message::Text(AxumUtf8Bytes::from("hello"));
+        match tungstenite_message_to_axum(axum_message_to_tungstenite(text)) {
+            Some(Message::Text(value)) => assert_eq!(value.as_str(), "hello"),
+            other => panic!("unexpected message: {other:?}"),
+        }
+
+        let binary = Message::Binary(vec![1, 2, 3].into());
+        match tungstenite_message_to_axum(axum_message_to_tungstenite(binary)) {
+            Some(Message::Binary(value)) => assert_eq!(value.as_ref(), &[1, 2, 3]),
+            other => panic!("unexpected message: {other:?}"),
+        }
+
+        let ping = Message::Ping(vec![9].into());
+        match tungstenite_message_to_axum(axum_message_to_tungstenite(ping)) {
+            Some(Message::Ping(value)) => assert_eq!(value.as_ref(), &[9]),
+            other => panic!("unexpected message: {other:?}"),
+        }
+
+        let pong = Message::Pong(vec![7].into());
+        match tungstenite_message_to_axum(axum_message_to_tungstenite(pong)) {
+            Some(Message::Pong(value)) => assert_eq!(value.as_ref(), &[7]),
+            other => panic!("unexpected message: {other:?}"),
+        }
+
+        let close = Message::Close(Some(CloseFrame {
+            code: 1000,
+            reason: AxumUtf8Bytes::from("bye"),
+        }));
+        match tungstenite_message_to_axum(axum_message_to_tungstenite(close)) {
+            Some(Message::Close(Some(frame))) => {
+                assert_eq!(u16::from(frame.code), 1000);
+                assert_eq!(frame.reason.as_str(), "bye");
+            }
+            other => panic!("unexpected message: {other:?}"),
+        }
+
+        match tungstenite_message_to_axum(axum_message_to_tungstenite(Message::Close(None))) {
+            Some(Message::Close(None)) => {}
+            other => panic!("unexpected message: {other:?}"),
+        }
     }
 
     #[test]

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -10,7 +10,9 @@ use std::thread;
 use std::time::Duration;
 
 use axum::body::Bytes;
-use axum::extract::ws::{CloseFrame, Message, Utf8Bytes as AxumUtf8Bytes, WebSocket, WebSocketUpgrade};
+use axum::extract::ws::{
+    CloseFrame, Message, Utf8Bytes as AxumUtf8Bytes, WebSocket, WebSocketUpgrade,
+};
 use axum::extract::{DefaultBodyLimit, Path as AxumPath, Query, RawQuery, State};
 use axum::http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -1064,7 +1066,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
     let remote_http_client = reqwest::Client::builder()
         .timeout(Duration::from_secs(20))
         .build()
-        .map_err(|err| io::Error::new(ErrorKind::Other, err.to_string()))?;
+        .map_err(|err| io::Error::other(err.to_string()))?;
     let state = BridgeState {
         api,
         client_socket_path: crate::session::active_client_socket_path(),
@@ -3053,7 +3055,7 @@ async fn proxy_terminal_socket(local: WebSocket, remote: RemoteBridge, query: Op
     } else {
         "ws"
     };
-    let authority = remote.base_url.splitn(2, "://").nth(1).unwrap_or("");
+    let authority = remote.base_url.split_once("://").map_or("", |x| x.1);
     let suffix = query
         .filter(|value| !value.is_empty())
         .map(|value| format!("?{value}"))

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -10,13 +10,13 @@ use std::thread;
 use std::time::Duration;
 
 use axum::body::Bytes;
-use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::{DefaultBodyLimit, Path as AxumPath, Query, State};
+use axum::extract::ws::{CloseFrame, Message, Utf8Bytes as AxumUtf8Bytes, WebSocket, WebSocketUpgrade};
+use axum::extract::{DefaultBodyLimit, Path as AxumPath, Query, RawQuery, State};
 use axum::http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
-    ACCESS_CONTROL_MAX_AGE, ACCESS_CONTROL_REQUEST_HEADERS, HOST, ORIGIN, VARY,
+    ACCESS_CONTROL_MAX_AGE, ACCESS_CONTROL_REQUEST_HEADERS, CONTENT_TYPE, HOST, ORIGIN, VARY,
 };
-use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Method as HttpMethod, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -25,6 +25,10 @@ use futures_util::{SinkExt, StreamExt};
 use herdr_compat::TryClone as _;
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode as TsCloseCode;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame as TsCloseFrame;
+use tokio_tungstenite::tungstenite::Message as TsMessage;
+use tokio_tungstenite::tungstenite::Utf8Bytes as TsUtf8Bytes;
 use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
 use tower_http::services::ServeDir;
@@ -90,6 +94,16 @@ struct BridgeOptions {
     allowed_hosts: Vec<String>,
     allowed_origins: Vec<String>,
     allowed_connect_sources: Vec<String>,
+    remote_bridges: Vec<String>,
+}
+
+/// Another herdr-web bridge instance (typically on a different Tailscale machine) that this
+/// bridge proxies `/api/remote/<id>/...` and `/ws/remote/<id>/terminal` requests through to.
+#[derive(Debug, Clone)]
+struct RemoteBridge {
+    id: String,
+    label: String,
+    base_url: String,
 }
 
 #[derive(Clone)]
@@ -107,6 +121,8 @@ struct BridgeState {
     ui_event_tx: tokio::sync::broadcast::Sender<String>,
     activity_tx: tokio::sync::broadcast::Sender<ActivityMessage>,
     upload_dir: PathBuf,
+    remote_bridges: Arc<Vec<RemoteBridge>>,
+    remote_http_client: reqwest::Client,
 }
 
 #[derive(Debug, Clone)]
@@ -125,6 +141,14 @@ struct Snapshot {
     panes: Vec<PaneInfo>,
     layouts: Vec<PaneLayoutSnapshot>,
     selected_pane_id: Option<String>,
+    bridges: Vec<SnapshotBridgeInfo>,
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotBridgeInfo {
+    id: String,
+    label: String,
+    url: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -796,6 +820,7 @@ fn parse_options(args: &[String]) -> Result<Option<BridgeOptions>, String> {
     let mut allowed_hosts = Vec::new();
     let mut allowed_origins = Vec::new();
     let mut allowed_connect_sources = Vec::new();
+    let mut remote_bridges = Vec::new();
     let mut explicit_session = None;
     let mut index = 0;
 
@@ -871,6 +896,13 @@ fn parse_options(args: &[String]) -> Result<Option<BridgeOptions>, String> {
                 allowed_connect_sources.extend(connect_sources_for_origin(value)?);
                 index += 2;
             }
+            "--remote-bridge" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err("missing value for --remote-bridge".into());
+                };
+                remote_bridges.push(normalize_remote_bridge_url(value)?);
+                index += 2;
+            }
             arg => return Err(format!("unknown herdr-web option: {arg}")),
         }
     }
@@ -891,7 +923,77 @@ fn parse_options(args: &[String]) -> Result<Option<BridgeOptions>, String> {
         allowed_hosts,
         allowed_origins,
         allowed_connect_sources,
+        remote_bridges,
     }))
+}
+
+/// Normalizes a `--remote-bridge` value into a canonical `scheme://host[:port]` origin
+/// (adding `http://` when no scheme is given, matching the frontend's bridge URL convention).
+fn normalize_remote_bridge_url(value: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("remote bridge URL must not be empty".into());
+    }
+    let with_scheme = if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("http://{trimmed}")
+    };
+    let normalized = with_scheme.trim_end_matches('/').to_ascii_lowercase();
+    let Some(authority) = origin_authority(&normalized) else {
+        return Err("remote bridge URL must be an http or https origin without a path".into());
+    };
+    if authority.is_empty() || authority.contains('@') {
+        return Err("remote bridge URL must include a host and no credentials".into());
+    }
+    Ok(normalized)
+}
+
+/// Assigns a stable id (derived from hostname) and display label to each configured remote
+/// bridge, deduplicating identical URLs and disambiguating id collisions.
+fn build_remote_bridges(urls: &[String]) -> Vec<RemoteBridge> {
+    let mut seen_urls = HashSet::new();
+    let mut used_ids = HashSet::new();
+    let mut bridges = Vec::new();
+    for url in urls {
+        if !seen_urls.insert(url.clone()) {
+            continue;
+        }
+        let base_id = remote_bridge_id_base(url);
+        let mut id = base_id.clone();
+        let mut suffix = 2;
+        while used_ids.contains(&id) {
+            id = format!("{base_id}-{suffix}");
+            suffix += 1;
+        }
+        used_ids.insert(id.clone());
+        bridges.push(RemoteBridge {
+            id,
+            label: remote_bridge_label(url),
+            base_url: url.clone(),
+        });
+    }
+    bridges
+}
+
+fn remote_bridge_id_base(url: &str) -> String {
+    let host = origin_authority(url).map(host_part).unwrap_or(url);
+    let slug: String = host
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect();
+    if slug.is_empty() {
+        "bridge".to_string()
+    } else {
+        slug
+    }
+}
+
+fn remote_bridge_label(url: &str) -> String {
+    origin_authority(url)
+        .map(host_part)
+        .unwrap_or(url)
+        .to_string()
 }
 
 fn print_help() {
@@ -901,7 +1003,7 @@ fn print_help() {
 fn help_text() -> &'static str {
     "herdr-web-bridge\n\
 \n\
-Usage: herdr-web-bridge [--session NAME] [--host HOST] [--port PORT] [--static-dir DIR] [--upload-dir DIR] [--launcher-presets PATH] [--allow-origin ORIGIN] [--allow-host HOSTNAME] [--allow-connect-origin ORIGIN]\n\
+Usage: herdr-web-bridge [--session NAME] [--host HOST] [--port PORT] [--static-dir DIR] [--upload-dir DIR] [--launcher-presets PATH] [--allow-origin ORIGIN] [--allow-host HOSTNAME] [--allow-connect-origin ORIGIN] [--remote-bridge URL]...\n\
 \n\
 Runs the local HTTP/WebSocket bridge for herdr-web.\n\
 Defaults to the active Herdr daemon sockets and 127.0.0.1:8787.\n\
@@ -911,6 +1013,10 @@ Use --allow-origin http://localhost for bundled Android app access.\n\
 Use --allow-host HOSTNAME to accept that exact DNS hostname in Host headers.\n\
 Use --allow-connect-origin ORIGIN to let the served web app connect to another bridge origin.\n\
 Use --launcher-presets PATH or HERDR_WEB_LAUNCHER_PRESETS to load custom launch presets.\n\
+Use --remote-bridge URL (repeatable) to register another herdr-web bridge (e.g. http://mini2:8787)\n\
+  to proxy through: reads at /api/remote/<id>/... and terminal sessions at\n\
+  /ws/remote/<id>/terminal, where <id> is the remote's hostname as reported in /api/snapshot's\n\
+  bridges array.\n\
 Uploads default to HERDR_WEB_UPLOAD_DIR, XDG_DATA_HOME/herdr-web/uploads, or ~/.local/share/herdr-web/uploads."
 }
 
@@ -944,6 +1050,14 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         protocol = daemon_protocol,
         "herdr-web bridge connected to compatible Herdr daemon"
     );
+    let remote_bridges = build_remote_bridges(&options.remote_bridges);
+    for remote in &remote_bridges {
+        info!(id = %remote.id, url = %remote.base_url, "herdr-web bridge proxying remote bridge");
+    }
+    let remote_http_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .map_err(|err| io::Error::new(ErrorKind::Other, err.to_string()))?;
     let state = BridgeState {
         api,
         client_socket_path: crate::session::active_client_socket_path(),
@@ -958,6 +1072,8 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         ui_event_tx: tokio::sync::broadcast::channel(256).0,
         activity_tx: tokio::sync::broadcast::channel(512).0,
         upload_dir: options.upload_dir.clone(),
+        remote_bridges: Arc::new(remote_bridges),
+        remote_http_client,
     };
     spawn_agent_activity_watcher(state.clone());
     let agent_activity_routes = Router::new().route(
@@ -1043,10 +1159,20 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
             "/api/uploads",
             post(upload_handler).options(preflight_handler),
         )
+        .route(
+            "/api/remote/{bridge_id}/{*rest}",
+            get(remote_api_proxy_handler)
+                .post(remote_api_proxy_handler)
+                .options(preflight_handler),
+        )
         .route("/ws/events", get(events_ws_handler))
         .route("/ws/activity", get(activity_ws_handler))
         .route("/ws/ui-events", get(ui_events_ws_handler))
         .route("/ws/terminal", get(terminal_ws_handler))
+        .route(
+            "/ws/remote/{bridge_id}/terminal",
+            get(remote_terminal_ws_handler),
+        )
         .fallback_service(
             ServiceBuilder::new()
                 .layer(CompressionLayer::new())
@@ -2460,16 +2586,27 @@ async fn snapshot_handler(
         Err(err) => warn!(error = %err, "failed to update pane note observations"),
     }
     let selected_pane_id = shared_selected_pane(&state, &session_snapshot.panes)?;
+    let bridges = state
+        .remote_bridges
+        .iter()
+        .map(|remote| SnapshotBridgeInfo {
+            id: remote.id.clone(),
+            label: remote.label.clone(),
+            url: remote.base_url.clone(),
+        })
+        .collect();
 
     Ok(Json(web_snapshot_from_session_snapshot(
         session_snapshot,
         selected_pane_id,
+        bridges,
     )))
 }
 
 fn web_snapshot_from_session_snapshot(
     snapshot: SessionSnapshot,
     selected_pane_id: Option<String>,
+    bridges: Vec<SnapshotBridgeInfo>,
 ) -> Snapshot {
     let SessionSnapshot {
         workspaces,
@@ -2508,6 +2645,7 @@ fn web_snapshot_from_session_snapshot(
         panes,
         layouts,
         selected_pane_id,
+        bridges,
     }
 }
 
@@ -2815,6 +2953,175 @@ async fn terminal_ws_handler(
     }
     ws.on_upgrade(move |socket| handle_terminal_socket(socket, state, query))
         .into_response()
+}
+
+fn find_remote_bridge(bridges: &[RemoteBridge], id: &str) -> Option<RemoteBridge> {
+    bridges.iter().find(|bridge| bridge.id == id).cloned()
+}
+
+/// Proxies `/api/remote/<bridge_id>/<rest>` requests through to `<remote-url>/api/<rest>` on
+/// another herdr-web bridge, forwarding method, query string, request body, and content type.
+async fn remote_api_proxy_handler(
+    State(state): State<BridgeState>,
+    AxumPath((bridge_id, rest)): AxumPath<(String, String)>,
+    method: HttpMethod,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
+        return err.into_response();
+    }
+    let Some(remote) = find_remote_bridge(&state.remote_bridges, &bridge_id) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "unknown remote bridge" })),
+        )
+            .into_response();
+    };
+
+    let mut target = format!("{}/api/{}", remote.base_url, rest);
+    if let Some(query) = query.filter(|value| !value.is_empty()) {
+        target.push('?');
+        target.push_str(&query);
+    }
+
+    let Ok(reqwest_method) = reqwest::Method::from_bytes(method.as_str().as_bytes()) else {
+        return StatusCode::METHOD_NOT_ALLOWED.into_response();
+    };
+    let mut request = state.remote_http_client.request(reqwest_method, &target);
+    if let Some(content_type) = headers.get(CONTENT_TYPE) {
+        request = request.header(CONTENT_TYPE, content_type.clone());
+    }
+
+    let response = match request.body(body).send().await {
+        Ok(response) => response,
+        Err(err) => {
+            warn!(error = %err, target = %target, "remote bridge proxy request failed");
+            return BridgeError::Protocol(format!("remote bridge unreachable: {err}"))
+                .into_response();
+        }
+    };
+    let status = response.status();
+    let content_type = response.headers().get(CONTENT_TYPE).cloned();
+    let body_bytes = match response.bytes().await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return BridgeError::Protocol(format!("remote bridge response error: {err}"))
+                .into_response();
+        }
+    };
+    let mut builder = Response::builder().status(status);
+    if let Some(content_type) = content_type {
+        builder = builder.header(CONTENT_TYPE, content_type);
+    }
+    builder
+        .body(axum::body::Body::from(body_bytes))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+/// Proxies `/ws/remote/<bridge_id>/terminal` websocket upgrades through to
+/// `<remote-url>/ws/terminal` on another herdr-web bridge, preserving the query string
+/// (terminal_id, cols, rows, coalesce_ms, takeover).
+async fn remote_terminal_ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<BridgeState>,
+    AxumPath(bridge_id): AxumPath<String>,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
+        return err.into_response();
+    }
+    let Some(remote) = find_remote_bridge(&state.remote_bridges, &bridge_id) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    ws.on_upgrade(move |socket| proxy_terminal_socket(socket, remote, query))
+        .into_response()
+}
+
+async fn proxy_terminal_socket(local: WebSocket, remote: RemoteBridge, query: Option<String>) {
+    let scheme = if remote.base_url.starts_with("https://") {
+        "wss"
+    } else {
+        "ws"
+    };
+    let authority = remote.base_url.splitn(2, "://").nth(1).unwrap_or("");
+    let suffix = query
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("?{value}"))
+        .unwrap_or_default();
+    let target = format!("{scheme}://{authority}/ws/terminal{suffix}");
+
+    let remote_socket = match tokio_tungstenite::connect_async(&target).await {
+        Ok((socket, _response)) => socket,
+        Err(err) => {
+            warn!(error = %err, target = %target, "failed to connect to remote bridge terminal websocket");
+            return;
+        }
+    };
+
+    let (mut local_sink, mut local_stream) = local.split();
+    let (mut remote_sink, mut remote_stream) = remote_socket.split();
+    loop {
+        tokio::select! {
+            message = local_stream.next() => {
+                match message {
+                    Some(Ok(message)) => {
+                        if remote_sink.send(axum_message_to_tungstenite(message)).await.is_err() {
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            message = remote_stream.next() => {
+                match message {
+                    Some(Ok(message)) => {
+                        let Some(converted) = tungstenite_message_to_axum(message) else {
+                            continue;
+                        };
+                        if local_sink.send(converted).await.is_err() {
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            else => break,
+        }
+    }
+    let _ = remote_sink.close().await;
+    let _ = local_sink.close().await;
+}
+
+fn axum_message_to_tungstenite(message: Message) -> TsMessage {
+    match message {
+        Message::Text(text) => TsMessage::Text(TsUtf8Bytes::from(text.as_str())),
+        Message::Binary(data) => TsMessage::Binary(data),
+        Message::Ping(data) => TsMessage::Ping(data),
+        Message::Pong(data) => TsMessage::Pong(data),
+        Message::Close(Some(frame)) => TsMessage::Close(Some(TsCloseFrame {
+            code: TsCloseCode::from(frame.code),
+            reason: TsUtf8Bytes::from(frame.reason.as_str()),
+        })),
+        Message::Close(None) => TsMessage::Close(None),
+    }
+}
+
+fn tungstenite_message_to_axum(message: TsMessage) -> Option<Message> {
+    Some(match message {
+        TsMessage::Text(text) => Message::Text(AxumUtf8Bytes::from(text.as_str())),
+        TsMessage::Binary(data) => Message::Binary(data),
+        TsMessage::Ping(data) => Message::Ping(data),
+        TsMessage::Pong(data) => Message::Pong(data),
+        TsMessage::Close(Some(frame)) => Message::Close(Some(CloseFrame {
+            code: frame.code.into(),
+            reason: AxumUtf8Bytes::from(frame.reason.as_str()),
+        })),
+        TsMessage::Close(None) => Message::Close(None),
+        TsMessage::Frame(_) => return None,
+    })
 }
 
 async fn events_ws_handler(
@@ -4705,8 +5012,11 @@ mod tests {
 
     #[test]
     fn web_snapshot_adapter_preserves_web_shape_and_clear_name_flags() {
-        let snapshot =
-            web_snapshot_from_session_snapshot(test_session_snapshot(), Some("pane-2".to_string()));
+        let snapshot = web_snapshot_from_session_snapshot(
+            test_session_snapshot(),
+            Some("pane-2".to_string()),
+            Vec::new(),
+        );
 
         assert_eq!(snapshot.selected_pane_id.as_deref(), Some("pane-2"));
         assert_eq!(snapshot.workspaces.len(), 2);
@@ -4756,6 +5066,7 @@ mod tests {
         let snapshot = web_snapshot_from_session_snapshot(
             test_session_snapshot(),
             Some("missing".to_string()),
+            Vec::new(),
         );
 
         assert_eq!(snapshot.selected_pane_id, None);

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -50,4 +50,16 @@ bin/herdr-web --host 0.0.0.0 --allow-host host-a --allow-connect-origin http://h
 bin/herdr-web --host 0.0.0.0 --allow-host host-b --allow-origin http://host-a:8787
 ```
 
+As an alternative, a bridge can proxy another herdr-web bridge server-side (for example, reaching
+other machines over Tailscale) with a repeatable `--remote-bridge URL` flag:
+
+```bash
+bin/herdr-web --remote-bridge http://mini2:8787 --remote-bridge http://mini3:8787
+```
+
+`--remote-bridge` URLs must use `http://`. The bridge derives an id from each URL's hostname and
+lists configured remote bridges in `/api/snapshot`; `/api/remote/{bridge_id}/...` and
+`/ws/remote/{bridge_id}/terminal` proxy to that remote bridge. Only bridges the process was started
+with are reachable this way.
+
 Only bind to non-loopback interfaces on networks you trust.

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -69,12 +69,19 @@ export type LayoutSnapshot = {
   }>;
 };
 
+export type SnapshotBridgeInfo = {
+  id: string;
+  label: string;
+  url: string;
+};
+
 export type Snapshot = {
   workspaces: WorkspaceInfo[];
   tabs: TabInfo[];
   panes: PaneInfo[];
   layouts: LayoutSnapshot[];
   selected_pane_id?: string | null;
+  bridges?: SnapshotBridgeInfo[];
 };
 
 export type PaneAgentStatusChangedMessage = {


### PR DESCRIPTION
## Intent

Add multi-bridge proxy support to herdr-web so the browser UI can eventually reach herdr instances running on other machines (macbook, mini1, mini2, mini3) over Tailscale, all from one browser session. Scope was deliberately split: Phase 1 (bridge server plumbing) is the critical, fully delivered piece — a repeatable --remote-bridge <url> CLI flag registers other herdr-web bridge instances; ids are derived server-side from the URL hostname with collision-safe suffixing and exact-duplicate dedup; /api/snapshot now returns a bridges array (id/label/url) for each configured remote bridge; /api/remote/{bridge_id}/{*rest} proxies REST reads to the remote bridge's /api/{rest}; /ws/remote/{bridge_id}/terminal proxies terminal WebSocket connections bidirectionally via a tokio::select! relay loop. Added reqwest (default-features=false, since Tailscale traffic is plain HTTP, no TLS backend needed) and tokio-tungstenite as new bridge dependencies for outbound HTTP/WS proxying. Wrote manual public conversion functions between axum's ws::Message/Utf8Bytes/CloseFrame and tungstenite's equivalents since axum only exposes private conversions. The REST proxy route intentionally only wires GET/POST/OPTIONS (not axum's any()) so CORS preflight isn't forwarded to the remote bridge, matching the existing API's GET/POST-only convention. cargo check and cargo test both pass (118 tests). Phase 2 (frontend) was deliberately scoped down: only added an optional bridges field to the TypeScript Snapshot type (in web/src/types.ts) so existing test fixtures didn't need updates, and tsc -b is clean with no test regressions. I explicitly did NOT build the interactive add/remove remote bridge URL UI persisted to localStorage in BackendSettingsDialog.tsx/App.tsx that the original brief sketched, because it can't work standalone: the proxy only recognizes bridges the server was actually launched with via --remote-bridge (bridge-id is derived and looked up server-side), so a client-added URL not also registered on the server would silently 404 through the proxy. That gap is a product decision (mirror server config read-only vs. add a server-side registration API) rather than something to decide unilaterally, so it is left for a follow-up and documented in AGENTS.md and the commit message. Also updated CHANGELOG.md under Unreleased and AGENTS.md with a note about this remote-bridge id/URL registration constraint for future frontend work.

## What Changed

- Added a repeatable `--remote-bridge <url>` CLI flag that registers other herdr-web bridge instances; ids are derived server-side from the URL hostname with collision-safe suffixing and exact-duplicate dedup, and `/api/snapshot` now returns a `bridges` array (id/label/url) for each configured remote.
- Added `/api/remote/{bridge_id}/{*rest}` (GET/POST/OPTIONS only, no CORS-preflight forwarding) to proxy REST reads to a remote bridge's `/api/{rest}`, and `/ws/remote/{bridge_id}/terminal` to bidirectionally proxy terminal WebSocket connections via a relay loop, using new manual conversions between axum's and tungstenite's WS message types.
- `normalize_remote_bridge_url()` now rejects `https://` remote-bridge URLs (plain HTTP only, matching the Tailscale use case and the bridge's TLS-less `reqwest`/`tokio-tungstenite` dependencies) and gained unit test coverage alongside the new URL/id-building helpers.
- Added `reqwest` and `tokio-tungstenite` as new bridge dependencies; documented the `--remote-bridge` proxying behavior and its id/URL registration constraint in README.md, AGENTS.md, docs/tarball-readme.md, and CHANGELOG.md; added an optional `bridges` field to the `Snapshot` TypeScript type in `web/src/types.ts` (no other frontend UI changes).

## Risk Assessment

✅ Low: The round-1 findings were both addressed correctly: https:// is now rejected at parse time with clear errors, and the new unit tests cover normalize_remote_bridge_url, build_remote_bridges/id collisions, and the axum/tungstenite message round-trip; the only remaining issue is a harmless unreachable dead-code branch left over from before the https rejection was added.

## Testing

Ran the bridge's Rust unit tests and the web type-check/build (both clean), then went beyond automated tests to prove the core Phase-1 deliverable end-to-end: two real herdr-web-bridge processes against an isolated throwaway herdr session, confirming /api/snapshot's new `bridges` field, a working GET REST proxy through /api/remote/{id}/..., a 404 for unregistered ids, and a working /ws/remote/{id}/terminal WebSocket relay that streamed real terminal output between the two bridges — all cleaned up afterward with no leftover processes or session state. One unrelated, pre-existing Vitest failure (Node-version localStorage/jsdom incompatibility in NoteEditor.test.tsx) was identified and is not caused by this change.

<details>
<summary>Evidence: Live end-to-end remote-bridge proxy demo (REST + WS terminal relay) between two herdr-web-bridge instances</summary>

```text
=== Setup: two herdr-web-bridge instances against an isolated throwaway herdr session (nomistakes-proxy-test-a) ===
Bridge A (simulated 'remote' machine): 127.0.0.1:18801, no --remote-bridge
Bridge B (simulated 'local' browser-facing bridge): 127.0.0.1:18802, started with --remote-bridge http://127.0.0.1:18801

=== 1. GET http://127.0.0.1:18802/api/snapshot -> bridges array (registered remote) ===
[
  {
    "id": "127-0-0-1",
    "label": "127.0.0.1",
    "url": "http://127.0.0.1:18801"
  }
]

=== 2. REST proxy: bridge A direct /api/snapshot vs bridge B's /api/remote/127-0-0-1/snapshot (byte-for-byte diff) ===
RESPONSE BODIES IDENTICAL

=== 3. Unknown bridge id returns 404 ===
HTTP 404

=== 4. WS terminal proxy: bridge B's /ws/remote/127-0-0-1/terminal relays real terminal buffer from bridge A's herdr session ===
=== bridge A direct terminal ws: connected, received 2 frame(s) ===
<binary 35955 bytes>
<binary 35955 bytes>
=== bridge B proxied remote terminal ws: connected, received 1 frame(s) ===
<binary 35955 bytes>
```
</details>
- Outcome: ⚠️ 1 info across 1 run (16m16s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bridge/src/web_bridge.rs:944` - normalize_remote_bridge_url() accepts `https://` as a valid --remote-bridge scheme (only http/https are rejected), and proxy_terminal_socket derives `wss` for such URLs. But bridge/Cargo.toml adds `reqwest = { version = &#34;0.12&#34;, default-features = false }` and `tokio-tungstenite = &#34;0.29&#34;` with no TLS feature enabled — confirmed via Cargo.lock, which has no rustls/native-tls/hyper-tls dependency anywhere in the tree. So an operator who passes `--remote-bridge https://host:port` will have the bridge start successfully and advertise the remote in /api/snapshot, but every REST proxy request and terminal WS connection to it will fail at runtime (reqwest &#39;TLS backend not found&#39;-style error, or a tungstenite connect failure), instead of failing fast and clearly at startup. Either reject non-http schemes in normalize_remote_bridge_url with a clear error, or add a TLS feature to both clients if https support is actually intended.
- ⚠️ `bridge/src/web_bridge.rs:932` - None of the new pure-logic helpers added in this branch have unit tests: normalize_remote_bridge_url (scheme/credential/empty-host validation), build_remote_bridges/remote_bridge_id_base (dedup of exact-duplicate URLs, collision-safe id suffixing when two different hosts slugify to the same base id), or the axum_message_to_tungstenite/tungstenite_message_to_axum WS message conversions. Test count in the file is unchanged (69 #[test] functions before and after). This is exactly the kind of small, deterministic logic that&#39;s cheap to unit test and easy to get subtly wrong (e.g. the suffix-collision loop, or the &#39;@&#39;-credential rejection), so a regression here wouldn&#39;t be caught by existing tests.
- ℹ️ `bridge/src/web_bridge.rs:992` - remote_bridge_label() returns only the hostname (via host_part), dropping the port. If an operator registers two remote bridges on the same host but different ports (e.g. two herdr-web instances on one machine), both get the same `label` in the /api/snapshot bridges array even though their `id`s differ via the collision suffix. A future frontend rendering just the label would show two indistinguishable entries. The `url` field is still present to disambiguate, so this is cosmetic, not a functional bug.

🔧 Fix: Reject https:// remote-bridge URLs; add unit tests for new helpers
1 info still open:
- ℹ️ `bridge/src/web_bridge.rs:3051` - proxy_terminal_socket() still branches on `remote.base_url.starts_with(&#34;https://&#34;)` to pick `wss` vs `ws`. Since this fix commit&#39;s normalize_remote_bridge_url() now rejects any https:// URL at registration time (and RemoteBridge.base_url is only ever constructed from build_remote_bridges(), whose inputs are normalize_remote_bridge_url()-validated strings), this branch is unreachable dead code — the scheme is always &#34;ws&#34; in practice. Not a bug, just a leftover that could be simplified to `let scheme = &#34;ws&#34;;` (or a comment explaining why the branch still exists) now that https is fully rejected upstream.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `web/src/NoteEditor.test.tsx` - web/src/NoteEditor.test.tsx has 13 pre-existing failures in this sandbox unrelated to the remote-bridge diff: Node v26.4.0&#39;s experimental global `localStorage` (which requires `--localstorage-file`) shadows jsdom&#39;s `window.localStorage` inside vitest&#39;s jsdom environment, so any test calling bare `localStorage.setItem/getItem/clear` throws. This file and vitest/vite config are untouched by this diff (only web/src/types.ts gained an optional `bridges` field), so it&#39;s a local Node-version/environment incompatibility, not a regression from this change. The other 27 test files (183 tests) pass.
- <code>cargo test (via `npm run bridge:test`) — 126 passed, 0 failed</code>
- `npm run vendor:check`
- <code>npm run build:web (`tsc -b &amp;&amp; vite build`)</code>
- `npm run test:web (vitest) — 183 passed / 13 failed, failures isolated to NoteEditor.test.tsx and pre-existing/environment-caused, unrelated to this diff`
- <code>Manual E2E: built bridge/target/debug/herdr-web-bridge; created isolated herdr session `nomistakes-proxy-test-a`; started bridge A on 127.0.0.1:18801 and bridge B on 127.0.0.1:18802 with `--remote-bridge http://127.0.0.1:18801`</code>
- <code>curl http://127.0.0.1:18802/api/snapshot — confirmed `bridges` array contains {id: &#39;127-0-0-1&#39;, label: &#39;127.0.0.1&#39;, url: &#39;http://127.0.0.1:18801&#39;}</code>
- `diff of bridge A's direct /api/snapshot vs bridge B's /api/remote/127-0-0-1/snapshot — byte-identical`
- `curl http://127.0.0.1:18802/api/remote/does-not-exist/snapshot — 404 as expected`
- `python3 websockets client: connected to bridge B's /ws/remote/127-0-0-1/terminal?terminal_id=... and received a real terminal buffer frame relayed from bridge A's herdr session`
- <code>Cleanup: killed test bridge processes, `herdr session stop/delete nomistakes-proxy-test-a`, removed /tmp scratch files, verified `git status --porcelain` is clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
