### PR TITLE
Integrate agent features into Tabs and improve Spaces navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,27 @@
 
 ### Breaking Changes
 
+- Changed the default ungrouped Tabs and Spaces sidebar presentation to compact rows with inline
+  host, Space, and tab context instead of contextual headers. Agent panes in Tabs also use the
+  Agents row presentation and agent-aware ordering by default. Choose a grouping mode to restore
+  contextual headers, or disable Agent features in Tabs to restore generic pane rows and the
+  original tab order. (PR #TBD)
+
 ### Added
 
-- Added a default-on Multi-host Space selection setting; disabling it limits Space-scoped Agents,
-  Tabs, and Notes to one globally selected Space while leaving All scope unchanged.
+- Added default-on Agent features in Tabs, including consistent Agents row metadata and pin
+  placement, agent-aware sorting, and pinned-only and active-only filters. Non-agent tabs remain
+  visible at the bottom of agent-aware sorts; disabling the setting restores generic pane rows.
+  (PR #TBD)
+- Added multi-host Spaces controls: Spaces can be shown as a flat list with host context or grouped
+  under host headers, and the default-on Multi-host Space selection setting can be disabled to limit
+  Space-scoped Agents, Tabs, and Notes to one globally selected Space. All scope remains unchanged.
+  (PR #TBD)
 
 ### Changed
 
-- Made ungrouped Tabs sidebar lists match the compact Agents layout by moving host, workspace, and
-  tab context into each pane row instead of rendering contextual headers.
-- Added default-on Agent features in Tabs, which uses the Agents row presentation and exposes
-  agent-aware sorting and the active-status filter while keeping non-agent tabs stable at the
-  bottom; disabling it restores plain pane rows and the original tab order.
-- Removed redundant generic status text from agent-row metadata because the row status indicator and
-  badge already communicate it, while retaining custom status text and bridge-defined labels.
-- Added dynamic Spaces grouping for multi-host scope: None uses compact flat rows with host context,
-  while Host renders host headers; the control and redundant host labels stay hidden in single-host
-  scope.
+- Simplified agent-row metadata by removing generic status text already communicated by the status
+  indicator and badge, while retaining custom status text and bridge-defined labels. (PR #TBD)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- Added a default-on Multi-host Space selection setting; disabling it limits Space-scoped Agents,
+  Tabs, and Notes to one globally selected Space while leaving All scope unchanged.
+
 ### Changed
 
 - Made ungrouped Tabs sidebar lists match the compact Agents layout by moving host, workspace, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Added default-on Agent features in Tabs, which uses the Agents row presentation and exposes
   agent-aware sorting and the active-status filter while keeping non-agent tabs stable at the
   bottom; disabling it restores plain pane rows and the original tab order.
+- Removed redundant status text from agent-row metadata because the row status indicator and badge
+  already communicate it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
 - Added default-on Agent features in Tabs, which uses the Agents row presentation and exposes
   agent-aware sorting and the active-status filter while keeping non-agent tabs stable at the
   bottom; disabling it restores plain pane rows and the original tab order.
-- Removed redundant status text from agent-row metadata because the row status indicator and badge
-  already communicate it.
+- Removed redundant generic status text from agent-row metadata because the row status indicator and
+  badge already communicate it, while retaining custom status text and bridge-defined labels.
 - Added dynamic Spaces grouping for multi-host scope: None uses compact flat rows with host context,
   while Host renders host headers; the control and redundant host labels stay hidden in single-host
   scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 - Made ungrouped Tabs sidebar lists match the compact Agents layout by moving host, workspace, and
   tab context into each pane row instead of rendering contextual headers.
 - Added default-on Agent features in Tabs, which uses the Agents row presentation and exposes
-  agent-aware sorting while keeping non-agent tabs stable at the bottom; disabling it restores
-  plain pane rows and the original tab order.
+  agent-aware sorting and the active-status filter while keeping non-agent tabs stable at the
+  bottom; disabling it restores plain pane rows and the original tab order.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,24 @@
   host, Space, and tab context instead of contextual headers. Agent panes in Tabs also use the
   Agents row presentation and agent-aware ordering by default. Choose a grouping mode to restore
   contextual headers, or disable Agent features in Tabs to restore generic pane rows and the
-  original tab order. (PR #TBD)
+  original tab order. [PR #41](https://github.com/kcosr/herdr-web/pull/41)
 
 ### Added
 
 - Added default-on Agent features in Tabs, including consistent Agents row metadata and pin
   placement, agent-aware sorting, and pinned-only and active-only filters. Non-agent tabs remain
   visible at the bottom of agent-aware sorts; disabling the setting restores generic pane rows.
-  (PR #TBD)
+  [PR #41](https://github.com/kcosr/herdr-web/pull/41)
 - Added multi-host Spaces controls: Spaces can be shown as a flat list with host context or grouped
   under host headers, and the default-on Multi-host Space selection setting can be disabled to limit
   Space-scoped Agents, Tabs, and Notes to one globally selected Space. All scope remains unchanged.
-  (PR #TBD)
+  [PR #41](https://github.com/kcosr/herdr-web/pull/41)
 
 ### Changed
 
 - Simplified agent-row metadata by removing generic status text already communicated by the status
-  indicator and badge, while retaining custom status text and bridge-defined labels. (PR #TBD)
+  indicator and badge, while retaining custom status text and bridge-defined labels.
+  [PR #41](https://github.com/kcosr/herdr-web/pull/41)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   bottom; disabling it restores plain pane rows and the original tab order.
 - Removed redundant status text from agent-row metadata because the row status indicator and badge
   already communicate it.
+- Added dynamic Spaces grouping for multi-host scope: None uses compact flat rows with host context,
+  while Host renders host headers; the control and redundant host labels stay hidden in single-host
+  scope.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Changed
 
+- Made ungrouped Tabs sidebar lists match the compact Agents layout by moving host, workspace, and
+  tab context into each pane row instead of rendering contextual headers.
+- Added default-on Agent features in Tabs, which uses the Agents row presentation and exposes
+  agent-aware sorting while keeping non-agent tabs stable at the bottom; disabling it restores
+  plain pane rows and the original tab order.
+
 ### Fixed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ Settings are grouped by area:
 
 - Bridge: same-origin and saved bridge profiles, reachability testing, and bridge enablement.
 - Features: client feature toggles such as Notes.
-- Display: agent features in Tabs, top/bottom app padding, and mobile terminal controls size.
+- Display: agent features in Tabs, dynamic Spaces grouping, top/bottom app padding, and mobile
+  terminal controls size.
 - Terminal: browser-to-bridge terminal input transport and input batching delay.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Settings are grouped by area:
 
 - Bridge: same-origin and saved bridge profiles, reachability testing, and bridge enablement.
 - Features: client feature toggles such as Notes.
-- Display: top/bottom app padding and mobile terminal controls size.
+- Display: agent features in Tabs, top/bottom app padding, and mobile terminal controls size.
 - Terminal: browser-to-bridge terminal input transport and input batching delay.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ Settings are grouped by area:
 
 - Bridge: same-origin and saved bridge profiles, reachability testing, and bridge enablement.
 - Features: client feature toggles such as Notes.
-- Display: agent features in Tabs, dynamic Spaces grouping, top/bottom app padding, and mobile
-  terminal controls size.
+- Display: agent features in Tabs, top/bottom app padding, and mobile terminal controls size.
 - Terminal: browser-to-bridge terminal input transport and input batching delay.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
+
+When viewing all of multiple hosts, use the Spaces list `…` menu to group spaces by host or keep a
+flat list with host context in each row. The menu stays hidden in single-host scope.
 
 Terminal input payloads can be sent as JSON or binary WebSocket frames. JSON remains the default;
 binary is available for comparing terminal input performance. Terminal input batching is off by

--- a/README.md
+++ b/README.md
@@ -152,12 +152,17 @@ Settings are grouped by area:
 
 - Bridge: same-origin and saved bridge profiles, reachability testing, and bridge enablement.
 - Features: client feature toggles such as Notes.
-- Display: agent features in Tabs, top/bottom app padding, and mobile terminal controls size.
+- Display: agent features in Tabs, multi-host Space selection, top/bottom app padding, and mobile
+  terminal controls size.
 - Terminal: browser-to-bridge terminal input transport and input batching delay.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
 
 When viewing all of multiple hosts, use the Spaces list `…` menu to group spaces by host or keep a
 flat list with host context in each row. The menu stays hidden in single-host scope.
+
+Multi-host Space selection is enabled by default, retaining one active Space per host in
+Space-scoped views. Turn it off under Settings → Display to keep only the selected host's Space,
+Agents, Tabs, and Notes in those views. All scope continues to show content from every host.
 
 Terminal input payloads can be sent as JSON or binary WebSocket frames. JSON remains the default;
 binary is available for comparing terminal input performance. Terminal input batching is off by

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -8,6 +8,7 @@ import {
   noteDraftStorageKey,
   buildVisibleScopedWorkspaces,
   buildVisibleTabEntries,
+  buildVisibleTabWorkspaceGroups,
   isInFlightNoteSaveVisible,
   menuItems,
   nextVisibleAgentPaneEntry,
@@ -807,6 +808,76 @@ describe("App multi-bridge helpers", () => {
         true,
       ).flatMap((entry) => entry.panes.map((paneInfo) => paneInfo.pane_id)),
     ).toEqual(["working", "blocked"]);
+  });
+
+  it("sorts agent tabs within workspace boundaries for workspace grouping", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1), workspace("workspace-b", 2)],
+      [
+        pane("shell-a", "workspace-a", "tab-shell-a", "unknown"),
+        pane("blocked", "workspace-a", "tab-blocked", "blocked"),
+        pane("shell-b", "workspace-b", "tab-shell-b", "unknown"),
+        pane("working", "workspace-b", "tab-working", "working"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+
+    expect(
+      buildVisibleTabEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "workspace",
+        new Set(),
+        false,
+        true,
+        "attention",
+      ).map((entry) => `${entry.workspace.workspace_id}:${entry.tab.tab_id}`),
+    ).toEqual([
+      "workspace-a:tab-blocked",
+      "workspace-a:tab-shell-a",
+      "workspace-b:tab-working",
+      "workspace-b:tab-shell-b",
+    ]);
+  });
+
+  it("omits workspace groups emptied by the Tabs active-only filter", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1), workspace("workspace-b", 2)],
+      [
+        pane("idle", "workspace-a", "tab-idle", "idle"),
+        pane("blocked", "workspace-b", "tab-blocked", "blocked"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+
+    expect(
+      buildVisibleTabWorkspaceGroups(
+        scopedWorkspaces,
+        new Set(),
+        false,
+        true,
+        "workspace",
+        new Map(),
+        true,
+      ).map((group) => group.workspace.workspace_id),
+    ).toEqual(["workspace-b"]);
   });
 
   it("sorts tabs by their most recently active agent pane", () => {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -741,6 +741,74 @@ describe("App multi-bridge helpers", () => {
     ).toEqual(["tab-shell-a", "tab-idle", "tab-blocked", "tab-shell-b"]);
   });
 
+  it("sorts agent tabs across workspace boundaries when grouping by host", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1), workspace("workspace-b", 2)],
+      [
+        pane("shell", "workspace-a", "tab-shell", "unknown"),
+        pane("blocked", "workspace-b", "tab-blocked", "blocked"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+
+    expect(
+      buildVisibleTabEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "host",
+        new Set(),
+        false,
+        true,
+        "attention",
+      ).map((entry) => entry.tab.tab_id),
+    ).toEqual(["tab-blocked", "tab-shell"]);
+  });
+
+  it("shows only active agents when the Tabs active-only filter is enabled", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1)],
+      [
+        pane("shell", "workspace-a", "tab-shell", "unknown"),
+        pane("idle", "workspace-a", "tab-idle", "idle"),
+        pane("working", "workspace-a", "tab-working", "working"),
+        pane("blocked", "workspace-a", "tab-blocked", "blocked"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+
+    expect(
+      buildVisibleTabEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "none",
+        new Set(),
+        false,
+        true,
+        "workspace",
+        new Map(),
+        true,
+      ).flatMap((entry) => entry.panes.map((paneInfo) => paneInfo.pane_id)),
+    ).toEqual(["working", "blocked"]);
+  });
+
   it("sorts tabs by their most recently active agent pane", () => {
     const snapshot = multiPaneSnapshot(
       [workspace("workspace-a", 1)],

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  agentSubtitle,
   buildVisibleAgentPaneEntries,
   buildVisibleScopedNotes,
   canAddNoteFromPaneMenu,
@@ -51,6 +52,21 @@ describe("App connection guards", () => {
 });
 
 describe("App multi-bridge helpers", () => {
+  it("keeps agent subtitles compact by omitting redundant status text", () => {
+    expect(
+      agentSubtitle(
+        {
+          ...pane("agent", "workspace-a", "tab-a", "working"),
+          custom_status: "Reviewing",
+          cwd: "/work/project",
+        },
+        workspace("workspace-a", 1),
+        "tab-a",
+        "host-a",
+      ),
+    ).toBe("host-a · workspace-a · tab-a · project");
+  });
+
   it("uses display preference selection before store fallback", () => {
     expect(resolveInitialSelectedBridgeId("bridge-b", ["bridge-a", "bridge-b"], "bridge-a")).toBe(
       "bridge-b",

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -66,7 +66,14 @@ describe("App multi-bridge helpers", () => {
         "tab-a",
         "host-a",
       ),
-    ).toBe("host-a · workspace-a · tab-a · project");
+    ).toBe("host-a · workspace-a · tab-a · project · Reviewing");
+    expect(
+      agentSubtitle({
+        ...pane("agent", "workspace-a", "tab-a", "working"),
+        state_labels: { working: "Running" },
+      }),
+    ).toBe("Running");
+    expect(agentSubtitle(pane("agent", "workspace-a", "tab-a", "working"))).toBe("");
   });
 
   it("uses display preference selection before store fallback", () => {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -15,11 +15,13 @@ import {
   nextVisibleAgentPaneEntry,
   nextVisibleTabEntry,
   resolveInitialSelectedBridgeId,
+  resolveEffectiveSpaceGroup,
   resolveCreatedPaneNoteForTarget,
   paneNoteListContains,
   shouldBlockDirtyNoteAutosave,
   shouldCollapseHostScope,
   shouldRenderAgentRowInTabs,
+  shouldOfferSpaceHostGrouping,
   shouldShowSidebarSort,
   shouldShowTabDivider,
   shouldShowLastStatusChangeSort,
@@ -85,6 +87,15 @@ describe("App multi-bridge helpers", () => {
     expect(shouldCollapseHostScope("all", 1, true)).toBe(true);
     expect(shouldCollapseHostScope("all", 2, true)).toBe(false);
     expect(shouldCollapseHostScope("selected", 1, true)).toBe(false);
+  });
+
+  it("offers Spaces host grouping only when all of multiple hosts are visible", () => {
+    expect(shouldOfferSpaceHostGrouping("all", 2)).toBe(true);
+    expect(shouldOfferSpaceHostGrouping("all", 1)).toBe(false);
+    expect(shouldOfferSpaceHostGrouping("selected", 2)).toBe(false);
+    expect(resolveEffectiveSpaceGroup("host", "all", 2)).toBe("host");
+    expect(resolveEffectiveSpaceGroup("host", "all", 1)).toBe("none");
+    expect(resolveEffectiveSpaceGroup("host", "selected", 2)).toBe("none");
   });
 
   it("keeps bridge refresh offsets deterministic and inside the fallback interval", () => {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -189,6 +189,60 @@ describe("App multi-bridge helpers", () => {
     ).toEqual(["bridge-a:pane-a", "bridge-b:pane-b"]);
   });
 
+  it("limits Space scope to one host when multi-host Space selection is disabled", () => {
+    const bridgeViews = [
+      bridgeView(
+        "bridge-a",
+        bridgeSnapshot("workspace-a", "tab-a", pane("pane-a", "workspace-a", "tab-a")),
+      ),
+      bridgeView(
+        "bridge-b",
+        bridgeSnapshot("workspace-b", "tab-b", pane("pane-b", "workspace-b", "tab-b")),
+      ),
+    ];
+
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "all",
+      "space",
+      bridgeViews[0].snapshot?.workspaces[0] ?? null,
+      { "bridge-a": "workspace-a", "bridge-b": "workspace-b" },
+      false,
+    );
+
+    expect(
+      scopedWorkspaces.map((entry) => `${entry.bridgeId}:${entry.workspace.workspace_id}`),
+    ).toEqual(["bridge-a:workspace-a"]);
+  });
+
+  it("keeps every workspace in All scope when multi-host Space selection is disabled", () => {
+    const bridgeViews = [
+      bridgeView(
+        "bridge-a",
+        bridgeSnapshot("workspace-a", "tab-a", pane("pane-a", "workspace-a", "tab-a")),
+      ),
+      bridgeView(
+        "bridge-b",
+        bridgeSnapshot("workspace-b", "tab-b", pane("pane-b", "workspace-b", "tab-b")),
+      ),
+    ];
+
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "all",
+      "all",
+      bridgeViews[0].snapshot?.workspaces[0] ?? null,
+      { "bridge-a": "workspace-a", "bridge-b": "workspace-b" },
+      false,
+    );
+
+    expect(
+      scopedWorkspaces.map((entry) => `${entry.bridgeId}:${entry.workspace.workspace_id}`),
+    ).toEqual(["bridge-a:workspace-a", "bridge-b:workspace-b"]);
+  });
+
   it("limits visible shortcut entries to the selected host in selected-host scope", () => {
     const bridgeViews = [
       bridgeView(
@@ -1071,6 +1125,7 @@ describe("App multi-bridge helpers", () => {
         "space",
         bridgeViews[0].snapshot?.workspaces[0] ?? null,
         { "bridge-a": "workspace-a" },
+        true,
         false,
         false,
       ).map((entry) => entry.note.note_id),
@@ -1087,8 +1142,40 @@ describe("App multi-bridge helpers", () => {
         { "bridge-a": "workspace-a" },
         true,
         true,
+        true,
       ).map((entry) => entry.note.note_id),
     ).toEqual(["deleted", "archived", "unresolved-other-space", "active-linked"]);
+  });
+
+  it("limits Space-scoped notes to one host when multi-host Space selection is disabled", () => {
+    const bridgeViews = [
+      bridgeView(
+        "bridge-a",
+        bridgeSnapshot("workspace-a", "tab-a", pane("pane-a", "workspace-a", "tab-a")),
+      ),
+      bridgeView(
+        "bridge-b",
+        bridgeSnapshot("workspace-b", "tab-b", pane("pane-b", "workspace-b", "tab-b")),
+      ),
+    ];
+
+    expect(
+      buildVisibleScopedNotes(
+        bridgeViews,
+        {
+          ...notesState("bridge-a", "store-a", [note("note-a", "workspace-a", "linked")]),
+          ...notesState("bridge-b", "store-b", [note("note-b", "workspace-b", "linked")]),
+        },
+        "bridge-a",
+        "all",
+        "space",
+        bridgeViews[0].snapshot?.workspaces[0] ?? null,
+        { "bridge-a": "workspace-a", "bridge-b": "workspace-b" },
+        false,
+        false,
+        false,
+      ).map((entry) => `${entry.bridgeId}:${entry.note.note_id}`),
+    ).toEqual(["bridge-a:note-a"]);
   });
 
   it("dedupes all-host notes by note identity when two bridge profiles point at the same store", () => {
@@ -1133,6 +1220,7 @@ describe("App multi-bridge helpers", () => {
         "all",
         null,
         {},
+        true,
         false,
         false,
       ).map((entry) => `${entry.bridgeId}:${entry.note.session_key}:${entry.note.note_id}`),
@@ -1158,6 +1246,7 @@ describe("App multi-bridge helpers", () => {
       "all",
       null,
       {},
+      true,
       false,
       false,
     );
@@ -1188,6 +1277,7 @@ describe("App multi-bridge helpers", () => {
       "all",
       null,
       {},
+      true,
       false,
       false,
     );

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -17,6 +17,9 @@ import {
   paneNoteListContains,
   shouldBlockDirtyNoteAutosave,
   shouldCollapseHostScope,
+  shouldRenderAgentRowInTabs,
+  shouldShowSidebarSort,
+  shouldShowTabDivider,
   shouldShowLastStatusChangeSort,
   sortScopedAgentPanes,
   stableBridgeRefreshOffsetMs,
@@ -73,6 +76,32 @@ describe("App multi-bridge helpers", () => {
     expect(first).toBeGreaterThanOrEqual(0);
     expect(first).toBeLessThan(10000);
     expect(stableBridgeRefreshOffsetMs("bridge-b")).toBeLessThan(10000);
+  });
+
+  it("keeps ungrouped tab lists flat even for multi-tab and split-pane workspaces", () => {
+    expect(shouldShowTabDivider("none", 3, 2)).toBe(false);
+    expect(shouldShowTabDivider("workspace", 3, 1)).toBe(true);
+    expect(shouldShowTabDivider("host", 1, 2)).toBe(true);
+    expect(shouldShowTabDivider("hostWorkspace", 1, 1)).toBe(false);
+  });
+
+  it("uses the Agents classifier only when agent rendering in Tabs is enabled", () => {
+    const agentPane = {
+      ...pane("agent", "workspace-a", "tab-a", "unknown"),
+      agent: "codex",
+    };
+    expect(shouldRenderAgentRowInTabs(agentPane, true)).toBe(true);
+    expect(shouldRenderAgentRowInTabs(agentPane, false)).toBe(false);
+    expect(
+      shouldRenderAgentRowInTabs(pane("shell", "workspace-a", "tab-a", "unknown"), true),
+    ).toBe(false);
+  });
+
+  it("shows agent sort options in Tabs only when agent features are enabled", () => {
+    expect(shouldShowSidebarSort("agents", false)).toBe(true);
+    expect(shouldShowSidebarSort("tabs", true)).toBe(true);
+    expect(shouldShowSidebarSort("tabs", false)).toBe(false);
+    expect(shouldShowSidebarSort("notes", true)).toBe(false);
   });
 
   it("sorts scoped agents by bridge display order, workspace, tab, then scoped pane id", () => {
@@ -664,6 +693,92 @@ describe("App multi-bridge helpers", () => {
         (item) => `${item.bridgeId}:${item.tab.tab_id}`,
       ),
     ).toEqual(["bridge-a:tab-a", "bridge-b:tab-b"]);
+  });
+
+  it("sorts agent tabs first by attention while keeping plain tabs stable at the bottom", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1)],
+      [
+        pane("shell-a", "workspace-a", "tab-shell-a", "unknown"),
+        pane("idle", "workspace-a", "tab-idle", "idle"),
+        pane("blocked", "workspace-a", "tab-blocked", "blocked"),
+        pane("shell-b", "workspace-a", "tab-shell-b", "unknown"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+
+    expect(
+      buildVisibleTabEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "none",
+        new Set(),
+        false,
+        true,
+        "attention",
+      ).map((entry) => entry.tab.tab_id),
+    ).toEqual(["tab-blocked", "tab-idle", "tab-shell-a", "tab-shell-b"]);
+    expect(
+      buildVisibleTabEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "none",
+        new Set(),
+        false,
+        false,
+        "attention",
+      ).map((entry) => entry.tab.tab_id),
+    ).toEqual(["tab-shell-a", "tab-idle", "tab-blocked", "tab-shell-b"]);
+  });
+
+  it("sorts tabs by their most recently active agent pane", () => {
+    const snapshot = multiPaneSnapshot(
+      [workspace("workspace-a", 1)],
+      [
+        pane("agent-a-old", "workspace-a", "tab-a", "idle"),
+        pane("agent-a-new", "workspace-a", "tab-a", "idle"),
+        pane("agent-b", "workspace-a", "tab-b", "idle"),
+        pane("shell", "workspace-a", "tab-shell", "unknown"),
+      ],
+    );
+    const bridgeViews = [bridgeView("bridge-a", snapshot)];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "selected",
+      "all",
+      null,
+      {},
+    );
+    const activity = new Map([
+      [agentActivityKey("bridge-a", "agent-a-old", "agent-a-old-terminal"), 100],
+      [agentActivityKey("bridge-a", "agent-a-new", "agent-a-new-terminal"), 500],
+      [agentActivityKey("bridge-a", "agent-b", "agent-b-terminal"), 300],
+    ]);
+
+    expect(
+      buildVisibleTabEntries(
+        scopedWorkspaces,
+        bridgeViews,
+        "selected",
+        "none",
+        new Set(),
+        false,
+        true,
+        "lastStatusChange",
+        activity,
+      ).map((entry) => entry.tab.tab_id),
+    ).toEqual(["tab-a", "tab-b", "tab-shell"]);
   });
 
   it("filters tab entries to pinned panes", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7767,7 +7767,11 @@ export function agentSubtitle(
   bridgeLabel?: string,
 ) {
   const dir = basename(pane.foreground_cwd || pane.cwd);
-  return [bridgeLabel, workspace?.label, tabLabel, dir].filter(Boolean).join(" · ");
+  const customStateText =
+    pane.custom_status || pane.state_labels?.[statusLabel(pane.agent_status)];
+  return [bridgeLabel, workspace?.label, tabLabel, dir, customStateText]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function SplitGlyph() {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,6 +35,7 @@ import type {
   FormEvent as ReactFormEvent,
   KeyboardEvent as ReactKeyboardEvent,
   MutableRefObject,
+  ReactNode,
   SetStateAction,
 } from "react";
 import { Capacitor } from "@capacitor/core";
@@ -175,6 +176,7 @@ type HostScope = "selected" | "all";
 type SidebarView = "agents" | "tabs" | "notes";
 type AgentSort = "attention" | "status" | "workspace" | "lastStatusChange";
 type AgentGroup = "none" | "host" | "workspace" | "hostWorkspace";
+type SpaceGroup = "none" | "host";
 type MenuKind = "space" | "tab" | "pane";
 type ScopedPaneRef = {
   bridgeId: BridgeId;
@@ -319,6 +321,7 @@ type DisplayPrefs = {
   sidebarView: SidebarView;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
+  spaceGroup: SpaceGroup;
   agentPinnedOnly: boolean;
   agentActiveOnly: boolean;
   agentFeaturesInTabs: boolean;
@@ -375,6 +378,7 @@ function readDisplayPrefs(): DisplayPrefs {
     sidebarView: "agents",
     agentSort: "attention",
     agentGroup: "none",
+    spaceGroup: "none",
     agentPinnedOnly: false,
     agentActiveOnly: false,
     agentFeaturesInTabs: DEFAULT_AGENT_FEATURES_IN_TABS,
@@ -474,6 +478,10 @@ function parseDisplayPrefsValue(
       parsed.agentGroup === "hostWorkspace"
         ? parsed.agentGroup
         : fallback.agentGroup,
+    spaceGroup:
+      parsed.spaceGroup === "none" || parsed.spaceGroup === "host"
+        ? parsed.spaceGroup
+        : fallback.spaceGroup,
     agentPinnedOnly:
       typeof parsed.agentPinnedOnly === "boolean"
         ? parsed.agentPinnedOnly
@@ -776,6 +784,7 @@ export function App() {
   const [sidebarView, setSidebarView] = useState<SidebarView>(initialPrefs.sidebarView);
   const [agentSort, setAgentSort] = useState<AgentSort>(initialPrefs.agentSort);
   const [agentGroup, setAgentGroup] = useState<AgentGroup>(initialPrefs.agentGroup);
+  const [spaceGroup, setSpaceGroup] = useState<SpaceGroup>(initialPrefs.spaceGroup);
   const [agentPinnedOnly, setAgentPinnedOnly] = useState(initialPrefs.agentPinnedOnly);
   const [agentActiveOnly, setAgentActiveOnly] = useState(initialPrefs.agentActiveOnly);
   const [agentFeaturesInTabs, setAgentFeaturesInTabs] = useState(initialPrefs.agentFeaturesInTabs);
@@ -879,6 +888,7 @@ export function App() {
       setSidebarView(prefs.sidebarView);
       setAgentSort(prefs.agentSort);
       setAgentGroup(prefs.agentGroup);
+      setSpaceGroup(prefs.spaceGroup);
       setAgentPinnedOnly(prefs.agentPinnedOnly);
       setAgentActiveOnly(prefs.agentActiveOnly);
       setAgentFeaturesInTabs(prefs.agentFeaturesInTabs);
@@ -1361,6 +1371,7 @@ export function App() {
       sidebarView,
       agentSort,
       agentGroup,
+      spaceGroup,
       agentPinnedOnly,
       agentActiveOnly,
       agentFeaturesInTabs,
@@ -1397,6 +1408,7 @@ export function App() {
     sidebarView,
     agentSort,
     agentGroup,
+    spaceGroup,
     agentPinnedOnly,
     agentActiveOnly,
     agentFeaturesInTabs,
@@ -3226,6 +3238,7 @@ export function App() {
           agentFeaturesInTabs={agentFeaturesInTabs}
           agentSort={agentSort}
           agentGroup={agentGroup}
+          spaceGroup={spaceGroup}
           activeSpace={activeSpace}
           activeWorkspacesByBridgeId={activeWorkspacesByBridgeId}
           selectedPane={selectedPane}
@@ -3238,6 +3251,7 @@ export function App() {
           onAgentActiveOnly={setAgentActiveOnly}
           onAgentSort={setAgentSort}
           onAgentGroup={setAgentGroup}
+          onSpaceGroup={setSpaceGroup}
           onSelectBridge={setSelectedBridgeId}
           onSelectSpace={selectSpace}
           onSelectTab={selectTab}
@@ -3258,11 +3272,6 @@ export function App() {
           }
           onCreateTab={(bridgeId, workspaceId) =>
             setLaunchTarget({ mode: "tab", workspaceId, bridgeId })
-          }
-          onMenu={(kind, id, label, x, y, clearable) =>
-            selectedRuntime
-              ? setMenu({ kind, bridgeId: selectedRuntime.id, id, label, x, y, clearable })
-              : undefined
           }
           onScopedMenu={(kind, bridgeId, id, label, x, y, clearable, pinLabel) =>
             setMenu({ kind, bridgeId, id, label, x, y, clearable, pinLabel })
@@ -5101,6 +5110,7 @@ function Switcher({
   agentFeaturesInTabs,
   agentSort,
   agentGroup,
+  spaceGroup,
   activeSpace,
   activeWorkspacesByBridgeId,
   selectedPane,
@@ -5113,6 +5123,7 @@ function Switcher({
   onAgentActiveOnly,
   onAgentSort,
   onAgentGroup,
+  onSpaceGroup,
   onSelectBridge,
   onSelectSpace,
   onSelectTab,
@@ -5122,7 +5133,6 @@ function Switcher({
   onBackendSettings,
   onCreateSpace,
   onCreateTab,
-  onMenu,
   onScopedMenu,
 }: {
   bridgeViews: BridgeConnectionView[];
@@ -5148,6 +5158,7 @@ function Switcher({
   agentFeaturesInTabs: boolean;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
+  spaceGroup: SpaceGroup;
   activeSpace: WorkspaceInfo | null;
   activeWorkspacesByBridgeId: Record<string, string>;
   selectedPane: PaneInfo | null;
@@ -5160,6 +5171,7 @@ function Switcher({
   onAgentActiveOnly: (activeOnly: boolean) => void;
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
+  onSpaceGroup: (group: SpaceGroup) => void;
   onSelectBridge: (bridgeId: BridgeId) => void;
   onSelectSpace: (bridgeId: BridgeId, workspaceId: string) => void;
   onSelectTab: (bridgeId: BridgeId, tabId: string) => void;
@@ -5169,14 +5181,6 @@ function Switcher({
   onBackendSettings: () => void;
   onCreateSpace: () => void;
   onCreateTab: (bridgeId: BridgeId, workspaceId: string) => void;
-  onMenu: (
-    kind: MenuKind,
-    id: string,
-    label: string,
-    x: number,
-    y: number,
-    clearable?: boolean,
-  ) => void;
   onScopedMenu: (
     kind: MenuKind,
     bridgeId: BridgeId,
@@ -5189,6 +5193,7 @@ function Switcher({
   ) => void;
 }) {
   const [optionsMenu, setOptionsMenu] = useState<{ x: number; y: number } | null>(null);
+  const [spaceOptionsMenu, setSpaceOptionsMenu] = useState<{ x: number; y: number } | null>(null);
   const selectedBridgeView = selectedBridgeId
     ? (bridgeViews.find((view) => view.runtime.id === selectedBridgeId) ?? null)
     : null;
@@ -5197,6 +5202,30 @@ function Switcher({
     (view: BridgeConnectionView) =>
       activeWorkspaceForBridgeView(view, selectedBridgeId, activeSpace, activeWorkspacesByBridgeId),
     [activeSpace, activeWorkspacesByBridgeId, selectedBridgeId],
+  );
+  const spaceEntries = hostBridgeViews.flatMap((view) => {
+    const viewSnapshot = view.snapshot;
+    if (!viewSnapshot) {
+      return [];
+    }
+    const activeWorkspace = activeWorkspaceForView(view);
+    return viewSnapshot.workspaces.map((workspace) => {
+      const workspacePanes = viewSnapshot.panes.filter(
+        (pane) => pane.workspace_id === workspace.workspace_id,
+      );
+      return {
+        view,
+        workspace,
+        workspacePanes,
+        active: workspace.workspace_id === activeWorkspace?.workspace_id,
+      };
+    });
+  });
+  const canGroupSpacesByHost = shouldOfferSpaceHostGrouping(hostScope, hostBridgeViews.length);
+  const effectiveSpaceGroup = resolveEffectiveSpaceGroup(
+    spaceGroup,
+    hostScope,
+    hostBridgeViews.length,
   );
   const scopedWorkspaces = useMemo<ScopedWorkspace[]>(
     () =>
@@ -5320,10 +5349,7 @@ function Switcher({
       ),
     [agentActivityTransitions, agentFeaturesInTabs, agentSort, spaceGroups],
   );
-  const spaceCount = hostBridgeViews.reduce(
-    (count, view) => count + (view.snapshot?.workspaces.length ?? 0),
-    0,
-  );
+  const spaceCount = spaceEntries.length;
   const showGroupedHostContext = hostScope === "all";
   const showGroupControl =
     sidebarView !== "notes" &&
@@ -5351,6 +5377,12 @@ function Switcher({
       setOptionsMenu(null);
     }
   }, [optionsMenu, showOptionsControl]);
+
+  useEffect(() => {
+    if (spaceOptionsMenu && !canGroupSpacesByHost) {
+      setSpaceOptionsMenu(null);
+    }
+  }, [canGroupSpacesByHost, spaceOptionsMenu]);
 
   let agentPaneIndex = 0;
   let paneIndex = 0;
@@ -5628,6 +5660,33 @@ function Switcher({
       />
     ));
   };
+  const renderSpaceEntry = (
+    entry: (typeof spaceEntries)[number],
+    index: number,
+    showBridgeLabel: boolean,
+  ) => (
+    <SpaceRow
+      key={`${entry.view.runtime.id}:${entry.workspace.workspace_id}`}
+      index={index}
+      workspace={entry.workspace}
+      bridgeLabel={showBridgeLabel ? entry.view.runtime.label : undefined}
+      agentCount={entry.workspacePanes.filter(isAgentPane).length}
+      active={entry.active}
+      attention={countAttention(entry.workspacePanes)}
+      onSelect={() => onSelectSpace(entry.view.runtime.id, entry.workspace.workspace_id)}
+      onMenu={(x, y) =>
+        onScopedMenu(
+          "space",
+          entry.view.runtime.id,
+          entry.workspace.workspace_id,
+          entry.workspace.label,
+          x,
+          y,
+          canClearWorkspaceName(entry.workspace, entry.workspacePanes),
+        )
+      }
+    />
+  );
 
   return (
     <>
@@ -5795,75 +5854,48 @@ function Switcher({
                     <Plus size={14} />
                   </button>
                 ) : null}
+                {canGroupSpacesByHost ? (
+                  <button
+                    className="sec-add"
+                    type="button"
+                    aria-label="Space list options"
+                    title="Space list options"
+                    aria-haspopup="dialog"
+                    aria-expanded={spaceOptionsMenu ? "true" : "false"}
+                    onClick={(event) => {
+                      const rect = event.currentTarget.getBoundingClientRect();
+                      setOptionsMenu(null);
+                      setSpaceOptionsMenu({ x: rect.right, y: rect.bottom + 4 });
+                    }}
+                  >
+                    <MoreVertical size={14} />
+                  </button>
+                ) : null}
               </div>
               {spaceCount === 0 ? (
                 <div className="empty">
                   <strong>No spaces yet</strong>
                   <span>{hostScope === "selected" ? "Tap + to create one." : "No enabled host has spaces."}</span>
                 </div>
-              ) : hostScope === "all" ? (
+              ) : effectiveSpaceGroup === "host" ? (
                 hostBridgeViews.map((view) => {
-                  const viewSnapshot = view.snapshot;
-                  if (!viewSnapshot) {
+                  const entries = spaceEntries.filter(
+                    (entry) => entry.view.runtime.id === view.runtime.id,
+                  );
+                  if (entries.length === 0) {
                     return null;
                   }
-                  const activeWorkspace = activeWorkspaceForView(view);
                   return (
                     <Fragment key={view.runtime.id}>
                       <GroupHeader label={view.runtime.label} bridgeColor={view.runtime.color} />
-                      {viewSnapshot.workspaces.map((workspace, index) => (
-                        <SpaceRow
-                          key={`${view.runtime.id}:${workspace.workspace_id}`}
-                          index={index}
-                          workspace={workspace}
-                          active={workspace.workspace_id === activeWorkspace?.workspace_id}
-                          attention={countAttention(
-                            viewSnapshot.panes.filter(
-                              (pane) => pane.workspace_id === workspace.workspace_id,
-                            ),
-                          )}
-                          onSelect={() => onSelectSpace(view.runtime.id, workspace.workspace_id)}
-                          onMenu={(x, y) =>
-                            onScopedMenu(
-                              "space",
-                              view.runtime.id,
-                              workspace.workspace_id,
-                              workspace.label,
-                              x,
-                              y,
-                              canClearWorkspaceName(workspace, viewSnapshot.panes),
-                            )
-                          }
-                        />
-                      ))}
+                      {entries.map((entry, index) => renderSpaceEntry(entry, index, false))}
                     </Fragment>
                   );
                 })
               ) : (
-                snapshot?.workspaces.map((workspace, index) => (
-                  <SpaceRow
-                    key={workspace.workspace_id}
-                    index={index}
-                    workspace={workspace}
-                    active={workspace.workspace_id === activeSpace?.workspace_id}
-                    attention={countAttention(
-                      snapshot.panes.filter((pane) => pane.workspace_id === workspace.workspace_id),
-                    )}
-                    onSelect={() =>
-                      selectedBridgeId ? onSelectSpace(selectedBridgeId, workspace.workspace_id) : undefined
-                    }
-                    onMenu={(x, y) =>
-                      onMenu(
-                        "space",
-                        workspace.workspace_id,
-                        workspace.label,
-                        x,
-                        y,
-                        canClearWorkspaceName(workspace, snapshot.panes),
-                      )
-                    }
-                  />
-                )) ?? null
+                spaceEntries.map((entry, index) =>
+                  renderSpaceEntry(entry, index, canGroupSpacesByHost),
+                )
               )}
             </section>
             ) : null}
@@ -5951,6 +5983,7 @@ function Switcher({
                     aria-expanded={optionsMenu ? "true" : "false"}
                     onClick={(event) => {
                       const rect = event.currentTarget.getBoundingClientRect();
+                      setSpaceOptionsMenu(null);
                       setOptionsMenu({ x: rect.right, y: rect.bottom + 4 });
                     }}
                   >
@@ -6025,6 +6058,15 @@ function Switcher({
           onClose={() => setOptionsMenu(null)}
         />
       ) : null}
+      {spaceOptionsMenu ? (
+        <SpaceOptionsMenu
+          x={spaceOptionsMenu.x}
+          y={spaceOptionsMenu.y}
+          spaceGroup={spaceGroup}
+          onSpaceGroup={onSpaceGroup}
+          onClose={() => setSpaceOptionsMenu(null)}
+        />
+      ) : null}
     </>
   );
 }
@@ -6053,6 +6095,89 @@ function SidebarOptionsMenu({
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
   onClose: () => void;
+}) {
+  return (
+    <OptionsMenuShell
+      x={x}
+      y={y}
+      ariaLabel={`${sidebarView === "agents" ? "Agent" : "Tab"} list options`}
+      onClose={onClose}
+    >
+      {showSort ? (
+        <label className="sidebar-option-field">
+          <span>Sort</span>
+          <select
+            value={agentSort}
+            onChange={(event) => onAgentSort(event.currentTarget.value as AgentSort)}
+          >
+            <option value="attention">Attention</option>
+            <option value="status">Status</option>
+            {showLastStatusChangeSort ? (
+              <option value="lastStatusChange">Last status change</option>
+            ) : null}
+            <option value="workspace">Workspace</option>
+          </select>
+        </label>
+      ) : null}
+      {showGroup ? (
+        <label className="sidebar-option-field">
+          <span>Group</span>
+          <select
+            value={agentGroup}
+            onChange={(event) => onAgentGroup(event.currentTarget.value as AgentGroup)}
+          >
+            <option value="none">None</option>
+            <option value="host">Host</option>
+            <option value="workspace">Workspace</option>
+            <option value="hostWorkspace">Host + workspace</option>
+          </select>
+        </label>
+      ) : null}
+    </OptionsMenuShell>
+  );
+}
+
+function SpaceOptionsMenu({
+  x,
+  y,
+  spaceGroup,
+  onSpaceGroup,
+  onClose,
+}: {
+  x: number;
+  y: number;
+  spaceGroup: SpaceGroup;
+  onSpaceGroup: (group: SpaceGroup) => void;
+  onClose: () => void;
+}) {
+  return (
+    <OptionsMenuShell x={x} y={y} ariaLabel="Space list options" onClose={onClose}>
+      <label className="sidebar-option-field">
+        <span>Group</span>
+        <select
+          value={spaceGroup}
+          onChange={(event) => onSpaceGroup(event.currentTarget.value as SpaceGroup)}
+        >
+          <option value="none">None</option>
+          <option value="host">Host</option>
+        </select>
+      </label>
+    </OptionsMenuShell>
+  );
+}
+
+function OptionsMenuShell({
+  x,
+  y,
+  ariaLabel,
+  onClose,
+  children,
+}: {
+  x: number;
+  y: number;
+  ariaLabel: string;
+  onClose: () => void;
+  children: ReactNode;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
@@ -6105,7 +6230,7 @@ function SidebarOptionsMenu({
         ref={ref}
         className="sidebar-options-menu"
         role="dialog"
-        aria-label={`${sidebarView === "agents" ? "Agent" : "Tab"} list options`}
+        aria-label={ariaLabel}
         tabIndex={-1}
         style={{
           left: pos?.left ?? x,
@@ -6113,36 +6238,7 @@ function SidebarOptionsMenu({
           visibility: pos ? "visible" : "hidden",
         }}
       >
-        {showSort ? (
-          <label className="sidebar-option-field">
-            <span>Sort</span>
-            <select
-              value={agentSort}
-              onChange={(event) => onAgentSort(event.currentTarget.value as AgentSort)}
-            >
-              <option value="attention">Attention</option>
-              <option value="status">Status</option>
-              {showLastStatusChangeSort ? (
-                <option value="lastStatusChange">Last status change</option>
-              ) : null}
-              <option value="workspace">Workspace</option>
-            </select>
-          </label>
-        ) : null}
-        {showGroup ? (
-          <label className="sidebar-option-field">
-            <span>Group</span>
-            <select
-              value={agentGroup}
-              onChange={(event) => onAgentGroup(event.currentTarget.value as AgentGroup)}
-            >
-              <option value="none">None</option>
-              <option value="host">Host</option>
-              <option value="workspace">Workspace</option>
-              <option value="hostWorkspace">Host + workspace</option>
-            </select>
-          </label>
-        ) : null}
+        {children}
       </div>
     </div>
   );
@@ -7132,6 +7228,8 @@ function GroupHeader({
 
 function SpaceRow({
   workspace,
+  bridgeLabel,
+  agentCount,
   active,
   attention,
   index,
@@ -7139,6 +7237,8 @@ function SpaceRow({
   onMenu,
 }: {
   workspace: WorkspaceInfo;
+  bridgeLabel?: string;
+  agentCount: number;
   active: boolean;
   attention: number;
   index: number;
@@ -7157,7 +7257,9 @@ function SpaceRow({
       <span className="dot" data-status={workspace.agent_status} />
       <span className="space-body">
         <span className="space-name">{workspace.label}</span>
-        <span className="space-sub mono">{spaceSubtitle(workspace)}</span>
+        <span className="space-sub mono">
+          {spaceSubtitle(workspace, bridgeLabel, agentCount)}
+        </span>
       </span>
       {attention > 0 ? <span className="attn">{attention}</span> : null}
     </button>
@@ -7524,6 +7626,18 @@ export function shouldShowSidebarSort(
   agentFeaturesInTabs: boolean,
 ) {
   return sidebarView === "agents" || (sidebarView === "tabs" && agentFeaturesInTabs);
+}
+
+export function shouldOfferSpaceHostGrouping(hostScope: HostScope, hostCount: number) {
+  return hostScope === "all" && hostCount > 1;
+}
+
+export function resolveEffectiveSpaceGroup(
+  spaceGroup: SpaceGroup,
+  hostScope: HostScope,
+  hostCount: number,
+): SpaceGroup {
+  return shouldOfferSpaceHostGrouping(hostScope, hostCount) ? spaceGroup : "none";
 }
 
 export function canAddNoteFromPaneMenu({

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -70,10 +70,12 @@ import {
   DEFAULT_CONTENT_INSET_TOP_PX,
   DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
   DEFAULT_AGENT_FEATURES_IN_TABS,
+  DEFAULT_MULTI_HOST_SPACE_SELECTION,
   parseContentInsetBottomPx,
   parseContentInsetTopPx,
   parseMobileControlsScalePercent,
   parseAgentFeaturesInTabs,
+  parseMultiHostSpaceSelection,
 } from "./displayPrefs";
 import { LaunchDialog } from "./LaunchDialog";
 import { resolveLaunchSpec } from "./launch";
@@ -325,6 +327,7 @@ type DisplayPrefs = {
   agentPinnedOnly: boolean;
   agentActiveOnly: boolean;
   agentFeaturesInTabs: boolean;
+  multiHostSpaceSelection: boolean;
   sidebarWidth: number;
   notesPanelWidth: number;
   notesListPaneWidth: number;
@@ -382,6 +385,7 @@ function readDisplayPrefs(): DisplayPrefs {
     agentPinnedOnly: false,
     agentActiveOnly: false,
     agentFeaturesInTabs: DEFAULT_AGENT_FEATURES_IN_TABS,
+    multiHostSpaceSelection: DEFAULT_MULTI_HOST_SPACE_SELECTION,
     sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
     notesPanelWidth: DEFAULT_NOTES_PANEL_WIDTH,
     notesListPaneWidth: DEFAULT_NOTES_LIST_PANE_WIDTH,
@@ -493,6 +497,10 @@ function parseDisplayPrefsValue(
     agentFeaturesInTabs: parseAgentFeaturesInTabs(
       parsed.agentFeaturesInTabs,
       fallback.agentFeaturesInTabs,
+    ),
+    multiHostSpaceSelection: parseMultiHostSpaceSelection(
+      parsed.multiHostSpaceSelection,
+      fallback.multiHostSpaceSelection,
     ),
     sidebarWidth,
     notesPanelWidth,
@@ -788,6 +796,9 @@ export function App() {
   const [agentPinnedOnly, setAgentPinnedOnly] = useState(initialPrefs.agentPinnedOnly);
   const [agentActiveOnly, setAgentActiveOnly] = useState(initialPrefs.agentActiveOnly);
   const [agentFeaturesInTabs, setAgentFeaturesInTabs] = useState(initialPrefs.agentFeaturesInTabs);
+  const [multiHostSpaceSelection, setMultiHostSpaceSelection] = useState(
+    initialPrefs.multiHostSpaceSelection,
+  );
   const [sidebarWidth, setSidebarWidth] = useState(initialPrefs.sidebarWidth);
   const [notesPanelWidth, setNotesPanelWidth] = useState(initialPrefs.notesPanelWidth);
   const [notesListPaneWidth, setNotesListPaneWidth] = useState(initialPrefs.notesListPaneWidth);
@@ -892,6 +903,7 @@ export function App() {
       setAgentPinnedOnly(prefs.agentPinnedOnly);
       setAgentActiveOnly(prefs.agentActiveOnly);
       setAgentFeaturesInTabs(prefs.agentFeaturesInTabs);
+      setMultiHostSpaceSelection(prefs.multiHostSpaceSelection);
       setSidebarWidth(prefs.sidebarWidth);
       setNotesPanelWidth(prefs.notesPanelWidth);
       setNotesListPaneWidth(prefs.notesListPaneWidth);
@@ -1375,6 +1387,7 @@ export function App() {
       agentPinnedOnly,
       agentActiveOnly,
       agentFeaturesInTabs,
+      multiHostSpaceSelection,
       sidebarWidth,
       notesPanelWidth,
       notesListPaneWidth,
@@ -1412,6 +1425,7 @@ export function App() {
     agentPinnedOnly,
     agentActiveOnly,
     agentFeaturesInTabs,
+    multiHostSpaceSelection,
     sidebarWidth,
     notesPanelWidth,
     notesListPaneWidth,
@@ -1781,6 +1795,7 @@ export function App() {
         scope,
         activeSpace,
         activeWorkspacesByBridgeId,
+        multiHostSpaceSelection,
         notesIncludeArchived,
         notesIncludeDeleted,
       );
@@ -1790,6 +1805,7 @@ export function App() {
       activeWorkspacesByBridgeId,
       bridgeViews,
       hostScope,
+      multiHostSpaceSelection,
       notesEnabled,
       notesStates,
       notesIncludeArchived,
@@ -1811,6 +1827,7 @@ export function App() {
         "all",
         null,
         {},
+        true,
         true,
         true,
         false,
@@ -2565,6 +2582,7 @@ export function App() {
             scope,
             activeSpace,
             activeWorkspacesByBridgeId,
+            multiHostSpaceSelection,
           ),
           bridgeViews,
           hostScope,
@@ -2606,6 +2624,7 @@ export function App() {
           scope,
           activeSpace,
           activeWorkspacesByBridgeId,
+          multiHostSpaceSelection,
         ),
         bridgeViews,
         hostScope,
@@ -2659,6 +2678,7 @@ export function App() {
     isCompactLayout,
     launchTarget,
     menu,
+    multiHostSpaceSelection,
     paneFocusSupported,
     pinnedAgentKeys,
     scope,
@@ -3239,6 +3259,7 @@ export function App() {
           agentSort={agentSort}
           agentGroup={agentGroup}
           spaceGroup={spaceGroup}
+          multiHostSpaceSelection={multiHostSpaceSelection}
           activeSpace={activeSpace}
           activeWorkspacesByBridgeId={activeWorkspacesByBridgeId}
           selectedPane={selectedPane}
@@ -3722,6 +3743,8 @@ export function App() {
           onNotesEnabled={setNotesEnabled}
           agentFeaturesInTabs={agentFeaturesInTabs}
           onAgentFeaturesInTabs={setAgentFeaturesInTabs}
+          multiHostSpaceSelection={multiHostSpaceSelection}
+          onMultiHostSpaceSelection={setMultiHostSpaceSelection}
           terminalFontSizePx={terminalFontSizePx}
           onTerminalFontSizePx={setTerminalFontSizePx}
           terminalInputTransport={terminalInputTransport}
@@ -4069,9 +4092,13 @@ export function activeWorkspaceForBridgeView(
   selectedBridgeId: BridgeId | null,
   activeSpace: WorkspaceInfo | null,
   activeWorkspacesByBridgeId: Record<string, string>,
+  multiHostSpaceSelection = true,
 ) {
   const viewSnapshot = view.snapshot;
   if (!viewSnapshot || viewSnapshot.workspaces.length === 0) {
+    return null;
+  }
+  if (!multiHostSpaceSelection && view.runtime.id !== selectedBridgeId) {
     return null;
   }
   const preferredWorkspaceId =
@@ -4153,6 +4180,7 @@ export function buildVisibleScopedWorkspaces(
   scope: Scope,
   activeSpace: WorkspaceInfo | null,
   activeWorkspacesByBridgeId: Record<string, string>,
+  multiHostSpaceSelection = true,
 ): ScopedWorkspace[] {
   const hostBridgeViews = visibleHostBridgeViews(bridgeViews, selectedBridgeId, hostScope);
   return hostBridgeViews.flatMap((view) => {
@@ -4173,6 +4201,7 @@ export function buildVisibleScopedWorkspaces(
               selectedBridgeId,
               activeSpace,
               activeWorkspacesByBridgeId,
+              multiHostSpaceSelection,
             ),
           ].filter((workspace): workspace is WorkspaceInfo => workspace !== null);
     return workspaces.map((workspace) => ({
@@ -4471,12 +4500,20 @@ export function buildVisibleScopedNotes(
   scope: Scope,
   activeSpace: WorkspaceInfo | null,
   activeWorkspacesByBridgeId: Record<string, string>,
+  multiHostSpaceSelection: boolean,
   includeArchived: boolean,
   includeDeleted: boolean,
   dedupeStores = true,
 ): ScopedNoteEntry[] {
   const hostBridgeViews = visibleHostBridgeViews(bridgeViews, selectedBridgeId, hostScope);
   const entries = hostBridgeViews.flatMap((view) => {
+    if (
+      scope === "space" &&
+      !multiHostSpaceSelection &&
+      view.runtime.id !== selectedBridgeId
+    ) {
+      return [];
+    }
     const notesState = notesStates[view.runtime.id];
     if (!notesState || notesState.connectionKey !== view.runtime.connectionKey) {
       return [];
@@ -4493,6 +4530,7 @@ export function buildVisibleScopedNotes(
             selectedBridgeId,
             activeSpace,
             activeWorkspacesByBridgeId,
+            multiHostSpaceSelection,
           )
         : null;
     return (notesState.response?.notes ?? [])
@@ -5111,6 +5149,7 @@ function Switcher({
   agentSort,
   agentGroup,
   spaceGroup,
+  multiHostSpaceSelection,
   activeSpace,
   activeWorkspacesByBridgeId,
   selectedPane,
@@ -5159,6 +5198,7 @@ function Switcher({
   agentSort: AgentSort;
   agentGroup: AgentGroup;
   spaceGroup: SpaceGroup;
+  multiHostSpaceSelection: boolean;
   activeSpace: WorkspaceInfo | null;
   activeWorkspacesByBridgeId: Record<string, string>;
   selectedPane: PaneInfo | null;
@@ -5200,8 +5240,19 @@ function Switcher({
   const hostBridgeViews = visibleHostBridgeViews(bridgeViews, selectedBridgeId, hostScope);
   const activeWorkspaceForView = useCallback(
     (view: BridgeConnectionView) =>
-      activeWorkspaceForBridgeView(view, selectedBridgeId, activeSpace, activeWorkspacesByBridgeId),
-    [activeSpace, activeWorkspacesByBridgeId, selectedBridgeId],
+      activeWorkspaceForBridgeView(
+        view,
+        selectedBridgeId,
+        activeSpace,
+        activeWorkspacesByBridgeId,
+        multiHostSpaceSelection,
+      ),
+    [
+      activeSpace,
+      activeWorkspacesByBridgeId,
+      multiHostSpaceSelection,
+      selectedBridgeId,
+    ],
   );
   const spaceEntries = hostBridgeViews.flatMap((view) => {
     const viewSnapshot = view.snapshot;
@@ -5236,8 +5287,17 @@ function Switcher({
         scope,
         activeSpace,
         activeWorkspacesByBridgeId,
+        multiHostSpaceSelection,
       ),
-    [activeSpace, activeWorkspacesByBridgeId, bridgeViews, hostScope, scope, selectedBridgeId],
+    [
+      activeSpace,
+      activeWorkspacesByBridgeId,
+      bridgeViews,
+      hostScope,
+      multiHostSpaceSelection,
+      scope,
+      selectedBridgeId,
+    ],
   );
   const panes = scopedWorkspaces.flatMap((entry) =>
     entry.snapshot.panes.filter((pane) => pane.workspace_id === entry.workspace.workspace_id),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4311,37 +4311,39 @@ export function buildVisibleTabWorkspaceGroups(
   agentActivityTransitions: ReadonlyMap<string, number> = EMPTY_AGENT_ACTIVITY_TRANSITIONS,
   activeOnly = false,
 ): ScopedTabWorkspace[] {
-  return scopedWorkspaces.map((entry) => {
-    const tabs = sortTabsForWorkspace(entry.snapshot.tabs, entry.workspace.workspace_id)
-      .map((tab) => {
-        const panes = sortPanesForTab(entry.snapshot.panes, tab.tab_id);
-        const pinnedPanes = pinnedOnly
-          ? panes.filter((pane) => isAgentPinned(pinnedAgentKeys, entry.bridgeId, pane.pane_id))
-          : panes;
-        return {
-          tab,
-          panes:
-            agentFeaturesInTabs && activeOnly
-              ? pinnedPanes.filter(
-                  (pane) => isAgentPane(pane) && isActiveAgentStatus(pane.agent_status),
-                )
-              : pinnedPanes,
-        };
-      })
-      .filter((group) => group.panes.length > 0);
-    if (!agentFeaturesInTabs) {
-      return { ...entry, tabs };
-    }
-    const sorted = sortScopedTabEntriesByAgents(
-      tabs.map(({ tab, panes }) => ({ ...entry, tab, panes })),
-      agentSort,
-      agentActivityTransitions,
-    );
-    return {
-      ...entry,
-      tabs: sorted.map(({ tab, panes }) => ({ tab, panes })),
-    };
-  });
+  return scopedWorkspaces
+    .map((entry) => {
+      const tabs = sortTabsForWorkspace(entry.snapshot.tabs, entry.workspace.workspace_id)
+        .map((tab) => {
+          const panes = sortPanesForTab(entry.snapshot.panes, tab.tab_id);
+          const pinnedPanes = pinnedOnly
+            ? panes.filter((pane) => isAgentPinned(pinnedAgentKeys, entry.bridgeId, pane.pane_id))
+            : panes;
+          return {
+            tab,
+            panes:
+              agentFeaturesInTabs && activeOnly
+                ? pinnedPanes.filter(
+                    (pane) => isAgentPane(pane) && isActiveAgentStatus(pane.agent_status),
+                  )
+                : pinnedPanes,
+          };
+        })
+        .filter((group) => group.panes.length > 0);
+      if (!agentFeaturesInTabs) {
+        return { ...entry, tabs };
+      }
+      const sorted = sortScopedTabEntriesByAgents(
+        tabs.map(({ tab, panes }) => ({ ...entry, tab, panes })),
+        agentSort,
+        agentActivityTransitions,
+      );
+      return {
+        ...entry,
+        tabs: sorted.map(({ tab, panes }) => ({ tab, panes })),
+      };
+    })
+    .filter((group) => group.tabs.length > 0);
 }
 
 export function buildVisibleTabEntries(
@@ -5375,6 +5377,7 @@ function Switcher({
         const paneRows = tabPanes.map((pane) => {
           const index = paneIndex++;
           const pinned = isAgentPinned(pinnedAgentKeys, group.bridgeId, pane.pane_id);
+          const renderAsAgent = shouldRenderAgentRowInTabs(pane, agentFeaturesInTabs);
           const active =
             group.bridgeId === selectedBridgeId && pane.pane_id === selectedPane?.pane_id;
           const onSelect = () => onSelectPane(group.bridgeId, pane);
@@ -5387,9 +5390,9 @@ function Switcher({
               x,
               y,
               undefined,
-              "pane",
+              renderAsAgent ? "agent" : "pane",
             );
-          if (shouldRenderAgentRowInTabs(pane, agentFeaturesInTabs)) {
+          if (renderAsAgent) {
             return (
               <AgentRow
                 key={`${group.bridgeId}:${pane.pane_id}`}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2603,6 +2603,7 @@ export function App() {
         sidebarView === "tabs" && agentFeaturesInTabs,
         agentSort,
         agentActivityTransitions,
+        sidebarView === "tabs" && agentFeaturesInTabs && agentActiveOnly,
       );
       const tabs = tabEntries;
       if (tabs.length === 0) {
@@ -4308,16 +4309,23 @@ export function buildVisibleTabWorkspaceGroups(
   agentFeaturesInTabs = false,
   agentSort: AgentSort = "workspace",
   agentActivityTransitions: ReadonlyMap<string, number> = EMPTY_AGENT_ACTIVITY_TRANSITIONS,
+  activeOnly = false,
 ): ScopedTabWorkspace[] {
   return scopedWorkspaces.map((entry) => {
     const tabs = sortTabsForWorkspace(entry.snapshot.tabs, entry.workspace.workspace_id)
       .map((tab) => {
         const panes = sortPanesForTab(entry.snapshot.panes, tab.tab_id);
+        const pinnedPanes = pinnedOnly
+          ? panes.filter((pane) => isAgentPinned(pinnedAgentKeys, entry.bridgeId, pane.pane_id))
+          : panes;
         return {
           tab,
-          panes: pinnedOnly
-            ? panes.filter((pane) => isAgentPinned(pinnedAgentKeys, entry.bridgeId, pane.pane_id))
-            : panes,
+          panes:
+            agentFeaturesInTabs && activeOnly
+              ? pinnedPanes.filter(
+                  (pane) => isAgentPane(pane) && isActiveAgentStatus(pane.agent_status),
+                )
+              : pinnedPanes,
         };
       })
       .filter((group) => group.panes.length > 0);
@@ -4346,6 +4354,7 @@ export function buildVisibleTabEntries(
   agentFeaturesInTabs = false,
   agentSort: AgentSort = "workspace",
   agentActivityTransitions: ReadonlyMap<string, number> = EMPTY_AGENT_ACTIVITY_TRANSITIONS,
+  activeOnly = false,
 ): ScopedTabEntry[] {
   const spaceGroups = buildVisibleTabWorkspaceGroups(
     scopedWorkspaces,
@@ -4354,6 +4363,7 @@ export function buildVisibleTabEntries(
     agentFeaturesInTabs,
     agentSort,
     agentActivityTransitions,
+    activeOnly,
   );
   const flattenGroup = (group: ScopedTabWorkspace): ScopedTabEntry[] =>
     group.tabs.map(({ tab, panes }) => ({ ...group, tab, panes }));
@@ -4364,11 +4374,15 @@ export function buildVisibleTabEntries(
       agentActivityTransitions,
     );
   }
-  if (agentGroup === "host" || (agentGroup === "hostWorkspace" && hostScope === "all")) {
+  if (agentGroup === "host") {
     return bridgeViews.flatMap((view) =>
-      spaceGroups
-        .filter((group) => group.bridgeId === view.runtime.id && group.tabs.length > 0)
-        .flatMap(flattenGroup),
+      sortScopedTabEntriesByAgents(
+        spaceGroups
+          .filter((group) => group.bridgeId === view.runtime.id && group.tabs.length > 0)
+          .flatMap(flattenGroup),
+        agentFeaturesInTabs ? agentSort : "workspace",
+        agentActivityTransitions,
+      ),
     );
   }
   return spaceGroups.flatMap(flattenGroup);
@@ -5276,9 +5290,11 @@ function Switcher({
         sidebarView === "tabs" && agentFeaturesInTabs,
         agentSort,
         agentActivityTransitions,
+        sidebarView === "tabs" && agentFeaturesInTabs && agentActiveOnly,
       ),
     [
       agentActivityTransitions,
+      agentActiveOnly,
       agentFeaturesInTabs,
       agentSort,
       effectiveAgentPinnedOnly,
@@ -5324,7 +5340,8 @@ function Switcher({
   const canCreateNoteFromHeader = notesViewActive && notesSupported;
   const showPinnedOnlyControl =
     (sidebarView === "agents" || sidebarView === "tabs") && agentPinsSupported;
-  const showActiveOnlyControl = sidebarView === "agents";
+  const showActiveOnlyControl =
+    sidebarView === "agents" || (sidebarView === "tabs" && agentFeaturesInTabs);
   const pinnedOnlyLabel = sidebarView === "tabs" ? "pinned panes" : "pinned agents";
 
   useEffect(() => {
@@ -5395,8 +5412,14 @@ function Switcher({
               key={`${group.bridgeId}:${pane.pane_id}`}
               index={index}
               pane={pane}
-              workspaceLabel={agentGroup === "none" ? group.workspace.label : undefined}
-              tabLabel={agentGroup === "none" ? tabLabel : undefined}
+              workspaceLabel={
+                agentGroup === "none" || agentGroup === "host"
+                  ? group.workspace.label
+                  : undefined
+              }
+              tabLabel={
+                agentGroup === "none" || agentGroup === "host" ? tabLabel : undefined
+              }
               bridgeLabel={
                 agentGroup === "none" && hostScope === "all" ? group.bridgeLabel : undefined
               }
@@ -5437,7 +5460,34 @@ function Switcher({
     </Fragment>
   );
   const renderTabGroups = () => {
-    if (agentGroup === "host" || (agentGroup === "hostWorkspace" && hostScope === "all")) {
+    if (agentGroup === "host") {
+      return hostBridgeViews.map((view) => {
+        const entries = flatTabEntries.filter(
+          (entry) => entry.bridgeId === view.runtime.id && entry.panes.length > 0,
+        );
+        if (entries.length === 0) {
+          return null;
+        }
+        return (
+          <Fragment key={view.runtime.id}>
+            <GroupHeader label={view.runtime.label} bridgeColor={view.runtime.color} />
+            {entries.map((entry) =>
+              renderTabWorkspaceGroup(
+                {
+                  ...entry,
+                  tabs: [{ tab: entry.tab, panes: entry.panes }],
+                },
+                false,
+                false,
+                `${entry.bridgeId}:${entry.tab.tab_id}`,
+              ),
+            )}
+          </Fragment>
+        );
+      });
+    }
+
+    if (agentGroup === "hostWorkspace" && hostScope === "all") {
       return hostBridgeViews.map((view) => {
         const groups = spaceGroups.filter(
           (group) => group.bridgeId === view.runtime.id && group.tabs.length > 0,
@@ -5879,8 +5929,8 @@ function Switcher({
                   <button
                     className="sec-add sec-add-active"
                     type="button"
-                    aria-label="Show active statuses only"
-                    title="Active statuses only"
+                    aria-label={`Show active ${sidebarView === "tabs" ? "agents" : "statuses"} only`}
+                    title={sidebarView === "tabs" ? "Active agents only" : "Active statuses only"}
                     aria-pressed={agentActiveOnly}
                     data-on={agentActiveOnly}
                     onClick={() => onAgentActiveOnly(!agentActiveOnly)}
@@ -5933,9 +5983,15 @@ function Switcher({
                   <>{renderDisconnectedBridgeRows()}</>
                 ) : (
                 <div className="empty">
-                  <strong>{effectiveAgentPinnedOnly ? "No pinned panes" : "No panes"}</strong>
+                  <strong>
+                    {agentFeaturesInTabs && agentActiveOnly
+                      ? emptyAgentListTitle(effectiveAgentPinnedOnly, true)
+                      : effectiveAgentPinnedOnly
+                        ? "No pinned panes"
+                        : "No panes"}
+                  </strong>
                   <span>
-                    {effectiveAgentPinnedOnly
+                    {effectiveAgentPinnedOnly || (agentFeaturesInTabs && agentActiveOnly)
                       ? ""
                       : scope === "space"
                         ? "This space has no panes yet."

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,9 +68,11 @@ import {
   DEFAULT_CONTENT_INSET_BOTTOM_PX,
   DEFAULT_CONTENT_INSET_TOP_PX,
   DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
+  DEFAULT_AGENT_FEATURES_IN_TABS,
   parseContentInsetBottomPx,
   parseContentInsetTopPx,
   parseMobileControlsScalePercent,
+  parseAgentFeaturesInTabs,
 } from "./displayPrefs";
 import { LaunchDialog } from "./LaunchDialog";
 import { resolveLaunchSpec } from "./launch";
@@ -150,6 +152,7 @@ import {
   isAttention,
   isLoud,
   paneMeta,
+  paneListSubtitle,
   paneTitle,
   sortPanesForTab,
   sortTabsForWorkspace,
@@ -318,6 +321,7 @@ type DisplayPrefs = {
   agentGroup: AgentGroup;
   agentPinnedOnly: boolean;
   agentActiveOnly: boolean;
+  agentFeaturesInTabs: boolean;
   sidebarWidth: number;
   notesPanelWidth: number;
   notesListPaneWidth: number;
@@ -373,6 +377,7 @@ function readDisplayPrefs(): DisplayPrefs {
     agentGroup: "none",
     agentPinnedOnly: false,
     agentActiveOnly: false,
+    agentFeaturesInTabs: DEFAULT_AGENT_FEATURES_IN_TABS,
     sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
     notesPanelWidth: DEFAULT_NOTES_PANEL_WIDTH,
     notesListPaneWidth: DEFAULT_NOTES_LIST_PANE_WIDTH,
@@ -477,6 +482,10 @@ function parseDisplayPrefsValue(
       typeof parsed.agentActiveOnly === "boolean"
         ? parsed.agentActiveOnly
         : fallback.agentActiveOnly,
+    agentFeaturesInTabs: parseAgentFeaturesInTabs(
+      parsed.agentFeaturesInTabs,
+      fallback.agentFeaturesInTabs,
+    ),
     sidebarWidth,
     notesPanelWidth,
     notesListPaneWidth:
@@ -769,6 +778,7 @@ export function App() {
   const [agentGroup, setAgentGroup] = useState<AgentGroup>(initialPrefs.agentGroup);
   const [agentPinnedOnly, setAgentPinnedOnly] = useState(initialPrefs.agentPinnedOnly);
   const [agentActiveOnly, setAgentActiveOnly] = useState(initialPrefs.agentActiveOnly);
+  const [agentFeaturesInTabs, setAgentFeaturesInTabs] = useState(initialPrefs.agentFeaturesInTabs);
   const [sidebarWidth, setSidebarWidth] = useState(initialPrefs.sidebarWidth);
   const [notesPanelWidth, setNotesPanelWidth] = useState(initialPrefs.notesPanelWidth);
   const [notesListPaneWidth, setNotesListPaneWidth] = useState(initialPrefs.notesListPaneWidth);
@@ -871,6 +881,7 @@ export function App() {
       setAgentGroup(prefs.agentGroup);
       setAgentPinnedOnly(prefs.agentPinnedOnly);
       setAgentActiveOnly(prefs.agentActiveOnly);
+      setAgentFeaturesInTabs(prefs.agentFeaturesInTabs);
       setSidebarWidth(prefs.sidebarWidth);
       setNotesPanelWidth(prefs.notesPanelWidth);
       setNotesListPaneWidth(prefs.notesListPaneWidth);
@@ -1352,6 +1363,7 @@ export function App() {
       agentGroup,
       agentPinnedOnly,
       agentActiveOnly,
+      agentFeaturesInTabs,
       sidebarWidth,
       notesPanelWidth,
       notesListPaneWidth,
@@ -1387,6 +1399,7 @@ export function App() {
     agentGroup,
     agentPinnedOnly,
     agentActiveOnly,
+    agentFeaturesInTabs,
     sidebarWidth,
     notesPanelWidth,
     notesListPaneWidth,
@@ -2587,6 +2600,9 @@ export function App() {
         agentGroup,
         pinnedAgentKeys,
         sidebarView === "tabs" && effectiveAgentPinnedOnly,
+        sidebarView === "tabs" && agentFeaturesInTabs,
+        agentSort,
+        agentActivityTransitions,
       );
       const tabs = tabEntries;
       if (tabs.length === 0) {
@@ -2619,6 +2635,7 @@ export function App() {
     activeWorkspacesByBridgeId,
     agentActivityTransitions,
     agentActiveOnly,
+    agentFeaturesInTabs,
     effectiveAgentPinnedOnly,
     agentGroup,
     agentSort,
@@ -3205,6 +3222,7 @@ export function App() {
           pinnedAgentKeys={pinnedAgentKeys}
           agentPinnedOnly={agentPinnedOnly}
           agentActiveOnly={agentActiveOnly}
+          agentFeaturesInTabs={agentFeaturesInTabs}
           agentSort={agentSort}
           agentGroup={agentGroup}
           activeSpace={activeSpace}
@@ -3692,6 +3710,8 @@ export function App() {
           showMobileTerminalSettings={isTouchInput}
           notesEnabled={notesEnabled}
           onNotesEnabled={setNotesEnabled}
+          agentFeaturesInTabs={agentFeaturesInTabs}
+          onAgentFeaturesInTabs={setAgentFeaturesInTabs}
           terminalFontSizePx={terminalFontSizePx}
           onTerminalFontSizePx={setTerminalFontSizePx}
           terminalInputTransport={terminalInputTransport}
@@ -4285,10 +4305,12 @@ export function buildVisibleTabWorkspaceGroups(
   scopedWorkspaces: ScopedWorkspace[],
   pinnedAgentKeys: ReadonlySet<string> = EMPTY_AGENT_PIN_KEYS,
   pinnedOnly = false,
+  agentFeaturesInTabs = false,
+  agentSort: AgentSort = "workspace",
+  agentActivityTransitions: ReadonlyMap<string, number> = EMPTY_AGENT_ACTIVITY_TRANSITIONS,
 ): ScopedTabWorkspace[] {
-  return scopedWorkspaces.map((entry) => ({
-    ...entry,
-    tabs: sortTabsForWorkspace(entry.snapshot.tabs, entry.workspace.workspace_id)
+  return scopedWorkspaces.map((entry) => {
+    const tabs = sortTabsForWorkspace(entry.snapshot.tabs, entry.workspace.workspace_id)
       .map((tab) => {
         const panes = sortPanesForTab(entry.snapshot.panes, tab.tab_id);
         return {
@@ -4298,8 +4320,20 @@ export function buildVisibleTabWorkspaceGroups(
             : panes,
         };
       })
-      .filter((group) => group.panes.length > 0),
-  }));
+      .filter((group) => group.panes.length > 0);
+    if (!agentFeaturesInTabs) {
+      return { ...entry, tabs };
+    }
+    const sorted = sortScopedTabEntriesByAgents(
+      tabs.map(({ tab, panes }) => ({ ...entry, tab, panes })),
+      agentSort,
+      agentActivityTransitions,
+    );
+    return {
+      ...entry,
+      tabs: sorted.map(({ tab, panes }) => ({ tab, panes })),
+    };
+  });
 }
 
 export function buildVisibleTabEntries(
@@ -4309,10 +4343,27 @@ export function buildVisibleTabEntries(
   agentGroup: AgentGroup,
   pinnedAgentKeys: ReadonlySet<string> = EMPTY_AGENT_PIN_KEYS,
   pinnedOnly = false,
+  agentFeaturesInTabs = false,
+  agentSort: AgentSort = "workspace",
+  agentActivityTransitions: ReadonlyMap<string, number> = EMPTY_AGENT_ACTIVITY_TRANSITIONS,
 ): ScopedTabEntry[] {
-  const spaceGroups = buildVisibleTabWorkspaceGroups(scopedWorkspaces, pinnedAgentKeys, pinnedOnly);
+  const spaceGroups = buildVisibleTabWorkspaceGroups(
+    scopedWorkspaces,
+    pinnedAgentKeys,
+    pinnedOnly,
+    agentFeaturesInTabs,
+    agentSort,
+    agentActivityTransitions,
+  );
   const flattenGroup = (group: ScopedTabWorkspace): ScopedTabEntry[] =>
     group.tabs.map(({ tab, panes }) => ({ ...group, tab, panes }));
+  if (agentFeaturesInTabs && agentGroup === "none") {
+    return sortScopedTabEntriesByAgents(
+      spaceGroups.flatMap(flattenGroup),
+      agentSort,
+      agentActivityTransitions,
+    );
+  }
   if (agentGroup === "host" || (agentGroup === "hostWorkspace" && hostScope === "all")) {
     return bridgeViews.flatMap((view) =>
       spaceGroups
@@ -4321,6 +4372,70 @@ export function buildVisibleTabEntries(
     );
   }
   return spaceGroups.flatMap(flattenGroup);
+}
+
+export function sortScopedTabEntriesByAgents(
+  entries: ScopedTabEntry[],
+  agentSort: AgentSort,
+  agentActivityTransitions: ReadonlyMap<string, number> = EMPTY_AGENT_ACTIVITY_TRANSITIONS,
+) {
+  if (agentSort === "workspace") {
+    return [...entries];
+  }
+  const ranked = entries.map((entry, index) => {
+    const agents = entry.panes.filter(isAgentPane);
+    let sortRank: number | undefined;
+    if (agentSort === "attention" || agentSort === "status") {
+      const order = agentSort === "attention" ? AGENT_ATTENTION_ORDER : AGENT_STATUS_ORDER;
+      sortRank =
+        agents.length > 0
+          ? Math.min(...agents.map((pane) => order[pane.agent_status]))
+          : undefined;
+    } else {
+      sortRank = agents.reduce<number | undefined>((latest, pane) => {
+        const transition = agentActivityTransitions.get(
+          agentActivityKey(entry.bridgeId, pane.pane_id, pane.terminal_id),
+        );
+        return transition === undefined || (latest !== undefined && latest >= transition)
+          ? latest
+          : transition;
+      }, undefined);
+    }
+    return { entry, index, agents, sortRank };
+  });
+  ranked.sort((a, b) => {
+    const agentPresence = Number(b.agents.length > 0) - Number(a.agents.length > 0);
+    if (agentPresence !== 0) {
+      return agentPresence;
+    }
+    if (a.agents.length === 0) {
+      return a.index - b.index;
+    }
+    if (a.sortRank !== undefined || b.sortRank !== undefined) {
+      if (a.sortRank === undefined) {
+        return 1;
+      }
+      if (b.sortRank === undefined) {
+        return -1;
+      }
+      if (a.sortRank !== b.sortRank) {
+        if (agentSort === "lastStatusChange") {
+          return b.sortRank - a.sortRank;
+        }
+        return a.sortRank - b.sortRank;
+      }
+    }
+    return a.index - b.index;
+  });
+  return ranked.map(({ entry }) => entry);
+}
+
+export function shouldShowTabDivider(
+  agentGroup: AgentGroup,
+  workspaceTabCount: number,
+  paneCount: number,
+) {
+  return agentGroup !== "none" && (workspaceTabCount > 1 || paneCount > 1);
 }
 
 export function buildVisibleScopedNotes(
@@ -4967,6 +5082,7 @@ function Switcher({
   pinnedAgentKeys,
   agentPinnedOnly,
   agentActiveOnly,
+  agentFeaturesInTabs,
   agentSort,
   agentGroup,
   activeSpace,
@@ -5013,6 +5129,7 @@ function Switcher({
   pinnedAgentKeys: ReadonlySet<string>;
   agentPinnedOnly: boolean;
   agentActiveOnly: boolean;
+  agentFeaturesInTabs: boolean;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
   activeSpace: WorkspaceInfo | null;
@@ -5156,8 +5273,34 @@ function Switcher({
         scopedWorkspaces,
         pinnedAgentKeys,
         sidebarView === "tabs" && effectiveAgentPinnedOnly,
+        sidebarView === "tabs" && agentFeaturesInTabs,
+        agentSort,
+        agentActivityTransitions,
       ),
-    [effectiveAgentPinnedOnly, pinnedAgentKeys, scopedWorkspaces, sidebarView],
+    [
+      agentActivityTransitions,
+      agentFeaturesInTabs,
+      agentSort,
+      effectiveAgentPinnedOnly,
+      pinnedAgentKeys,
+      scopedWorkspaces,
+      sidebarView,
+    ],
+  );
+  const flatTabEntries = useMemo(
+    () =>
+      sortScopedTabEntriesByAgents(
+        spaceGroups.flatMap((group) =>
+          group.tabs.map(({ tab, panes: tabPanes }) => ({
+            ...group,
+            tab,
+            panes: tabPanes,
+          })),
+        ),
+        agentFeaturesInTabs ? agentSort : "workspace",
+        agentActivityTransitions,
+      ),
+    [agentActivityTransitions, agentFeaturesInTabs, agentSort, spaceGroups],
   );
   const spaceCount = hostBridgeViews.reduce(
     (count, view) => count + (view.snapshot?.workspaces.length ?? 0),
@@ -5167,7 +5310,11 @@ function Switcher({
   const showGroupControl =
     sidebarView !== "notes" &&
     (sidebarView === "agents" || hostScope === "all" || scope === "all" || agentGroup !== "none");
-  const showOptionsControl = sidebarView !== "notes" && (sidebarView === "agents" || showGroupControl);
+  const showOptionsControl =
+    sidebarView !== "notes" &&
+    (sidebarView === "agents" ||
+      showGroupControl ||
+      (sidebarView === "tabs" && agentFeaturesInTabs));
   const canCreateTabFromHeader = Boolean(
     sidebarView === "tabs" &&
       scope === "space" &&
@@ -5191,10 +5338,10 @@ function Switcher({
   const renderTabWorkspaceGroup = (
     group: ScopedTabWorkspace,
     showWorkspaceHeader: boolean,
-    showContextInTabLabel: boolean,
     showBridgeInWorkspaceHeader = showGroupedHostContext,
+    key = `${group.bridgeId}:${group.workspace.workspace_id}`,
   ) => (
-    <Fragment key={`${group.bridgeId}:${group.workspace.workspace_id}`}>
+    <Fragment key={key}>
       {showWorkspaceHeader ? (
         <GroupHeader
           label={
@@ -5208,14 +5355,66 @@ function Switcher({
       ) : null}
       {group.tabs.map(({ tab, panes: tabPanes }) => {
         const tabLabel = displayTabLabel(tab, group.snapshot.panes);
-        const label = showContextInTabLabel
-          ? `${group.bridgeLabel} / ${group.workspace.label} / ${tabLabel}`
-          : tabLabel;
+        const paneRows = tabPanes.map((pane) => {
+          const index = paneIndex++;
+          const pinned = isAgentPinned(pinnedAgentKeys, group.bridgeId, pane.pane_id);
+          const active =
+            group.bridgeId === selectedBridgeId && pane.pane_id === selectedPane?.pane_id;
+          const onSelect = () => onSelectPane(group.bridgeId, pane);
+          const onPaneMenu = (x: number, y: number) =>
+            onScopedMenu(
+              "pane",
+              group.bridgeId,
+              pane.pane_id,
+              paneTitle(pane),
+              x,
+              y,
+              undefined,
+              "pane",
+            );
+          if (shouldRenderAgentRowInTabs(pane, agentFeaturesInTabs)) {
+            return (
+              <AgentRow
+                key={`${group.bridgeId}:${pane.pane_id}`}
+                index={index}
+                pane={pane}
+                workspace={group.workspace}
+                tabLabel={tabLabel}
+                bridgeLabel={
+                  agentGroup === "none" && hostScope === "all" ? group.bridgeLabel : undefined
+                }
+                pinned={pinned}
+                active={active}
+                onSelect={onSelect}
+                onMenu={onPaneMenu}
+              />
+            );
+          }
+          return (
+            <PaneRow
+              key={`${group.bridgeId}:${pane.pane_id}`}
+              index={index}
+              pane={pane}
+              workspaceLabel={agentGroup === "none" ? group.workspace.label : undefined}
+              tabLabel={agentGroup === "none" ? tabLabel : undefined}
+              bridgeLabel={
+                agentGroup === "none" && hostScope === "all" ? group.bridgeLabel : undefined
+              }
+              pinned={pinned}
+              active={active}
+              onSelect={onSelect}
+              onMenu={onPaneMenu}
+            />
+          );
+        });
+        if (agentGroup === "none") {
+          return <Fragment key={`${group.bridgeId}:${tab.tab_id}`}>{paneRows}</Fragment>;
+        }
         return (
           <div className="tabgrp" key={`${group.bridgeId}:${tab.tab_id}`}>
-            {showContextInTabLabel || group.workspace.tab_count > 1 || tabPanes.length > 1 ? (
+            {shouldShowTabDivider(agentGroup, group.workspace.tab_count, tabPanes.length) ? (
               <TabDivider
-                label={label}
+                label={tabLabel}
                 count={tabPanes.length}
                 onSelect={() => onSelectTab(group.bridgeId, tab.tab_id)}
                 onMenu={(x, y) =>
@@ -5231,28 +5430,7 @@ function Switcher({
                 }
               />
             ) : null}
-            {tabPanes.map((pane) => (
-              <PaneRow
-                key={`${group.bridgeId}:${pane.pane_id}`}
-                index={paneIndex++}
-                pane={pane}
-                pinned={isAgentPinned(pinnedAgentKeys, group.bridgeId, pane.pane_id)}
-                active={group.bridgeId === selectedBridgeId && pane.pane_id === selectedPane?.pane_id}
-                onSelect={() => onSelectPane(group.bridgeId, pane)}
-                onMenu={(x, y) =>
-                  onScopedMenu(
-                    "pane",
-                    group.bridgeId,
-                    pane.pane_id,
-                    paneTitle(pane),
-                    x,
-                    y,
-                    undefined,
-                    "pane",
-                  )
-                }
-              />
-            ))}
+            {paneRows}
           </div>
         );
       })}
@@ -5270,19 +5448,26 @@ function Switcher({
         return (
           <Fragment key={view.runtime.id}>
             <GroupHeader label={view.runtime.label} bridgeColor={view.runtime.color} />
-            {groups.map((group) => renderTabWorkspaceGroup(group, true, false, false))}
+            {groups.map((group) => renderTabWorkspaceGroup(group, true, false))}
           </Fragment>
         );
       });
     }
 
     if (agentGroup === "workspace" || agentGroup === "hostWorkspace") {
-      return spaceGroups.map((group) => renderTabWorkspaceGroup(group, true, false));
+      return spaceGroups.map((group) => renderTabWorkspaceGroup(group, true));
     }
 
-    const showContextInTabLabel = hostScope === "all" || scope === "all";
-    return spaceGroups.map((group) =>
-      renderTabWorkspaceGroup(group, false, showContextInTabLabel),
+    return flatTabEntries.map((entry) =>
+      renderTabWorkspaceGroup(
+        {
+          ...entry,
+          tabs: [{ tab: entry.tab, panes: entry.panes }],
+        },
+        false,
+        showGroupedHostContext,
+        `${entry.bridgeId}:${entry.tab.tab_id}`,
+      ),
     );
   };
   const renderDisconnectedBridgeRows = () =>
@@ -5771,6 +5956,7 @@ function Switcher({
           x={optionsMenu.x}
           y={optionsMenu.y}
           sidebarView={sidebarView}
+          showSort={shouldShowSidebarSort(sidebarView, agentFeaturesInTabs)}
           showGroup={showGroupControl}
           agentSort={agentSort}
           agentGroup={agentGroup}
@@ -5788,6 +5974,7 @@ function SidebarOptionsMenu({
   x,
   y,
   sidebarView,
+  showSort,
   showGroup,
   agentSort,
   agentGroup,
@@ -5799,6 +5986,7 @@ function SidebarOptionsMenu({
   x: number;
   y: number;
   sidebarView: SidebarView;
+  showSort: boolean;
   showGroup: boolean;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
@@ -5809,7 +5997,6 @@ function SidebarOptionsMenu({
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
-  const showSort = sidebarView === "agents";
 
   useLayoutEffect(() => {
     const el = ref.current;
@@ -6948,6 +7135,9 @@ function TabDivider({
 
 function PaneRow({
   pane,
+  workspaceLabel,
+  tabLabel,
+  bridgeLabel,
   pinned,
   active,
   index,
@@ -6955,6 +7145,9 @@ function PaneRow({
   onMenu,
 }: {
   pane: PaneInfo;
+  workspaceLabel?: string;
+  tabLabel?: string;
+  bridgeLabel?: string;
   pinned?: boolean;
   active: boolean;
   index: number;
@@ -6962,7 +7155,10 @@ function PaneRow({
   onMenu: (x: number, y: number) => void;
 }) {
   const press = useLongPress(onMenu, onSelect);
-  const meta = paneMeta(pane);
+  const meta =
+    workspaceLabel || tabLabel || bridgeLabel
+      ? paneListSubtitle(pane, workspaceLabel, tabLabel, bridgeLabel)
+      : paneMeta(pane);
   return (
     <button
       className="pane-row"
@@ -6974,7 +7170,9 @@ function PaneRow({
     >
       <span className="dot" data-status={pane.agent_status} />
       <span className="pane-body">
-        <span className="pane-name">{paneTitle(pane)}</span>
+        <span className="pane-name pane-title">
+          <span className="pane-title-text">{paneTitle(pane)}</span>
+        </span>
         {meta ? <span className="pane-meta mono">{meta}</span> : null}
       </span>
       {isLoud(pane.agent_status) ? (
@@ -7023,12 +7221,12 @@ function AgentRow({
     >
       <span className="dot" data-status={pane.agent_status} />
       <span className="pane-body">
-        <span className="pane-name agent-title">
+        <span className="pane-name pane-title">
           {iconKind ? <AgentIcon kind={iconKind} /> : null}
           {pinned ? (
             <Pin className="agent-pin-indicator" size={10} aria-label="Pinned" />
           ) : null}
-          <span className="agent-title-text">{agentTitle(pane)}</span>
+          <span className="pane-title-text">{agentTitle(pane)}</span>
         </span>
         <span className="pane-meta mono">{agentSubtitle(pane, workspace, tabLabel, bridgeLabel)}</span>
       </span>
@@ -7118,6 +7316,10 @@ function StatusBadge({ status }: { status: AgentStatus }) {
       {statusLabel(status)}
     </span>
   );
+}
+
+export function shouldRenderAgentRowInTabs(pane: PaneInfo, enabled: boolean) {
+  return enabled && isAgentPane(pane);
 }
 
 function isAgentPane(pane: PaneInfo) {
@@ -7256,6 +7458,13 @@ export function shouldShowLastStatusChangeSort(
   agentSort: AgentSort,
 ) {
   return agentActivitySupported || agentSort === "lastStatusChange";
+}
+
+export function shouldShowSidebarSort(
+  sidebarView: SidebarView,
+  agentFeaturesInTabs: boolean,
+) {
+  return sidebarView === "agents" || (sidebarView === "tabs" && agentFeaturesInTabs);
 }
 
 export function canAddNoteFromPaneMenu({

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7646,18 +7646,14 @@ function agentTitle(pane: PaneInfo) {
   return pane.display_agent || pane.label || pane.agent || pane.title || paneTitle(pane);
 }
 
-function agentSubtitle(
+export function agentSubtitle(
   pane: PaneInfo,
   workspace?: WorkspaceInfo,
   tabLabel?: string,
   bridgeLabel?: string,
 ) {
-  const stateText =
-    pane.custom_status ||
-    pane.state_labels?.[statusLabel(pane.agent_status)] ||
-    statusLabel(pane.agent_status);
   const dir = basename(pane.foreground_cwd || pane.cwd);
-  return [stateText, bridgeLabel, workspace?.label, tabLabel, dir].filter(Boolean).join(" · ");
+  return [bridgeLabel, workspace?.label, tabLabel, dir].filter(Boolean).join(" · ");
 }
 
 function SplitGlyph() {

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -60,6 +60,8 @@ type Props = {
   showMobileTerminalSettings: boolean;
   notesEnabled: boolean;
   onNotesEnabled: (enabled: boolean) => void;
+  agentFeaturesInTabs: boolean;
+  onAgentFeaturesInTabs: (enabled: boolean) => void;
   terminalFontSizePx: number;
   onTerminalFontSizePx: (value: number) => void;
   terminalInputTransport: TerminalInputTransport;
@@ -106,6 +108,8 @@ export function BackendSettingsDialog({
   showMobileTerminalSettings,
   notesEnabled,
   onNotesEnabled,
+  agentFeaturesInTabs,
+  onAgentFeaturesInTabs,
   terminalFontSizePx,
   onTerminalFontSizePx,
   terminalInputTransport,
@@ -501,6 +505,32 @@ export function BackendSettingsDialog({
 
             {activeArea === "display" ? (
               <div className="settings-section settings-section-flat">
+                <div className="settings-label">Sidebar</div>
+                <div className="settings-row">
+                  <span>Agent features in Tabs</span>
+                  <div
+                    className="segmented-control"
+                    role="group"
+                    aria-label="Agent features in Tabs"
+                  >
+                    <button
+                      type="button"
+                      data-on={!agentFeaturesInTabs}
+                      aria-pressed={!agentFeaturesInTabs}
+                      onClick={() => onAgentFeaturesInTabs(false)}
+                    >
+                      Off
+                    </button>
+                    <button
+                      type="button"
+                      data-on={agentFeaturesInTabs}
+                      aria-pressed={agentFeaturesInTabs}
+                      onClick={() => onAgentFeaturesInTabs(true)}
+                    >
+                      On
+                    </button>
+                  </div>
+                </div>
                 <div className="settings-label">Display spacing</div>
                 <div className="settings-row">
                   <span>Top padding</span>

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -62,6 +62,8 @@ type Props = {
   onNotesEnabled: (enabled: boolean) => void;
   agentFeaturesInTabs: boolean;
   onAgentFeaturesInTabs: (enabled: boolean) => void;
+  multiHostSpaceSelection: boolean;
+  onMultiHostSpaceSelection: (enabled: boolean) => void;
   terminalFontSizePx: number;
   onTerminalFontSizePx: (value: number) => void;
   terminalInputTransport: TerminalInputTransport;
@@ -110,6 +112,8 @@ export function BackendSettingsDialog({
   onNotesEnabled,
   agentFeaturesInTabs,
   onAgentFeaturesInTabs,
+  multiHostSpaceSelection,
+  onMultiHostSpaceSelection,
   terminalFontSizePx,
   onTerminalFontSizePx,
   terminalInputTransport,
@@ -526,6 +530,31 @@ export function BackendSettingsDialog({
                       data-on={agentFeaturesInTabs}
                       aria-pressed={agentFeaturesInTabs}
                       onClick={() => onAgentFeaturesInTabs(true)}
+                    >
+                      On
+                    </button>
+                  </div>
+                </div>
+                <div className="settings-row">
+                  <span>Multi-host Space selection</span>
+                  <div
+                    className="segmented-control"
+                    role="group"
+                    aria-label="Multi-host Space selection"
+                  >
+                    <button
+                      type="button"
+                      data-on={!multiHostSpaceSelection}
+                      aria-pressed={!multiHostSpaceSelection}
+                      onClick={() => onMultiHostSpaceSelection(false)}
+                    >
+                      Off
+                    </button>
+                    <button
+                      type="button"
+                      data-on={multiHostSpaceSelection}
+                      aria-pressed={multiHostSpaceSelection}
+                      onClick={() => onMultiHostSpaceSelection(true)}
                     >
                       On
                     </button>

--- a/web/src/displayPrefs.test.ts
+++ b/web/src/displayPrefs.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_CONTENT_INSET_BOTTOM_PX,
   DEFAULT_CONTENT_INSET_TOP_PX,
   DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
+  DEFAULT_AGENT_FEATURES_IN_TABS,
   MAX_CONTENT_INSET_BOTTOM_PX,
   MAX_CONTENT_INSET_TOP_PX,
   MAX_MOBILE_CONTROLS_SCALE_PERCENT,
@@ -10,6 +11,7 @@ import {
   parseContentInsetBottomPx,
   parseContentInsetTopPx,
   parseMobileControlsScalePercent,
+  parseAgentFeaturesInTabs,
 } from "./displayPrefs";
 
 describe("display preferences", () => {
@@ -40,5 +42,13 @@ describe("display preferences", () => {
   it("falls back for invalid mobile controls scale values", () => {
     expect(parseMobileControlsScalePercent(null)).toBe(DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT);
     expect(parseMobileControlsScalePercent("100")).toBe(DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT);
+  });
+
+  it("parses the Tabs agent features preference and defaults it on", () => {
+    expect(parseAgentFeaturesInTabs(true)).toBe(true);
+    expect(parseAgentFeaturesInTabs(false)).toBe(false);
+    expect(parseAgentFeaturesInTabs(undefined)).toBe(DEFAULT_AGENT_FEATURES_IN_TABS);
+    expect(parseAgentFeaturesInTabs("false")).toBe(DEFAULT_AGENT_FEATURES_IN_TABS);
+    expect(parseAgentFeaturesInTabs(undefined, false)).toBe(false);
   });
 });

--- a/web/src/displayPrefs.test.ts
+++ b/web/src/displayPrefs.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CONTENT_INSET_TOP_PX,
   DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
   DEFAULT_AGENT_FEATURES_IN_TABS,
+  DEFAULT_MULTI_HOST_SPACE_SELECTION,
   MAX_CONTENT_INSET_BOTTOM_PX,
   MAX_CONTENT_INSET_TOP_PX,
   MAX_MOBILE_CONTROLS_SCALE_PERCENT,
@@ -12,6 +13,7 @@ import {
   parseContentInsetTopPx,
   parseMobileControlsScalePercent,
   parseAgentFeaturesInTabs,
+  parseMultiHostSpaceSelection,
 } from "./displayPrefs";
 
 describe("display preferences", () => {
@@ -50,5 +52,13 @@ describe("display preferences", () => {
     expect(parseAgentFeaturesInTabs(undefined)).toBe(DEFAULT_AGENT_FEATURES_IN_TABS);
     expect(parseAgentFeaturesInTabs("false")).toBe(DEFAULT_AGENT_FEATURES_IN_TABS);
     expect(parseAgentFeaturesInTabs(undefined, false)).toBe(false);
+  });
+
+  it("parses multi-host Space selection and defaults it on", () => {
+    expect(parseMultiHostSpaceSelection(true)).toBe(true);
+    expect(parseMultiHostSpaceSelection(false)).toBe(false);
+    expect(parseMultiHostSpaceSelection(undefined)).toBe(DEFAULT_MULTI_HOST_SPACE_SELECTION);
+    expect(parseMultiHostSpaceSelection("false")).toBe(DEFAULT_MULTI_HOST_SPACE_SELECTION);
+    expect(parseMultiHostSpaceSelection(undefined, false)).toBe(false);
   });
 });

--- a/web/src/displayPrefs.ts
+++ b/web/src/displayPrefs.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_CONTENT_INSET_TOP_PX = 0;
 export const DEFAULT_CONTENT_INSET_BOTTOM_PX = 0;
 export const DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT = 100;
+export const DEFAULT_AGENT_FEATURES_IN_TABS = true;
 
 export const MIN_CONTENT_INSET_TOP_PX = 0;
 export const MAX_CONTENT_INSET_TOP_PX = 96;
@@ -34,6 +35,13 @@ export function parseMobileControlsScalePercent(value: unknown) {
     MAX_MOBILE_CONTROLS_SCALE_PERCENT,
     DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT,
   );
+}
+
+export function parseAgentFeaturesInTabs(
+  value: unknown,
+  fallback = DEFAULT_AGENT_FEATURES_IN_TABS,
+) {
+  return typeof value === "boolean" ? value : fallback;
 }
 
 function parseClampedInteger(value: unknown, min: number, max: number, fallback: number) {

--- a/web/src/displayPrefs.ts
+++ b/web/src/displayPrefs.ts
@@ -2,6 +2,7 @@ export const DEFAULT_CONTENT_INSET_TOP_PX = 0;
 export const DEFAULT_CONTENT_INSET_BOTTOM_PX = 0;
 export const DEFAULT_MOBILE_CONTROLS_SCALE_PERCENT = 100;
 export const DEFAULT_AGENT_FEATURES_IN_TABS = true;
+export const DEFAULT_MULTI_HOST_SPACE_SELECTION = true;
 
 export const MIN_CONTENT_INSET_TOP_PX = 0;
 export const MAX_CONTENT_INSET_TOP_PX = 96;
@@ -40,6 +41,13 @@ export function parseMobileControlsScalePercent(value: unknown) {
 export function parseAgentFeaturesInTabs(
   value: unknown,
   fallback = DEFAULT_AGENT_FEATURES_IN_TABS,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseMultiHostSpaceSelection(
+  value: unknown,
+  fallback = DEFAULT_MULTI_HOST_SPACE_SELECTION,
 ) {
   return typeof value === "boolean" ? value : fallback;
 }

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -10,6 +10,7 @@ import {
   paneListSubtitle,
   paneTitle,
   sortPanesForPicker,
+  spaceSubtitle,
 } from "./state";
 import type { PaneInfo, Snapshot, TabInfo, WorkspaceInfo } from "./types";
 
@@ -283,6 +284,16 @@ describe("paneListSubtitle", () => {
         "workspace",
       ),
     ).toBe("workspace");
+  });
+});
+
+describe("spaceSubtitle", () => {
+  it("prepends host context only when supplied and includes the agent count", () => {
+    const item = { ...workspace("repo"), tab_count: 2, pane_count: 3 };
+
+    expect(spaceSubtitle(item, "srv", 2)).toBe("srv · 2 tabs · 3 panes · 2 agents");
+    expect(spaceSubtitle(item, undefined, 1)).toBe("2 tabs · 3 panes · 1 agent");
+    expect(spaceSubtitle(item)).toBe("2 tabs · 3 panes");
   });
 });
 

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -7,6 +7,7 @@ import {
   chooseSelectedPane,
   chooseSelectedPaneForActiveWorkspace,
   displayTabLabel,
+  paneListSubtitle,
   paneTitle,
   sortPanesForPicker,
 } from "./state";
@@ -249,6 +250,39 @@ describe("paneTitle", () => {
       "herdr",
     );
     expect(paneTitle(pane("1-2"))).toBe("Terminal");
+  });
+});
+
+describe("paneListSubtitle", () => {
+  it("puts flat-list navigation context on the pane row", () => {
+    expect(
+      paneListSubtitle(
+        {
+          ...pane("1-1"),
+          display_agent: "Codex",
+          foreground_cwd: "/home/kevin/worktrees/herdr-web",
+        },
+        "development",
+        "review",
+        "srv",
+      ),
+    ).toBe("srv · development · review · herdr-web");
+  });
+
+  it("removes repeated title and context values", () => {
+    expect(
+      paneListSubtitle(
+        {
+          ...pane("1-1"),
+          label: "Codex",
+          display_agent: "Codex",
+          foreground_cwd: "/home/kevin/Codex",
+        },
+        "workspace",
+        "Codex",
+        "workspace",
+      ),
+    ).toBe("workspace");
   });
 });
 

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -138,6 +138,20 @@ export function paneMeta(pane: PaneInfo) {
   return parts.join(" · ");
 }
 
+export function paneListSubtitle(
+  pane: PaneInfo,
+  workspaceLabel?: string,
+  tabLabel?: string,
+  bridgeLabel?: string,
+) {
+  const title = paneTitle(pane);
+  const parts = [bridgeLabel, workspaceLabel, tabLabel, ...paneMeta(pane).split(" · ")];
+  return parts
+    .filter((part): part is string => Boolean(part) && part !== title)
+    .filter((part, index, items) => items.indexOf(part) === index)
+    .join(" · ");
+}
+
 export function spaceSubtitle(workspace: WorkspaceInfo) {
   const tabs = `${workspace.tab_count} tab${workspace.tab_count === 1 ? "" : "s"}`;
   const panes = `${workspace.pane_count} pane${workspace.pane_count === 1 ? "" : "s"}`;

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -152,10 +152,16 @@ export function paneListSubtitle(
     .join(" · ");
 }
 
-export function spaceSubtitle(workspace: WorkspaceInfo) {
+export function spaceSubtitle(
+  workspace: WorkspaceInfo,
+  bridgeLabel?: string,
+  agentCount = 0,
+) {
   const tabs = `${workspace.tab_count} tab${workspace.tab_count === 1 ? "" : "s"}`;
   const panes = `${workspace.pane_count} pane${workspace.pane_count === 1 ? "" : "s"}`;
-  return `${tabs} · ${panes}`;
+  const agents =
+    agentCount > 0 ? `${agentCount} agent${agentCount === 1 ? "" : "s"}` : undefined;
+  return [bridgeLabel, tabs, panes, agents].filter(Boolean).join(" · ");
 }
 
 export function sortTabsForWorkspace(tabs: TabInfo[], workspaceId: string) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -688,14 +688,14 @@ button {
   font-weight: 550;
 }
 
-.agent-title {
+.pane-title {
   display: flex;
   min-width: 0;
   align-items: center;
   gap: 6px;
 }
 
-.agent-title-text {
+.pane-title-text {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

- Make ungrouped Tabs and Spaces lists use compact inline context instead of redundant headers.
- Render agent panes consistently across Agents and Tabs, with agent-aware sorting plus pinned-only and active-only filters.
- Add dynamic Spaces grouping and configurable multi-host Space selection.
- Preserve custom agent status metadata while removing redundant generic status text.

## Behavior change

Ungrouped Tabs and Spaces now use compact rows by default, and agent panes in Tabs use agent-aware presentation and ordering. Grouping restores contextual headers; disabling Agent features in Tabs restores generic pane rows and original tab ordering.

## Verification

- `npm run check`
- 215 web tests
- 102 Herdr compatibility tests
- 118 bridge tests
- Keel iterative review clean (`run_1e22c42d-0f86-4514-8a6c-96f7138ece68`)
- Production web builds and service health checks on `srv` and `pc`
- Android debug APK build and package verification
