### PR TITLE
Add client-local navigation sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added a default-on client-local Sync navigation setting. Browser tabs and windows with sync off
   can view different panes through the same bridge without publishing or following shared pane
   selection or changing Herdr's focused tab through ordinary navigation.
+  [PR #42](https://github.com/kcosr/herdr-web/pull/42)
 - Added default-on Agent features in Tabs, including consistent Agents row metadata and pin
   placement, agent-aware sorting, and pinned-only and active-only filters. Non-agent tabs remain
   visible at the bottom of agent-aware sorts; disabling the setting restores generic pane rows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Added
 
+- Added a default-on client-local Sync navigation setting. Browser tabs and windows with sync off
+  can view different panes through the same bridge without publishing or following shared pane
+  selection or changing Herdr's focused tab through ordinary navigation.
 - Added default-on Agent features in Tabs, including consistent Agents row metadata and pin
   placement, agent-aware sorting, and pinned-only and active-only filters. Non-agent tabs remain
   visible at the bottom of agent-aware sorts; disabling the setting restores generic pane rows.

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ Settings are grouped by area:
 
 - Bridge: same-origin and saved bridge profiles, reachability testing, and bridge enablement.
 - Features: client feature toggles such as Notes.
-- Display: agent features in Tabs, multi-host Space selection, top/bottom app padding, and mobile
-  terminal controls size.
+- Display: client-local navigation synchronization, agent features in Tabs, multi-host Space
+  selection, top/bottom app padding, and mobile terminal controls size.
 - Terminal: browser-to-bridge terminal input transport and input batching delay.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
 
@@ -350,8 +350,11 @@ serving bridge origin and `data:`. Use `--allow-connect-origin ORIGIN` on the se
 that page should connect to another bridge; the bridge adds matching HTTP and WebSocket
 `connect-src` entries for that origin.
 
-Pane selection is bridge-owned. Selecting a pane in one browser updates `/api/selection`, broadcasts
-over `/ws/ui-events`, and other browsers switch to the same pane.
+Sync navigation is on by default. Selecting a pane updates `/api/selection`, broadcasts over
+`/ws/ui-events`, and other clients with sync enabled switch to the same pane. Clients can turn sync
+off in Display settings to keep their pane selection local to that browser tab or window. Navigation
+with sync off still uses the same Herdr session: terminal input, structural commands, and workspace,
+tab, and pane changes remain shared.
 
 ## Vendoring Strategy
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -122,6 +122,12 @@ import {
   updateNote,
 } from "./notes";
 import type { NoteAttachment, NotesListResponse, PaneNote } from "./notes";
+import {
+  readClientNavigationPrefs,
+  sharesNavigation,
+  writeClientNavigationPrefs,
+} from "./navigationPrefs";
+import type { NavigationSyncMode } from "./navigationPrefs";
 import { ActionMenu, ConfirmDialog, RenameDialog, useLongPress } from "./overlays";
 import type { MenuItem } from "./overlays";
 import { createSnapshotRefreshController } from "./refreshCoordinator";
@@ -751,6 +757,9 @@ function usePointerDragResize(
 export function App() {
   const bridge = useBridge();
   const initialPrefs = useMemo(readDisplayPrefs, []);
+  const initialClientNavigationPrefs = useMemo(readClientNavigationPrefs, []);
+  const initialNavigationIsIndependent =
+    initialClientNavigationPrefs.mode === "independent";
   const legacySelectionPrefs = useMemo(readLegacyDisplaySelectionPrefs, []);
   const [displayPrefsLoaded, setDisplayPrefsLoaded] = useState(() => !isNativeApp());
   const [connectionStates, setConnectionStates] = useState<Record<string, BridgeConnectionState>>({});
@@ -763,8 +772,14 @@ export function App() {
   >({});
   const launcherPresetStatesRef = useRef(launcherPresetStates);
   const [selectedBridgeId, setSelectedBridgeId] = useState<BridgeId | null>(
-    initialPrefs.selectedBridgeId,
+    initialNavigationIsIndependent
+      ? initialClientNavigationPrefs.selectedBridgeId
+      : initialPrefs.selectedBridgeId,
   );
+  const [navigationSyncMode, setNavigationSyncMode] = useState<NavigationSyncMode>(
+    initialClientNavigationPrefs.mode,
+  );
+  const navigationIsShared = sharesNavigation(navigationSyncMode);
   const [selectedNoteRef, setSelectedNoteRef] = useState<ScopedNoteRef | null>(null);
   const [noteTitleFocusRequest, setNoteTitleFocusRequest] =
     useState<ScopedNoteTitleFocusRequest | null>(null);
@@ -777,15 +792,24 @@ export function App() {
   const [quickPaneNoteTarget, setQuickPaneNoteTarget] = useState<QuickPaneNoteTarget | null>(null);
   const [quickPaneNoteCreating, setQuickPaneNoteCreating] = useState(false);
   const [selectedPaneRefState, setSelectedPaneRefState] = useState<ScopedPaneRef | null>(
-    initialPrefs.selectedPane,
+    initialNavigationIsIndependent
+      ? initialClientNavigationPrefs.selectedPane
+      : initialPrefs.selectedPane,
   );
-  const [activeWorkspaceRefState, setActiveWorkspaceRefState] =
-    useState<ScopedWorkspaceRef | null>(initialPrefs.activeWorkspace);
+  const [activeWorkspaceRefState, setActiveWorkspaceRefState] = useState<ScopedWorkspaceRef | null>(
+    initialNavigationIsIndependent
+      ? initialClientNavigationPrefs.activeWorkspace
+      : initialPrefs.activeWorkspace,
+  );
   const [selectedPanesByBridgeId, setSelectedPanesByBridgeId] = useState<Record<string, string>>(
-    initialPrefs.selectedPanesByBridgeId,
+    initialNavigationIsIndependent
+      ? initialClientNavigationPrefs.selectedPanesByBridgeId
+      : initialPrefs.selectedPanesByBridgeId,
   );
   const [activeWorkspacesByBridgeId, setActiveWorkspacesByBridgeId] = useState<Record<string, string>>(
-    initialPrefs.activeWorkspacesByBridgeId,
+    initialNavigationIsIndependent
+      ? initialClientNavigationPrefs.activeWorkspacesByBridgeId
+      : initialPrefs.activeWorkspacesByBridgeId,
   );
   const [hostScope, setHostScope] = useState<HostScope>(initialPrefs.hostScope);
   const [scope, setScope] = useState<Scope>(initialPrefs.scope);
@@ -911,11 +935,13 @@ export function App() {
       setNotesEnabled(prefs.notesEnabled);
       setNotesPanelOpen(prefs.notesEnabled && prefs.notesPanelOpen);
       setSidebarOpen(prefs.sidebarOpen);
-      setSelectedBridgeId(prefs.selectedBridgeId);
-      setSelectedPaneRefState(prefs.selectedPane);
-      setActiveWorkspaceRefState(prefs.activeWorkspace);
-      setSelectedPanesByBridgeId(prefs.selectedPanesByBridgeId);
-      setActiveWorkspacesByBridgeId(prefs.activeWorkspacesByBridgeId);
+      if (sharesNavigation(navigationSyncMode)) {
+        setSelectedBridgeId(prefs.selectedBridgeId);
+        setSelectedPaneRefState(prefs.selectedPane);
+        setActiveWorkspaceRefState(prefs.activeWorkspace);
+        setSelectedPanesByBridgeId(prefs.selectedPanesByBridgeId);
+        setActiveWorkspacesByBridgeId(prefs.activeWorkspacesByBridgeId);
+      }
       setTerminalFontSizePx(prefs.terminalFontSizePx);
       setTerminalInputTransport(prefs.terminalInputTransport);
       setTerminalInputBatchDelayMs(prefs.terminalInputBatchDelayMs);
@@ -934,7 +960,7 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [displayPrefsLoaded]);
+  }, [displayPrefsLoaded, navigationSyncMode]);
 
   useEffect(() => {
     return addNativeBackHandler(() => {
@@ -1026,7 +1052,11 @@ export function App() {
       : selectedRuntime
         ? (activeWorkspacesByBridgeId[selectedRuntime.id] ?? null)
         : null;
-  const resolvedPaneId = chooseSelectedPane(snapshot, selectedRawPaneId);
+  const resolvedPaneId = chooseSelectedPane(
+    snapshot,
+    selectedRawPaneId,
+    sharesNavigation(navigationSyncMode),
+  );
   const supportedCommands =
     selectedRuntime?.capabilityState === "ready" ? (selectedRuntime.capabilities?.commands ?? []) : [];
   const splitSupported = supportedCommands.includes("pane.split");
@@ -1328,6 +1358,7 @@ export function App() {
       snapshot,
       restoredPaneId,
       restoredWorkspaceId,
+      sharesNavigation(navigationSyncMode),
     );
     setSelectedPaneRefState((current) => {
       if (!nextPaneId) {
@@ -1368,15 +1399,38 @@ export function App() {
     });
   }, [
     activeWorkspacesByBridgeId,
+    navigationSyncMode,
     selectedPanesByBridgeId,
     selectedRuntime?.id,
     snapshot,
   ]);
 
   useEffect(() => {
+    writeClientNavigationPrefs({
+      mode: navigationSyncMode,
+      selectedBridgeId,
+      selectedPane: selectedPaneRefState,
+      activeWorkspace: activeWorkspaceRefState,
+      selectedPanesByBridgeId,
+      activeWorkspacesByBridgeId,
+    });
+  }, [
+    activeWorkspaceRefState,
+    activeWorkspacesByBridgeId,
+    navigationSyncMode,
+    selectedBridgeId,
+    selectedPaneRefState,
+    selectedPanesByBridgeId,
+  ]);
+
+  useEffect(() => {
     if (!displayPrefsLoaded) {
       return;
     }
+    // Independent clients persist navigation in sessionStorage. Preserve the shared
+    // local/native selection fields when writing unrelated display preferences so
+    // another tab's independent navigation cannot replace a Shared client's reload state.
+    const persistedSharedNavigation = navigationIsShared ? null : readDisplayPrefs();
     void writeDisplayPrefs({
       hostScope,
       scope,
@@ -1395,11 +1449,21 @@ export function App() {
       notesEnabled,
       notesPanelOpen,
       sidebarOpen,
-      selectedBridgeId,
-      selectedPane: selectedPaneRefState,
-      activeWorkspace: activeWorkspaceRefState,
-      selectedPanesByBridgeId,
-      activeWorkspacesByBridgeId,
+      selectedBridgeId: persistedSharedNavigation
+        ? persistedSharedNavigation.selectedBridgeId
+        : selectedBridgeId,
+      selectedPane: persistedSharedNavigation
+        ? persistedSharedNavigation.selectedPane
+        : selectedPaneRefState,
+      activeWorkspace: persistedSharedNavigation
+        ? persistedSharedNavigation.activeWorkspace
+        : activeWorkspaceRefState,
+      selectedPanesByBridgeId: persistedSharedNavigation
+        ? persistedSharedNavigation.selectedPanesByBridgeId
+        : selectedPanesByBridgeId,
+      activeWorkspacesByBridgeId: persistedSharedNavigation
+        ? persistedSharedNavigation.activeWorkspacesByBridgeId
+        : activeWorkspacesByBridgeId,
       terminalFontSizePx,
       terminalInputTransport,
       terminalInputBatchDelayMs,
@@ -1426,6 +1490,7 @@ export function App() {
     agentActiveOnly,
     agentFeaturesInTabs,
     multiHostSpaceSelection,
+    navigationIsShared,
     sidebarWidth,
     notesPanelWidth,
     notesListPaneWidth,
@@ -1569,6 +1634,18 @@ export function App() {
       );
     }
   }, []);
+
+  const changeNavigationSyncMode = (mode: NavigationSyncMode) => {
+    if (mode === "shared" && selectedRuntime && snapshot?.selected_pane_id) {
+      const pane = snapshot.panes.find(
+        (candidate) => candidate.pane_id === snapshot.selected_pane_id,
+      );
+      if (pane) {
+        rememberPaneSelection(selectedRuntime.id, pane.pane_id, pane.workspace_id);
+      }
+    }
+    setNavigationSyncMode(mode);
+  };
 
   useEffect(() => {
     const activeBridgeIds = new Set(bridge.enabledRuntimes.map((runtime) => runtime.id));
@@ -1878,11 +1955,11 @@ export function App() {
 
   const showSplit = !isCompactLayout && splitCells !== null;
 
-  // Mirror browser navigation to the herdr session so `active_tab_id` tracks
-  // what we're viewing here. `tab.focus` also activates the tab's workspace, so
-  // a workspace-only focus is just the fallback for a space with no panes yet.
+  // Shared navigation mirrors browser focus to Herdr so `active_tab_id` tracks
+  // the synchronized view. Independent navigation deliberately leaves Herdr's
+  // global focus alone. `tab.focus` also activates the tab's workspace.
   const pushFocus = (runtime: BridgeRuntime | null, tabId?: string, workspaceId?: string) => {
-    if (!runtime || runtime.capabilityState !== "ready") {
+    if (!navigationIsShared || !runtime || runtime.capabilityState !== "ready") {
       return;
     }
     const commands = createCommands(runtime.httpUrl);
@@ -1925,7 +2002,7 @@ export function App() {
     setSelectedBridgeId(bridgeId);
     bridge.markBridgeUsed(bridgeId);
     rememberPaneSelection(bridgeId, pane.pane_id, pane.workspace_id);
-    if (runtime.capabilityState === "ready") {
+    if (navigationIsShared && runtime.capabilityState === "ready") {
       void syncSelectedPane(runtime.httpUrl, pane.pane_id).catch(() => {});
     }
     pushFocus(runtime, pane.tab_id, pane.workspace_id);
@@ -1976,7 +2053,7 @@ export function App() {
       if (paneId) {
         const pane = bridgeSnapshot.panes.find((item) => item.pane_id === paneId);
         rememberPaneSelection(bridgeId, paneId, pane?.workspace_id ?? workspaceId);
-        if (runtime.capabilityState === "ready") {
+        if (navigationIsShared && runtime.capabilityState === "ready") {
           void syncSelectedPane(runtime.httpUrl, paneId).catch(() => {});
         }
         pushFocus(runtime, pane?.tab_id, workspaceId);
@@ -3004,7 +3081,9 @@ export function App() {
         if (created) {
           setSelectedBridgeId(runtime.id);
           rememberPaneSelection(runtime.id, created.pane_id, created.workspace_id);
-          void syncSelectedPane(runtime.httpUrl, created.pane_id).catch(() => {});
+          if (navigationIsShared) {
+            void syncSelectedPane(runtime.httpUrl, created.pane_id).catch(() => {});
+          }
           if (isCompactLayout) {
             openMobileDetail();
           }
@@ -3225,6 +3304,7 @@ export function App() {
         <BridgeConnectionController
           key={runtime.id}
           runtime={runtime}
+          followSharedSelection={navigationIsShared}
           connectionRefs={connectionRefs}
           setConnectionStates={setConnectionStates}
           onPaneSelection={rememberPaneSelection}
@@ -3741,6 +3821,8 @@ export function App() {
           showMobileTerminalSettings={isTouchInput}
           notesEnabled={notesEnabled}
           onNotesEnabled={setNotesEnabled}
+          navigationSyncMode={navigationSyncMode}
+          onNavigationSyncMode={changeNavigationSyncMode}
           agentFeaturesInTabs={agentFeaturesInTabs}
           onAgentFeaturesInTabs={setAgentFeaturesInTabs}
           multiHostSpaceSelection={multiHostSpaceSelection}
@@ -3817,6 +3899,7 @@ export function shouldCollapseHostScope(
 
 export function BridgeConnectionController({
   runtime,
+  followSharedSelection,
   connectionRefs,
   setConnectionStates,
   onPaneSelection,
@@ -3825,6 +3908,7 @@ export function BridgeConnectionController({
   onNotesChanged,
 }: {
   runtime: BridgeRuntime;
+  followSharedSelection: boolean;
   connectionRefs: MutableRefObject<Record<string, BridgeConnectionRef>>;
   setConnectionStates: Dispatch<SetStateAction<Record<string, BridgeConnectionState>>>;
   onPaneSelection: (bridgeId: BridgeId, paneId: string, workspaceId?: string) => void;
@@ -3837,6 +3921,7 @@ export function BridgeConnectionController({
   const onAgentActivityChangedRef = useRef(onAgentActivityChanged);
   const onAgentPinsChangedRef = useRef(onAgentPinsChanged);
   const onNotesChangedRef = useRef(onNotesChanged);
+  const followSharedSelectionRef = useRef(followSharedSelection);
   const refreshOffsetRef = useRef(stableBridgeRefreshOffsetMs(runtime.id));
 
   useEffect(() => {
@@ -3845,10 +3930,16 @@ export function BridgeConnectionController({
   }, [runtime.httpUrl, runtime.wsUrl]);
 
   useEffect(() => {
+    followSharedSelectionRef.current = followSharedSelection;
     onAgentActivityChangedRef.current = onAgentActivityChanged;
     onAgentPinsChangedRef.current = onAgentPinsChanged;
     onNotesChangedRef.current = onNotesChanged;
-  }, [onAgentActivityChanged, onAgentPinsChanged, onNotesChanged]);
+  }, [
+    followSharedSelection,
+    onAgentActivityChanged,
+    onAgentPinsChanged,
+    onNotesChanged,
+  ]);
 
   useEffect(() => {
     let disposed = false;
@@ -3997,6 +4088,10 @@ export function BridgeConnectionController({
         }
         const paneId = selectionPaneId(event);
         if (paneId) {
+          if (!followSharedSelectionRef.current) {
+            refresh();
+            return;
+          }
           const pane = connectionRefs.current[runtime.id]?.snapshot?.panes.find(
             (item) => item.pane_id === paneId,
           );

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -52,6 +52,7 @@ import type {
   MobileTerminalTapTarget,
   MobileTouchSelectionEndpointTimeoutMs,
 } from "./mobileTerminalPrefs";
+import type { NavigationSyncMode } from "./navigationPrefs";
 import { TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS } from "./terminalInputTransport";
 import type { TerminalInputTransport } from "./terminalInputTransport";
 import { TERMINAL_OUTPUT_COALESCE_OPTIONS_MS } from "./terminalOutputCoalescing";
@@ -60,6 +61,8 @@ type Props = {
   showMobileTerminalSettings: boolean;
   notesEnabled: boolean;
   onNotesEnabled: (enabled: boolean) => void;
+  navigationSyncMode: NavigationSyncMode;
+  onNavigationSyncMode: (mode: NavigationSyncMode) => void;
   agentFeaturesInTabs: boolean;
   onAgentFeaturesInTabs: (enabled: boolean) => void;
   multiHostSpaceSelection: boolean;
@@ -110,6 +113,8 @@ export function BackendSettingsDialog({
   showMobileTerminalSettings,
   notesEnabled,
   onNotesEnabled,
+  navigationSyncMode,
+  onNavigationSyncMode,
   agentFeaturesInTabs,
   onAgentFeaturesInTabs,
   multiHostSpaceSelection,
@@ -510,6 +515,33 @@ export function BackendSettingsDialog({
             {activeArea === "display" ? (
               <div className="settings-section settings-section-flat">
                 <div className="settings-label">Sidebar</div>
+                <div className="settings-row">
+                  <span title="Choose whether this window follows pane selections from other clients">
+                    Sync navigation
+                  </span>
+                  <div
+                    className="segmented-control"
+                    role="group"
+                    aria-label="Navigation synchronization"
+                  >
+                    <button
+                      type="button"
+                      data-on={navigationSyncMode === "independent"}
+                      aria-pressed={navigationSyncMode === "independent"}
+                      onClick={() => onNavigationSyncMode("independent")}
+                    >
+                      Off
+                    </button>
+                    <button
+                      type="button"
+                      data-on={navigationSyncMode === "shared"}
+                      aria-pressed={navigationSyncMode === "shared"}
+                      onClick={() => onNavigationSyncMode("shared")}
+                    >
+                      On
+                    </button>
+                  </div>
+                </div>
                 <div className="settings-row">
                   <span>Agent features in Tabs</span>
                   <div

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -71,6 +71,54 @@ describe("BridgeConnectionController sockets", () => {
     expect(FakeWebSocket.instances).toHaveLength(3);
     expect(FakeWebSocket.instances.filter((socket) => socket.closed)).toHaveLength(0);
   });
+
+  it("stops applying shared selection events without recreating event sockets", async () => {
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(emptySnapshot()), { status: 200 })),
+    );
+    const connectionRefs = { current: {} } as MutableRefObject<Record<string, BridgeConnectionRef>>;
+    const setConnectionStates = vi.fn() as unknown as Dispatch<
+      SetStateAction<Record<string, BridgeConnectionState>>
+    >;
+    const { render, onPaneSelection } = createConnectionHarness({
+      runtime: bridgeRuntime("bridge-a"),
+      connectionRefs,
+      setConnectionStates,
+    });
+
+    await render(vi.fn(), true);
+    const uiEvents = FakeWebSocket.instances.find(
+      (socket) => socket.url === "ws://bridge-a/ws/ui-events",
+    );
+    if (!uiEvents) {
+      throw new Error("missing UI events socket");
+    }
+    await act(async () => {
+      uiEvents.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({ type: "herdr_web.selection_changed", pane_id: "pane-a" }),
+        }),
+      );
+      await Promise.resolve();
+    });
+    expect(onPaneSelection).toHaveBeenCalledTimes(1);
+
+    await render(vi.fn(), false);
+    await act(async () => {
+      uiEvents.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({ type: "herdr_web.selection_changed", pane_id: "pane-b" }),
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(onPaneSelection).toHaveBeenCalledTimes(1);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+    expect(FakeWebSocket.instances.filter((socket) => socket.closed)).toHaveLength(0);
+  });
 });
 
 describe("QuickPaneNoteDialog", () => {
@@ -608,11 +656,15 @@ function createConnectionHarness({
   const onPaneSelection = vi.fn();
   roots.push(root);
 
-  const render = async (onNotesChanged: (bridgeId: string) => void) => {
+  const render = async (
+    onNotesChanged: (bridgeId: string) => void,
+    followSharedSelection = true,
+  ) => {
     await act(async () => {
       root.render(
         <BridgeConnectionController
           runtime={runtime}
+          followSharedSelection={followSharedSelection}
           connectionRefs={connectionRefs}
           setConnectionStates={setConnectionStates}
           onPaneSelection={onPaneSelection}
@@ -625,7 +677,7 @@ function createConnectionHarness({
     });
   };
 
-  return { render };
+  return { render, onPaneSelection };
 }
 
 function bridgeRuntime(bridgeId: string): BridgeRuntime {

--- a/web/src/navigationPrefs.test.ts
+++ b/web/src/navigationPrefs.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLIENT_NAVIGATION_PREFS_KEY,
+  DEFAULT_NAVIGATION_SYNC_MODE,
+  parseNavigationSyncMode,
+  readClientNavigationPrefs,
+  sharesNavigation,
+  writeClientNavigationPrefs,
+} from "./navigationPrefs";
+
+function memoryStorage(initial?: string) {
+  let value = initial ?? null;
+  return {
+    getItem: (key: string) => (key === CLIENT_NAVIGATION_PREFS_KEY ? value : null),
+    setItem: (key: string, next: string) => {
+      if (key === CLIENT_NAVIGATION_PREFS_KEY) {
+        value = next;
+      }
+    },
+  };
+}
+
+describe("client navigation preferences", () => {
+  it("defaults navigation synchronization to shared", () => {
+    expect(parseNavigationSyncMode(undefined)).toBe(DEFAULT_NAVIGATION_SYNC_MODE);
+    expect(parseNavigationSyncMode("other")).toBe(DEFAULT_NAVIGATION_SYNC_MODE);
+    expect(sharesNavigation(DEFAULT_NAVIGATION_SYNC_MODE)).toBe(true);
+    expect(sharesNavigation("independent")).toBe(false);
+  });
+
+  it("round-trips per-client navigation state", () => {
+    const storage = memoryStorage();
+    const prefs = {
+      mode: "independent" as const,
+      selectedBridgeId: "bridge-a",
+      selectedPane: { bridgeId: "bridge-a", paneId: "pane-a" },
+      activeWorkspace: { bridgeId: "bridge-a", workspaceId: "workspace-a" },
+      selectedPanesByBridgeId: { "bridge-a": "pane-a" },
+      activeWorkspacesByBridgeId: { "bridge-a": "workspace-a" },
+    };
+
+    writeClientNavigationPrefs(prefs, storage);
+
+    expect(readClientNavigationPrefs(storage)).toEqual(prefs);
+  });
+
+  it("drops malformed client selection data", () => {
+    const storage = memoryStorage(
+      JSON.stringify({
+        mode: "independent",
+        selectedBridgeId: 3,
+        selectedPane: { bridgeId: "bridge-a" },
+        activeWorkspace: "workspace-a",
+        selectedPanesByBridgeId: { "bridge-a": "pane-a", invalid: 4 },
+        activeWorkspacesByBridgeId: null,
+      }),
+    );
+
+    expect(readClientNavigationPrefs(storage)).toEqual({
+      mode: "independent",
+      selectedBridgeId: null,
+      selectedPane: null,
+      activeWorkspace: null,
+      selectedPanesByBridgeId: { "bridge-a": "pane-a" },
+      activeWorkspacesByBridgeId: {},
+    });
+  });
+});

--- a/web/src/navigationPrefs.ts
+++ b/web/src/navigationPrefs.ts
@@ -1,0 +1,126 @@
+export type NavigationSyncMode = "shared" | "independent";
+
+export type ClientNavigationPrefs = {
+  mode: NavigationSyncMode;
+  selectedBridgeId: string | null;
+  selectedPane: {
+    bridgeId: string;
+    paneId: string;
+  } | null;
+  activeWorkspace: {
+    bridgeId: string;
+    workspaceId: string;
+  } | null;
+  selectedPanesByBridgeId: Record<string, string>;
+  activeWorkspacesByBridgeId: Record<string, string>;
+};
+
+export const DEFAULT_NAVIGATION_SYNC_MODE: NavigationSyncMode = "shared";
+export const CLIENT_NAVIGATION_PREFS_KEY = "herdrWeb.clientNavigation.v1";
+
+const DEFAULT_CLIENT_NAVIGATION_PREFS: ClientNavigationPrefs = {
+  mode: DEFAULT_NAVIGATION_SYNC_MODE,
+  selectedBridgeId: null,
+  selectedPane: null,
+  activeWorkspace: null,
+  selectedPanesByBridgeId: {},
+  activeWorkspacesByBridgeId: {},
+};
+
+export function parseNavigationSyncMode(value: unknown): NavigationSyncMode {
+  return value === "independent" || value === "shared"
+    ? value
+    : DEFAULT_NAVIGATION_SYNC_MODE;
+}
+
+export function sharesNavigation(mode: NavigationSyncMode) {
+  return mode === "shared";
+}
+
+export function readClientNavigationPrefs(
+  storage: Pick<Storage, "getItem"> | null = browserSessionStorage(),
+): ClientNavigationPrefs {
+  if (!storage) {
+    return DEFAULT_CLIENT_NAVIGATION_PREFS;
+  }
+  try {
+    const raw = storage.getItem(CLIENT_NAVIGATION_PREFS_KEY);
+    if (!raw) {
+      return DEFAULT_CLIENT_NAVIGATION_PREFS;
+    }
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      mode: parseNavigationSyncMode(parsed.mode),
+      selectedBridgeId:
+        typeof parsed.selectedBridgeId === "string" ? parsed.selectedBridgeId : null,
+      selectedPane: parsePaneRef(parsed.selectedPane),
+      activeWorkspace: parseWorkspaceRef(parsed.activeWorkspace),
+      selectedPanesByBridgeId: parseStringRecord(parsed.selectedPanesByBridgeId),
+      activeWorkspacesByBridgeId: parseStringRecord(parsed.activeWorkspacesByBridgeId),
+    };
+  } catch {
+    return DEFAULT_CLIENT_NAVIGATION_PREFS;
+  }
+}
+
+export function writeClientNavigationPrefs(
+  prefs: ClientNavigationPrefs,
+  storage: Pick<Storage, "setItem"> | null = browserSessionStorage(),
+) {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(CLIENT_NAVIGATION_PREFS_KEY, JSON.stringify(prefs));
+  } catch {
+    // Session storage can be unavailable in private or locked-down browser contexts.
+  }
+}
+
+function browserSessionStorage() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function parsePaneRef(value: unknown): ClientNavigationPrefs["selectedPane"] {
+  if (
+    !isRecord(value) ||
+    typeof value.bridgeId !== "string" ||
+    typeof value.paneId !== "string"
+  ) {
+    return null;
+  }
+  return { bridgeId: value.bridgeId, paneId: value.paneId };
+}
+
+function parseWorkspaceRef(value: unknown): ClientNavigationPrefs["activeWorkspace"] {
+  if (
+    !isRecord(value) ||
+    typeof value.bridgeId !== "string" ||
+    typeof value.workspaceId !== "string"
+  ) {
+    return null;
+  }
+  return { bridgeId: value.bridgeId, workspaceId: value.workspaceId };
+}
+
+function parseStringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -114,6 +114,19 @@ describe("chooseSelectedPane", () => {
     ).toBe("1-1");
   });
 
+  it("ignores the bridge selection for independent navigation", () => {
+    expect(
+      chooseSelectedPane(
+        {
+          ...snapshot([pane("1-1"), pane("1-2", true)]),
+          selected_pane_id: "1-1",
+        },
+        null,
+        false,
+      ),
+    ).toBe("1-2");
+  });
+
   it("uses the snapshot selection when the current pane is gone", () => {
     expect(
       chooseSelectedPane(

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -8,7 +8,11 @@ const statusRank: Record<AgentStatus, number> = {
   unknown: 4,
 };
 
-export function chooseSelectedPane(snapshot: Snapshot | null, currentPaneId: string | null) {
+export function chooseSelectedPane(
+  snapshot: Snapshot | null,
+  currentPaneId: string | null,
+  useSharedSelection = true,
+) {
   if (!snapshot || snapshot.panes.length === 0) {
     return null;
   }
@@ -16,6 +20,7 @@ export function chooseSelectedPane(snapshot: Snapshot | null, currentPaneId: str
     return currentPaneId;
   }
   if (
+    useSharedSelection &&
     snapshot.selected_pane_id &&
     snapshot.panes.some((pane) => pane.pane_id === snapshot.selected_pane_id)
   ) {
@@ -28,18 +33,19 @@ export function chooseSelectedPaneForActiveWorkspace(
   snapshot: Snapshot | null,
   currentPaneId: string | null,
   activeWorkspaceId: string | null,
+  useSharedSelection = true,
 ) {
   if (!snapshot || !activeWorkspaceId) {
-    return chooseSelectedPane(snapshot, currentPaneId);
+    return chooseSelectedPane(snapshot, currentPaneId, useSharedSelection);
   }
   if (!snapshot.workspaces.some((workspace) => workspace.workspace_id === activeWorkspaceId)) {
-    return chooseSelectedPane(snapshot, currentPaneId);
+    return chooseSelectedPane(snapshot, currentPaneId, useSharedSelection);
   }
   const currentPane = currentPaneId
     ? snapshot.panes.find((pane) => pane.pane_id === currentPaneId)
     : null;
   if (currentPane?.workspace_id === activeWorkspaceId) {
-    return chooseSelectedPane(snapshot, currentPaneId);
+    return chooseSelectedPane(snapshot, currentPaneId, useSharedSelection);
   }
   return choosePaneForWorkspace(snapshot, activeWorkspaceId);
 }


### PR DESCRIPTION
## Summary
- add a Display setting to turn sidebar navigation sync on or off
- keep navigation selection local to each browser tab when sync is off
- preserve the existing shared bridge selection behavior when sync is on
- default navigation sync to on

## Verification
- `npm run check`
- `npm run lint:web`
- `npm run build:web`
