### PR TITLE
Harden navigation sync semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 
 ### Fixed
 
+- Fixed client-local navigation synchronization across reloads, reconnects, lagging snapshots, and
+  rapid multi-client selection races. Sync-off split navigation now stays local, and independent
+  clients no longer rewrite shared navigation persistence.
+
 ### Removed
 
 ## [0.3.3] - 2026-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - Store the Sync navigation setting browser-wide while keeping sync-off pane selections only in
   memory. The app no longer creates per-tab navigation storage records.
+  [PR #43](https://github.com/kcosr/herdr-web/pull/43)
 - Simplified agent-row metadata by removing generic status text already communicated by the status
   indicator and badge, while retaining custom status text and bridge-defined labels.
   [PR #41](https://github.com/kcosr/herdr-web/pull/41)
@@ -39,6 +40,7 @@
   rapid multi-client selection races. Sync-off split navigation now stays local, and independent
   clients no longer rewrite shared navigation persistence. After a bridge restart, the focused
   Herdr pane now seeds shared navigation so synced clients immediately converge.
+  [PR #43](https://github.com/kcosr/herdr-web/pull/43)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,6 @@
 
 - Store the Sync navigation setting browser-wide while keeping sync-off pane selections only in
   memory. The app no longer creates per-tab navigation storage records.
-- Launch each installed desktop web-app request in a new browsing context instead of allowing the
-  browser to reuse an existing exact-URL app instance.
 - Simplified agent-row metadata by removing generic status text already communicated by the status
   indicator and badge, while retaining custom status text and bridge-defined labels.
   [PR #41](https://github.com/kcosr/herdr-web/pull/41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 - Store the Sync navigation setting browser-wide while keeping sync-off pane selections only in
   memory. The app no longer creates per-tab navigation storage records.
+- Launch each installed desktop web-app request in a new browsing context instead of allowing the
+  browser to reuse an existing exact-URL app instance.
 - Simplified agent-row metadata by removing generic status text already communicated by the status
   indicator and badge, while retaining custom status text and bridge-defined labels.
   [PR #41](https://github.com/kcosr/herdr-web/pull/41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@
 
 - Fixed client-local navigation synchronization across reloads, reconnects, lagging snapshots, and
   rapid multi-client selection races. Sync-off split navigation now stays local, and independent
-  clients no longer rewrite shared navigation persistence.
+  clients no longer rewrite shared navigation persistence. After a bridge restart, the focused
+  Herdr pane now seeds shared navigation so synced clients immediately converge.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### Changed
 
+- Store the Sync navigation setting browser-wide while keeping sync-off pane selections only in
+  memory. The app no longer creates per-tab navigation storage records.
 - Simplified agent-row metadata by removing generic status text already communicated by the status
   indicator and badge, while retaining custom status text and bridge-defined labels.
   [PR #41](https://github.com/kcosr/herdr-web/pull/41)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Settings are grouped by area:
 
 - Bridge: same-origin and saved bridge profiles, reachability testing, and bridge enablement.
 - Features: client feature toggles such as Notes.
-- Display: client-local navigation synchronization, agent features in Tabs, multi-host Space
+- Display: browser-wide navigation synchronization, agent features in Tabs, multi-host Space
   selection, top/bottom app padding, and mobile terminal controls size.
 - Terminal: browser-to-bridge terminal input transport and input batching delay.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
@@ -352,9 +352,10 @@ that page should connect to another bridge; the bridge adds matching HTTP and We
 
 Sync navigation is on by default. Selecting a pane updates `/api/selection`, broadcasts over
 `/ws/ui-events`, and other clients with sync enabled switch to the same pane. Clients can turn sync
-off in Display settings to keep their pane selection local to that browser tab or window. Navigation
-with sync off still uses the same Herdr session: terminal input, structural commands, and workspace,
-tab, and pane changes remain shared.
+off in Display settings to keep each open tab's pane selection in that tab's in-memory app state.
+The Sync setting is shared by every tab on the same browser origin; no pane selection is stored per
+tab. Navigation with sync off still uses the same Herdr session: terminal input, structural
+commands, and workspace, tab, and pane changes remain shared.
 
 ## Vendoring Strategy
 

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -2472,6 +2472,7 @@ fn web_snapshot_from_session_snapshot(
     selected_pane_id: Option<String>,
 ) -> Snapshot {
     let SessionSnapshot {
+        focused_pane_id,
         workspaces,
         tabs,
         panes,
@@ -2479,7 +2480,11 @@ fn web_snapshot_from_session_snapshot(
         ..
     } = snapshot;
     let selected_pane_id = selected_pane_id
-        .filter(|pane_id| panes.iter().any(|pane| pane.pane_id == pane_id.as_str()));
+        .filter(|pane_id| panes.iter().any(|pane| pane.pane_id == pane_id.as_str()))
+        .or_else(|| {
+            focused_pane_id
+                .filter(|pane_id| panes.iter().any(|pane| pane.pane_id == pane_id.as_str()))
+        });
     let workspaces = workspaces
         .into_iter()
         .map(|workspace| {
@@ -4752,13 +4757,20 @@ mod tests {
     }
 
     #[test]
-    fn web_snapshot_adapter_drops_stale_selected_pane_ids() {
+    fn web_snapshot_adapter_falls_back_to_focused_pane_for_stale_selection() {
         let snapshot = web_snapshot_from_session_snapshot(
             test_session_snapshot(),
             Some("missing".to_string()),
         );
 
-        assert_eq!(snapshot.selected_pane_id, None);
+        assert_eq!(snapshot.selected_pane_id.as_deref(), Some("pane-1"));
+    }
+
+    #[test]
+    fn web_snapshot_adapter_uses_focused_pane_before_shared_selection_exists() {
+        let snapshot = web_snapshot_from_session_snapshot(test_session_snapshot(), None);
+
+        assert_eq!(snapshot.selected_pane_id.as_deref(), Some("pane-1"));
     }
 
     #[test]

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -4,6 +4,9 @@
   "description": "Terminal multiplexer web interface",
   "start_url": "/",
   "display": "standalone",
+  "launch_handler": {
+    "client_mode": "navigate-new"
+  },
   "orientation": "any",
   "background_color": "#11111b",
   "theme_color": "#11111b",

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -4,9 +4,6 @@
   "description": "Terminal multiplexer web interface",
   "start_url": "/",
   "display": "standalone",
-  "launch_handler": {
-    "client_mode": "navigate-new"
-  },
   "orientation": "any",
   "background_color": "#11111b",
   "theme_color": "#11111b",

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   agentSubtitle,
+  applySnapshotOverlays,
   buildVisibleAgentPaneEntries,
   buildVisibleScopedNotes,
   canAddNoteFromPaneMenu,
@@ -28,7 +29,7 @@ import {
   sortScopedAgentPanes,
   stableBridgeRefreshOffsetMs,
 } from "./App";
-import type { BridgeConnectionView } from "./App";
+import type { BridgeConnectionRef, BridgeConnectionView } from "./App";
 import type { BridgeRuntime } from "./bridge";
 import { agentActivityKey } from "./agentActivity";
 import {
@@ -45,6 +46,46 @@ describe("App connection guards", () => {
 
     expect(currentConnectionSnapshot(snapshot, "same-origin", "same-origin")).toBe(snapshot);
     expect(currentConnectionSnapshot(snapshot, "configured:a", "configured:b")).toBeNull();
+  });
+
+  it("keeps a recent selection event over a lagging snapshot until the snapshot catches up", () => {
+    const data = multiPaneSnapshot(
+      [workspace("workspace-a", 1)],
+      [
+        pane("pane-a", "workspace-a", "tab-a"),
+        pane("pane-b", "workspace-a", "tab-a"),
+      ],
+    );
+    const ref: BridgeConnectionRef = {
+      connectionKey: "bridge-a",
+      snapshot: data,
+      activityGeneration: 1,
+      resyncBarrierGeneration: 1,
+      activityLog: [],
+      sharedSelectionOverride: {
+        paneId: "pane-b",
+        expiresAtMs: Date.now() + 2000,
+      },
+    };
+
+    expect(
+      applySnapshotOverlays({ ...data, selected_pane_id: "pane-a" }, ref, 1)
+        .selected_pane_id,
+    ).toBe("pane-b");
+    expect(ref.sharedSelectionOverride?.paneId).toBe("pane-b");
+
+    expect(
+      applySnapshotOverlays({ ...data, selected_pane_id: "pane-b" }, ref, 1)
+        .selected_pane_id,
+    ).toBe("pane-b");
+    expect(ref.sharedSelectionOverride).toBeNull();
+
+    ref.sharedSelectionOverride = { paneId: "pane-b", expiresAtMs: 0 };
+    expect(
+      applySnapshotOverlays({ ...data, selected_pane_id: "pane-a" }, ref, 1)
+        .selected_pane_id,
+    ).toBe("pane-a");
+    expect(ref.sharedSelectionOverride).toBeNull();
   });
 
   it("rejects async results from stale backend connections", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -125,6 +125,7 @@ import type { NoteAttachment, NotesListResponse, PaneNote } from "./notes";
 import {
   NAVIGATION_SYNC_MODE_KEY,
   navigationSyncModeForStorageEvent,
+  parseNavigationSyncMode,
   readNavigationSyncMode,
   sharesNavigation,
   writeNavigationSyncMode,
@@ -501,6 +502,28 @@ async function loadSharedNavigationPrefs(): Promise<SharedNavigationPrefs> {
     return value ? parseSharedNavigationPrefs(JSON.parse(value)) : localPrefs;
   } catch {
     return localPrefs;
+  }
+}
+
+async function loadNavigationSyncMode(): Promise<NavigationSyncMode> {
+  const localMode = readNavigationSyncMode();
+  if (!isNativeApp()) {
+    return localMode;
+  }
+  try {
+    const { value } = await Preferences.get({ key: NAVIGATION_SYNC_MODE_KEY });
+    return value ? parseNavigationSyncMode(value) : localMode;
+  } catch {
+    return localMode;
+  }
+}
+
+function persistNavigationSyncMode(mode: NavigationSyncMode) {
+  writeNavigationSyncMode(mode);
+  if (isNativeApp()) {
+    void Preferences.set({ key: NAVIGATION_SYNC_MODE_KEY, value: mode }).catch(() => {
+      // Browser storage above remains a best-effort backup.
+    });
   }
 }
 
@@ -989,8 +1012,12 @@ export function App() {
       return;
     }
     let cancelled = false;
-    void Promise.all([loadDisplayPrefs(), loadSharedNavigationPrefs()]).then(
-      ([prefs, sharedNavigationPrefs]) => {
+    void Promise.all([
+      loadDisplayPrefs(),
+      loadSharedNavigationPrefs(),
+      loadNavigationSyncMode(),
+    ]).then(
+      ([prefs, sharedNavigationPrefs, loadedNavigationSyncMode]) => {
       if (cancelled) {
         return;
       }
@@ -1011,13 +1038,12 @@ export function App() {
       setNotesEnabled(prefs.notesEnabled);
       setNotesPanelOpen(prefs.notesEnabled && prefs.notesPanelOpen);
       setSidebarOpen(prefs.sidebarOpen);
-      if (sharesNavigation(navigationSyncMode)) {
-        setSelectedBridgeId(sharedNavigationPrefs.selectedBridgeId);
-        setSelectedPaneRefState(sharedNavigationPrefs.selectedPane);
-        setActiveWorkspaceRefState(sharedNavigationPrefs.activeWorkspace);
-        setSelectedPanesByBridgeId(sharedNavigationPrefs.selectedPanesByBridgeId);
-        setActiveWorkspacesByBridgeId(sharedNavigationPrefs.activeWorkspacesByBridgeId);
-      }
+      setNavigationSyncMode(loadedNavigationSyncMode);
+      setSelectedBridgeId(sharedNavigationPrefs.selectedBridgeId);
+      setSelectedPaneRefState(sharedNavigationPrefs.selectedPane);
+      setActiveWorkspaceRefState(sharedNavigationPrefs.activeWorkspace);
+      setSelectedPanesByBridgeId(sharedNavigationPrefs.selectedPanesByBridgeId);
+      setActiveWorkspacesByBridgeId(sharedNavigationPrefs.activeWorkspacesByBridgeId);
       setTerminalFontSizePx(prefs.terminalFontSizePx);
       setTerminalInputTransport(prefs.terminalInputTransport);
       setTerminalInputBatchDelayMs(prefs.terminalInputBatchDelayMs);
@@ -1037,7 +1063,7 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [displayPrefsLoaded, navigationSyncMode]);
+  }, [displayPrefsLoaded]);
 
   useEffect(() => {
     return addNativeBackHandler(() => {
@@ -1744,7 +1770,7 @@ export function App() {
   ]);
 
   const changeNavigationSyncMode = useCallback((mode: NavigationSyncMode) => {
-    writeNavigationSyncMode(mode);
+    persistNavigationSyncMode(mode);
     applyNavigationSyncMode(mode);
   }, [applyNavigationSyncMode]);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -123,9 +123,11 @@ import {
 } from "./notes";
 import type { NoteAttachment, NotesListResponse, PaneNote } from "./notes";
 import {
-  readClientNavigationPrefs,
+  NAVIGATION_SYNC_MODE_KEY,
+  navigationSyncModeForStorageEvent,
+  readNavigationSyncMode,
   sharesNavigation,
-  writeClientNavigationPrefs,
+  writeNavigationSyncMode,
 } from "./navigationPrefs";
 import type { NavigationSyncMode } from "./navigationPrefs";
 import { ActionMenu, ConfirmDialog, RenameDialog, useLongPress } from "./overlays";
@@ -815,9 +817,7 @@ export function App() {
   const bridge = useBridge();
   const initialPrefs = useMemo(readDisplayPrefs, []);
   const initialSharedNavigationPrefs = useMemo(readSharedNavigationPrefs, []);
-  const initialClientNavigationPrefs = useMemo(readClientNavigationPrefs, []);
-  const initialNavigationIsIndependent =
-    initialClientNavigationPrefs.mode === "independent";
+  const initialNavigationSyncMode = useMemo(readNavigationSyncMode, []);
   const legacySelectionPrefs = useMemo(readLegacyDisplaySelectionPrefs, []);
   const [displayPrefsLoaded, setDisplayPrefsLoaded] = useState(() => !isNativeApp());
   const [connectionStates, setConnectionStates] = useState<Record<string, BridgeConnectionState>>({});
@@ -830,12 +830,10 @@ export function App() {
   >({});
   const launcherPresetStatesRef = useRef(launcherPresetStates);
   const [selectedBridgeId, setSelectedBridgeId] = useState<BridgeId | null>(
-    initialNavigationIsIndependent
-      ? initialClientNavigationPrefs.selectedBridgeId
-      : initialSharedNavigationPrefs.selectedBridgeId,
+    initialSharedNavigationPrefs.selectedBridgeId,
   );
   const [navigationSyncMode, setNavigationSyncMode] = useState<NavigationSyncMode>(
-    initialClientNavigationPrefs.mode,
+    initialNavigationSyncMode,
   );
   const navigationIsShared = sharesNavigation(navigationSyncMode);
   const [selectedNoteRef, setSelectedNoteRef] = useState<ScopedNoteRef | null>(null);
@@ -850,24 +848,16 @@ export function App() {
   const [quickPaneNoteTarget, setQuickPaneNoteTarget] = useState<QuickPaneNoteTarget | null>(null);
   const [quickPaneNoteCreating, setQuickPaneNoteCreating] = useState(false);
   const [selectedPaneRefState, setSelectedPaneRefState] = useState<ScopedPaneRef | null>(
-    initialNavigationIsIndependent
-      ? initialClientNavigationPrefs.selectedPane
-      : initialSharedNavigationPrefs.selectedPane,
+    initialSharedNavigationPrefs.selectedPane,
   );
   const [activeWorkspaceRefState, setActiveWorkspaceRefState] = useState<ScopedWorkspaceRef | null>(
-    initialNavigationIsIndependent
-      ? initialClientNavigationPrefs.activeWorkspace
-      : initialSharedNavigationPrefs.activeWorkspace,
+    initialSharedNavigationPrefs.activeWorkspace,
   );
   const [selectedPanesByBridgeId, setSelectedPanesByBridgeId] = useState<Record<string, string>>(
-    initialNavigationIsIndependent
-      ? initialClientNavigationPrefs.selectedPanesByBridgeId
-      : initialSharedNavigationPrefs.selectedPanesByBridgeId,
+    initialSharedNavigationPrefs.selectedPanesByBridgeId,
   );
   const [activeWorkspacesByBridgeId, setActiveWorkspacesByBridgeId] = useState<Record<string, string>>(
-    initialNavigationIsIndependent
-      ? initialClientNavigationPrefs.activeWorkspacesByBridgeId
-      : initialSharedNavigationPrefs.activeWorkspacesByBridgeId,
+    initialSharedNavigationPrefs.activeWorkspacesByBridgeId,
   );
   const [hostScope, setHostScope] = useState<HostScope>(initialPrefs.hostScope);
   const [scope, setScope] = useState<Scope>(initialPrefs.scope);
@@ -1509,24 +1499,6 @@ export function App() {
   ]);
 
   useEffect(() => {
-    writeClientNavigationPrefs({
-      mode: navigationSyncMode,
-      selectedBridgeId,
-      selectedPane: selectedPaneRefState,
-      activeWorkspace: activeWorkspaceRefState,
-      selectedPanesByBridgeId,
-      activeWorkspacesByBridgeId,
-    });
-  }, [
-    activeWorkspaceRefState,
-    activeWorkspacesByBridgeId,
-    navigationSyncMode,
-    selectedBridgeId,
-    selectedPaneRefState,
-    selectedPanesByBridgeId,
-  ]);
-
-  useEffect(() => {
     if (!displayPrefsLoaded || !navigationIsShared) {
       return;
     }
@@ -1749,7 +1721,7 @@ export function App() {
     rememberPaneSelection(bridgeId, paneId, workspaceId);
   }, [clearPendingSharedPaneSelection, rememberPaneSelection]);
 
-  const changeNavigationSyncMode = (mode: NavigationSyncMode) => {
+  const applyNavigationSyncMode = useCallback((mode: NavigationSyncMode) => {
     if (mode === "independent") {
       for (const bridgeId of Object.keys(pendingSharedPaneSelectionsRef.current)) {
         clearPendingSharedPaneSelection(bridgeId);
@@ -1764,7 +1736,31 @@ export function App() {
       }
     }
     setNavigationSyncMode(mode);
-  };
+  }, [
+    clearPendingSharedPaneSelection,
+    rememberPaneSelection,
+    selectedRuntime,
+    snapshot,
+  ]);
+
+  const changeNavigationSyncMode = useCallback((mode: NavigationSyncMode) => {
+    writeNavigationSyncMode(mode);
+    applyNavigationSyncMode(mode);
+  }, [applyNavigationSyncMode]);
+
+  useEffect(() => {
+    const syncNavigationModeFromStorage = (event: StorageEvent) => {
+      if (event.key !== NAVIGATION_SYNC_MODE_KEY) {
+        return;
+      }
+      const mode = navigationSyncModeForStorageEvent(event.newValue);
+      if (mode) {
+        applyNavigationSyncMode(mode);
+      }
+    };
+    window.addEventListener("storage", syncNavigationModeFromStorage);
+    return () => window.removeEventListener("storage", syncNavigationModeFromStorage);
+  }, [applyNavigationSyncMode]);
 
   useEffect(() => {
     const activeBridgeIds = new Set(bridge.enabledRuntimes.map((runtime) => runtime.id));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -152,6 +152,7 @@ import {
   basename,
   canClearTabName,
   canClearWorkspaceName,
+  chooseDirectionalPane,
   choosePaneForTab,
   choosePaneForWorkspace,
   chooseSelectedPane,
@@ -233,6 +234,11 @@ type PendingCreatedPaneNote = PendingCreatedPaneNoteTarget & {
 type QuickPaneNoteTarget = ScopedPaneRef & {
   label: string;
 };
+type PendingSharedPaneSelection = {
+  paneId: string;
+  connectionKey: string;
+  timeoutId: number;
+};
 type BridgeAgentPinsState = BridgeResourceState<AgentPinsListResponse>;
 type BridgeAgentActivityState = BridgeResourceState<AgentActivityListResponse>;
 export type BridgeConnectionRef = {
@@ -241,6 +247,10 @@ export type BridgeConnectionRef = {
   activityGeneration: number;
   resyncBarrierGeneration: number;
   activityLog: ActivityLogEntry[];
+  sharedSelectionOverride: {
+    paneId: string;
+    expiresAtMs: number;
+  } | null;
 };
 export type ScopedAgentPane = {
   bridgeId: BridgeId;
@@ -341,11 +351,6 @@ type DisplayPrefs = {
   notesEnabled: boolean;
   notesPanelOpen: boolean;
   sidebarOpen: boolean;
-  selectedBridgeId: BridgeId | null;
-  selectedPane: ScopedPaneRef | null;
-  activeWorkspace: ScopedWorkspaceRef | null;
-  selectedPanesByBridgeId: Record<string, string>;
-  activeWorkspacesByBridgeId: Record<string, string>;
   terminalFontSizePx: number;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
@@ -360,6 +365,13 @@ type DisplayPrefs = {
   mobileCommandExpandingInput: boolean;
   mobileCommandEnterNewline: boolean;
 };
+type SharedNavigationPrefs = {
+  selectedBridgeId: BridgeId | null;
+  selectedPane: ScopedPaneRef | null;
+  activeWorkspace: ScopedWorkspaceRef | null;
+  selectedPanesByBridgeId: Record<string, string>;
+  activeWorkspacesByBridgeId: Record<string, string>;
+};
 type LegacyDisplaySelectionPrefs = {
   activeSpaceId: string | null;
   selectedPaneId: string | null;
@@ -367,6 +379,7 @@ type LegacyDisplaySelectionPrefs = {
 const COMPACT_LAYOUT_QUERY = "(max-width: 820px)";
 const TOUCH_INPUT_QUERY = "(hover: none) and (pointer: coarse)";
 const DISPLAY_PREFS_KEY = "herdr.mobileWeb.displayPrefs.v2";
+const SHARED_NAVIGATION_PREFS_KEY = "herdr.mobileWeb.sharedNavigation.v1";
 const LEGACY_DISPLAY_PREFS_KEY = "herdr.mobileWeb.displayPrefs.v1";
 const MOBILE_SIDEBAR_HISTORY_KEY = "herdrWebMobileSidebar";
 const MOBILE_DETAIL_HISTORY_KEY = "herdrWebMobileDetail";
@@ -399,11 +412,6 @@ function readDisplayPrefs(): DisplayPrefs {
     notesEnabled: true,
     notesPanelOpen: false,
     sidebarOpen: true,
-    selectedBridgeId: null,
-    selectedPane: null,
-    activeWorkspace: null,
-    selectedPanesByBridgeId: {},
-    activeWorkspacesByBridgeId: {},
     terminalFontSizePx: DEFAULT_TERMINAL_FONT_SIZE_PX,
     terminalInputTransport: DEFAULT_TERMINAL_INPUT_TRANSPORT,
     terminalInputBatchDelayMs: DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
@@ -446,6 +454,52 @@ async function loadDisplayPrefs(): Promise<DisplayPrefs> {
     // Fall back to browser storage backup.
   }
   return localPrefs;
+}
+
+function emptySharedNavigationPrefs(): SharedNavigationPrefs {
+  return {
+    selectedBridgeId: null,
+    selectedPane: null,
+    activeWorkspace: null,
+    selectedPanesByBridgeId: {},
+    activeWorkspacesByBridgeId: {},
+  };
+}
+
+function parseSharedNavigationPrefs(value: unknown): SharedNavigationPrefs {
+  if (!isRecord(value)) {
+    return emptySharedNavigationPrefs();
+  }
+  return {
+    selectedBridgeId:
+      typeof value.selectedBridgeId === "string" ? value.selectedBridgeId : null,
+    selectedPane: parseScopedPaneRef(value.selectedPane),
+    activeWorkspace: parseScopedWorkspaceRef(value.activeWorkspace),
+    selectedPanesByBridgeId: parseStringRecord(value.selectedPanesByBridgeId),
+    activeWorkspacesByBridgeId: parseStringRecord(value.activeWorkspacesByBridgeId),
+  };
+}
+
+function readSharedNavigationPrefs(): SharedNavigationPrefs {
+  try {
+    const raw = window.localStorage.getItem(SHARED_NAVIGATION_PREFS_KEY);
+    return raw ? parseSharedNavigationPrefs(JSON.parse(raw)) : emptySharedNavigationPrefs();
+  } catch {
+    return emptySharedNavigationPrefs();
+  }
+}
+
+async function loadSharedNavigationPrefs(): Promise<SharedNavigationPrefs> {
+  const localPrefs = readSharedNavigationPrefs();
+  if (!isNativeApp()) {
+    return localPrefs;
+  }
+  try {
+    const { value } = await Preferences.get({ key: SHARED_NAVIGATION_PREFS_KEY });
+    return value ? parseSharedNavigationPrefs(JSON.parse(value)) : localPrefs;
+  } catch {
+    return localPrefs;
+  }
 }
 
 function parseDisplayPrefsValue(
@@ -523,12 +577,6 @@ function parseDisplayPrefsValue(
     notesPanelOpen:
       typeof parsed.notesPanelOpen === "boolean" ? parsed.notesPanelOpen : fallback.notesPanelOpen,
     sidebarOpen,
-    selectedBridgeId:
-      typeof parsed.selectedBridgeId === "string" ? parsed.selectedBridgeId : fallback.selectedBridgeId,
-    selectedPane: parseScopedPaneRef(parsed.selectedPane),
-    activeWorkspace: parseScopedWorkspaceRef(parsed.activeWorkspace),
-    selectedPanesByBridgeId: parseStringRecord(parsed.selectedPanesByBridgeId),
-    activeWorkspacesByBridgeId: parseStringRecord(parsed.activeWorkspacesByBridgeId),
     terminalFontSizePx: parseTerminalFontSizePx(parsed.terminalFontSizePx),
     terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
     terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
@@ -582,14 +630,7 @@ function readLegacyDisplayPrefs(fallback: DisplayPrefs): DisplayPrefs {
       selectedPaneId?: unknown;
       mobileTouchSelection?: unknown;
     } & Partial<DisplayPrefs>;
-    return {
-      ...parseDisplayPrefsValue(parsed, fallback),
-      selectedBridgeId: fallback.selectedBridgeId,
-      selectedPane: fallback.selectedPane,
-      activeWorkspace: fallback.activeWorkspace,
-      selectedPanesByBridgeId: fallback.selectedPanesByBridgeId,
-      activeWorkspacesByBridgeId: fallback.activeWorkspacesByBridgeId,
-    };
+    return parseDisplayPrefsValue(parsed, fallback);
   } catch {
     return fallback;
   }
@@ -667,6 +708,22 @@ async function writeDisplayPrefs(prefs: DisplayPrefs) {
   try {
     window.localStorage.setItem(DISPLAY_PREFS_KEY, value);
     window.localStorage.removeItem(LEGACY_DISPLAY_PREFS_KEY);
+  } catch {
+    // Storage can be unavailable in private or locked-down browser contexts.
+  }
+}
+
+async function writeSharedNavigationPrefs(prefs: SharedNavigationPrefs) {
+  const value = JSON.stringify(prefs);
+  if (isNativeApp()) {
+    try {
+      await Preferences.set({ key: SHARED_NAVIGATION_PREFS_KEY, value });
+    } catch {
+      // Browser storage below remains a best-effort backup.
+    }
+  }
+  try {
+    window.localStorage.setItem(SHARED_NAVIGATION_PREFS_KEY, value);
   } catch {
     // Storage can be unavailable in private or locked-down browser contexts.
   }
@@ -757,6 +814,7 @@ function usePointerDragResize(
 export function App() {
   const bridge = useBridge();
   const initialPrefs = useMemo(readDisplayPrefs, []);
+  const initialSharedNavigationPrefs = useMemo(readSharedNavigationPrefs, []);
   const initialClientNavigationPrefs = useMemo(readClientNavigationPrefs, []);
   const initialNavigationIsIndependent =
     initialClientNavigationPrefs.mode === "independent";
@@ -774,7 +832,7 @@ export function App() {
   const [selectedBridgeId, setSelectedBridgeId] = useState<BridgeId | null>(
     initialNavigationIsIndependent
       ? initialClientNavigationPrefs.selectedBridgeId
-      : initialPrefs.selectedBridgeId,
+      : initialSharedNavigationPrefs.selectedBridgeId,
   );
   const [navigationSyncMode, setNavigationSyncMode] = useState<NavigationSyncMode>(
     initialClientNavigationPrefs.mode,
@@ -794,22 +852,22 @@ export function App() {
   const [selectedPaneRefState, setSelectedPaneRefState] = useState<ScopedPaneRef | null>(
     initialNavigationIsIndependent
       ? initialClientNavigationPrefs.selectedPane
-      : initialPrefs.selectedPane,
+      : initialSharedNavigationPrefs.selectedPane,
   );
   const [activeWorkspaceRefState, setActiveWorkspaceRefState] = useState<ScopedWorkspaceRef | null>(
     initialNavigationIsIndependent
       ? initialClientNavigationPrefs.activeWorkspace
-      : initialPrefs.activeWorkspace,
+      : initialSharedNavigationPrefs.activeWorkspace,
   );
   const [selectedPanesByBridgeId, setSelectedPanesByBridgeId] = useState<Record<string, string>>(
     initialNavigationIsIndependent
       ? initialClientNavigationPrefs.selectedPanesByBridgeId
-      : initialPrefs.selectedPanesByBridgeId,
+      : initialSharedNavigationPrefs.selectedPanesByBridgeId,
   );
   const [activeWorkspacesByBridgeId, setActiveWorkspacesByBridgeId] = useState<Record<string, string>>(
     initialNavigationIsIndependent
       ? initialClientNavigationPrefs.activeWorkspacesByBridgeId
-      : initialPrefs.activeWorkspacesByBridgeId,
+      : initialSharedNavigationPrefs.activeWorkspacesByBridgeId,
   );
   const [hostScope, setHostScope] = useState<HostScope>(initialPrefs.hostScope);
   const [scope, setScope] = useState<Scope>(initialPrefs.scope);
@@ -896,6 +954,7 @@ export function App() {
   const isCompactLayoutRef = useRef(isCompactLayout);
   const showDetailRef = useRef(showDetail);
   const selectedBridgeIdRef = useRef(selectedBridgeId);
+  const pendingSharedPaneSelectionsRef = useRef<Record<string, PendingSharedPaneSelection>>({});
   const mobileSidebarHistoryRef = useRef(false);
   const mobileDetailHistoryRef = useRef(false);
   const legacySelectionAppliedRef = useRef(false);
@@ -908,13 +967,40 @@ export function App() {
     y: number;
     target: HTMLDivElement;
   } | null>(null);
+  const clearPendingSharedPaneSelection = useCallback((
+    bridgeId: BridgeId,
+    paneId?: string,
+    connectionKey?: string,
+  ) => {
+    const pending = pendingSharedPaneSelectionsRef.current[bridgeId];
+    if (
+      !pending ||
+      (paneId && pending.paneId !== paneId) ||
+      (connectionKey && pending.connectionKey !== connectionKey)
+    ) {
+      return false;
+    }
+    window.clearTimeout(pending.timeoutId);
+    delete pendingSharedPaneSelectionsRef.current[bridgeId];
+    return true;
+  }, []);
+
+  useEffect(
+    () => () => {
+      for (const bridgeId of Object.keys(pendingSharedPaneSelectionsRef.current)) {
+        clearPendingSharedPaneSelection(bridgeId);
+      }
+    },
+    [clearPendingSharedPaneSelection],
+  );
 
   useEffect(() => {
     if (displayPrefsLoaded) {
       return;
     }
     let cancelled = false;
-    void loadDisplayPrefs().then((prefs) => {
+    void Promise.all([loadDisplayPrefs(), loadSharedNavigationPrefs()]).then(
+      ([prefs, sharedNavigationPrefs]) => {
       if (cancelled) {
         return;
       }
@@ -936,11 +1022,11 @@ export function App() {
       setNotesPanelOpen(prefs.notesEnabled && prefs.notesPanelOpen);
       setSidebarOpen(prefs.sidebarOpen);
       if (sharesNavigation(navigationSyncMode)) {
-        setSelectedBridgeId(prefs.selectedBridgeId);
-        setSelectedPaneRefState(prefs.selectedPane);
-        setActiveWorkspaceRefState(prefs.activeWorkspace);
-        setSelectedPanesByBridgeId(prefs.selectedPanesByBridgeId);
-        setActiveWorkspacesByBridgeId(prefs.activeWorkspacesByBridgeId);
+        setSelectedBridgeId(sharedNavigationPrefs.selectedBridgeId);
+        setSelectedPaneRefState(sharedNavigationPrefs.selectedPane);
+        setActiveWorkspaceRefState(sharedNavigationPrefs.activeWorkspace);
+        setSelectedPanesByBridgeId(sharedNavigationPrefs.selectedPanesByBridgeId);
+        setActiveWorkspacesByBridgeId(sharedNavigationPrefs.activeWorkspacesByBridgeId);
       }
       setTerminalFontSizePx(prefs.terminalFontSizePx);
       setTerminalInputTransport(prefs.terminalInputTransport);
@@ -956,7 +1042,8 @@ export function App() {
       setMobileCommandExpandingInput(prefs.mobileCommandExpandingInput);
       setMobileCommandEnterNewline(prefs.mobileCommandEnterNewline);
       setDisplayPrefsLoaded(true);
-    });
+      },
+    );
     return () => {
       cancelled = true;
     };
@@ -1052,10 +1139,15 @@ export function App() {
       : selectedRuntime
         ? (activeWorkspacesByBridgeId[selectedRuntime.id] ?? null)
         : null;
+  const preferSharedSnapshotSelection =
+    navigationIsShared &&
+    Boolean(selectedRuntime) &&
+    !pendingSharedPaneSelectionsRef.current[selectedRuntime?.id ?? ""];
   const resolvedPaneId = chooseSelectedPane(
     snapshot,
     selectedRawPaneId,
-    sharesNavigation(navigationSyncMode),
+    navigationIsShared,
+    preferSharedSnapshotSelection,
   );
   const supportedCommands =
     selectedRuntime?.capabilityState === "ready" ? (selectedRuntime.capabilities?.commands ?? []) : [];
@@ -1354,11 +1446,21 @@ export function App() {
     }
     const restoredPaneId = selectedPanesByBridgeId[selectedRuntime.id] ?? null;
     const restoredWorkspaceId = activeWorkspacesByBridgeId[selectedRuntime.id] ?? null;
+    if (
+      navigationIsShared &&
+      snapshot?.selected_pane_id &&
+      pendingSharedPaneSelectionsRef.current[selectedRuntime.id]?.paneId ===
+        snapshot.selected_pane_id
+    ) {
+      clearPendingSharedPaneSelection(selectedRuntime.id, snapshot.selected_pane_id);
+    }
     const nextPaneId = chooseSelectedPaneForActiveWorkspace(
       snapshot,
       restoredPaneId,
       restoredWorkspaceId,
-      sharesNavigation(navigationSyncMode),
+      navigationIsShared,
+      navigationIsShared &&
+        !pendingSharedPaneSelectionsRef.current[selectedRuntime.id],
     );
     setSelectedPaneRefState((current) => {
       if (!nextPaneId) {
@@ -1399,7 +1501,8 @@ export function App() {
     });
   }, [
     activeWorkspacesByBridgeId,
-    navigationSyncMode,
+    clearPendingSharedPaneSelection,
+    navigationIsShared,
     selectedPanesByBridgeId,
     selectedRuntime?.id,
     snapshot,
@@ -1424,13 +1527,30 @@ export function App() {
   ]);
 
   useEffect(() => {
+    if (!displayPrefsLoaded || !navigationIsShared) {
+      return;
+    }
+    void writeSharedNavigationPrefs({
+      selectedBridgeId,
+      selectedPane: selectedPaneRefState,
+      activeWorkspace: activeWorkspaceRefState,
+      selectedPanesByBridgeId,
+      activeWorkspacesByBridgeId,
+    });
+  }, [
+    activeWorkspaceRefState,
+    activeWorkspacesByBridgeId,
+    displayPrefsLoaded,
+    navigationIsShared,
+    selectedBridgeId,
+    selectedPaneRefState,
+    selectedPanesByBridgeId,
+  ]);
+
+  useEffect(() => {
     if (!displayPrefsLoaded) {
       return;
     }
-    // Independent clients persist navigation in sessionStorage. Preserve the shared
-    // local/native selection fields when writing unrelated display preferences so
-    // another tab's independent navigation cannot replace a Shared client's reload state.
-    const persistedSharedNavigation = navigationIsShared ? null : readDisplayPrefs();
     void writeDisplayPrefs({
       hostScope,
       scope,
@@ -1449,21 +1569,6 @@ export function App() {
       notesEnabled,
       notesPanelOpen,
       sidebarOpen,
-      selectedBridgeId: persistedSharedNavigation
-        ? persistedSharedNavigation.selectedBridgeId
-        : selectedBridgeId,
-      selectedPane: persistedSharedNavigation
-        ? persistedSharedNavigation.selectedPane
-        : selectedPaneRefState,
-      activeWorkspace: persistedSharedNavigation
-        ? persistedSharedNavigation.activeWorkspace
-        : activeWorkspaceRefState,
-      selectedPanesByBridgeId: persistedSharedNavigation
-        ? persistedSharedNavigation.selectedPanesByBridgeId
-        : selectedPanesByBridgeId,
-      activeWorkspacesByBridgeId: persistedSharedNavigation
-        ? persistedSharedNavigation.activeWorkspacesByBridgeId
-        : activeWorkspacesByBridgeId,
       terminalFontSizePx,
       terminalInputTransport,
       terminalInputBatchDelayMs,
@@ -1490,7 +1595,6 @@ export function App() {
     agentActiveOnly,
     agentFeaturesInTabs,
     multiHostSpaceSelection,
-    navigationIsShared,
     sidebarWidth,
     notesPanelWidth,
     notesListPaneWidth,
@@ -1498,11 +1602,6 @@ export function App() {
     notesEnabled,
     notesPanelOpen,
     sidebarOpen,
-    selectedBridgeId,
-    selectedPaneRefState,
-    activeWorkspaceRefState,
-    selectedPanesByBridgeId,
-    activeWorkspacesByBridgeId,
     terminalFontSizePx,
     terminalInputTransport,
     terminalInputBatchDelayMs,
@@ -1635,7 +1734,27 @@ export function App() {
     }
   }, []);
 
+  const applySharedPaneSelection = useCallback((
+    bridgeId: BridgeId,
+    paneId: string,
+    workspaceId?: string,
+  ) => {
+    const pendingPaneId = pendingSharedPaneSelectionsRef.current[bridgeId]?.paneId;
+    if (pendingPaneId && pendingPaneId !== paneId) {
+      return;
+    }
+    if (pendingPaneId === paneId) {
+      clearPendingSharedPaneSelection(bridgeId, paneId);
+    }
+    rememberPaneSelection(bridgeId, paneId, workspaceId);
+  }, [clearPendingSharedPaneSelection, rememberPaneSelection]);
+
   const changeNavigationSyncMode = (mode: NavigationSyncMode) => {
+    if (mode === "independent") {
+      for (const bridgeId of Object.keys(pendingSharedPaneSelectionsRef.current)) {
+        clearPendingSharedPaneSelection(bridgeId);
+      }
+    }
     if (mode === "shared" && selectedRuntime && snapshot?.selected_pane_id) {
       const pane = snapshot.panes.find(
         (candidate) => candidate.pane_id === snapshot.selected_pane_id,
@@ -1660,6 +1779,14 @@ export function App() {
         pendingCreatedPaneNotesRef.current[bridgeId] = nextEntries;
       } else {
         delete pendingCreatedPaneNotesRef.current[bridgeId];
+      }
+    }
+
+    for (const [bridgeId, pending] of Object.entries(
+      pendingSharedPaneSelectionsRef.current,
+    )) {
+      if (activeConnectionKeysByBridgeId.get(bridgeId) !== pending.connectionKey) {
+        clearPendingSharedPaneSelection(bridgeId);
       }
     }
 
@@ -1716,7 +1843,7 @@ export function App() {
       }
       return changed ? next : current;
     });
-  }, [bridge.enabledRuntimes]);
+  }, [bridge.enabledRuntimes, clearPendingSharedPaneSelection]);
 
   useEffect(() => {
     if (!error) {
@@ -1958,6 +2085,34 @@ export function App() {
   // Shared navigation mirrors browser focus to Herdr so `active_tab_id` tracks
   // the synchronized view. Independent navigation deliberately leaves Herdr's
   // global focus alone. `tab.focus` also activates the tab's workspace.
+  const publishSharedPaneSelection = (runtime: BridgeRuntime, paneId: string) => {
+    clearPendingSharedPaneSelection(runtime.id);
+    const refreshIfConnectionIsCurrent = () => {
+      if (connectionRefs.current[runtime.id]?.connectionKey === runtime.connectionKey) {
+        void refreshBridgeSnapshot(runtime, false);
+      }
+    };
+    const timeoutId = window.setTimeout(() => {
+      if (
+        clearPendingSharedPaneSelection(runtime.id, paneId, runtime.connectionKey)
+      ) {
+        refreshIfConnectionIsCurrent();
+      }
+    }, SHARED_SELECTION_SETTLE_TIMEOUT_MS);
+    pendingSharedPaneSelectionsRef.current[runtime.id] = {
+      paneId,
+      connectionKey: runtime.connectionKey,
+      timeoutId,
+    };
+    void syncSelectedPane(runtime.httpUrl, paneId).catch(() => {
+      if (
+        clearPendingSharedPaneSelection(runtime.id, paneId, runtime.connectionKey)
+      ) {
+        refreshIfConnectionIsCurrent();
+      }
+    });
+  };
+
   const pushFocus = (runtime: BridgeRuntime | null, tabId?: string, workspaceId?: string) => {
     if (!navigationIsShared || !runtime || runtime.capabilityState !== "ready") {
       return;
@@ -2003,7 +2158,7 @@ export function App() {
     bridge.markBridgeUsed(bridgeId);
     rememberPaneSelection(bridgeId, pane.pane_id, pane.workspace_id);
     if (navigationIsShared && runtime.capabilityState === "ready") {
-      void syncSelectedPane(runtime.httpUrl, pane.pane_id).catch(() => {});
+      publishSharedPaneSelection(runtime, pane.pane_id);
     }
     pushFocus(runtime, pane.tab_id, pane.workspace_id);
     if (isCompactLayout) {
@@ -2054,7 +2209,7 @@ export function App() {
         const pane = bridgeSnapshot.panes.find((item) => item.pane_id === paneId);
         rememberPaneSelection(bridgeId, paneId, pane?.workspace_id ?? workspaceId);
         if (navigationIsShared && runtime.capabilityState === "ready") {
-          void syncSelectedPane(runtime.httpUrl, paneId).catch(() => {});
+          publishSharedPaneSelection(runtime, paneId);
         }
         pushFocus(runtime, pane?.tab_id, workspaceId);
         return;
@@ -2529,7 +2684,10 @@ export function App() {
       const closeTabShortcut = isCloseTabShortcut(event);
       const newTabShortcut = isNewTabShortcut(event);
       const splitDirection = splitSupported ? splitShortcutDirection(event) : null;
-      const paneFocusDirection = paneFocusSupported ? paneFocusShortcutDirection(event) : null;
+      const paneFocusDirection =
+        paneFocusSupported || !navigationIsShared
+          ? paneFocusShortcutDirection(event)
+          : null;
       const paneCycleStep = paneCycleShortcutStep(event);
       if (
         (!navigationShortcut &&
@@ -2549,7 +2707,22 @@ export function App() {
       }
 
       if (paneFocusDirection) {
-        if (!selectedPane || !selectedCommands) {
+        if (!selectedPane || !selectedRuntime) {
+          return;
+        }
+        if (!navigationIsShared) {
+          const nextPane = snapshot
+            ? chooseDirectionalPane(snapshot, selectedPane.pane_id, paneFocusDirection)
+            : null;
+          event.preventDefault();
+          event.stopPropagation();
+          if (!nextPane) {
+            return;
+          }
+          focusPane(selectedRuntime.id, nextPane);
+          return;
+        }
+        if (!selectedCommands) {
           return;
         }
         event.preventDefault();
@@ -2756,6 +2929,7 @@ export function App() {
     launchTarget,
     menu,
     multiHostSpaceSelection,
+    navigationIsShared,
     paneFocusSupported,
     pinnedAgentKeys,
     scope,
@@ -2804,7 +2978,7 @@ export function App() {
       if (currentRef.resyncBarrierGeneration > refreshGeneration) {
         return refreshBridgeSnapshot(runtime, false);
       }
-      const patched = replayActivityMessages(next, currentRef.activityLog, refreshGeneration);
+      const patched = applySnapshotOverlays(next, currentRef, refreshGeneration);
       currentRef.snapshot = patched;
       setConnectionStates((current) => ({
         ...current,
@@ -3065,7 +3239,7 @@ export function App() {
       if (!ref || !isConnectionResultCurrent(ref.connectionKey, requestConnectionKey)) {
         return false;
       }
-      const patched = replayActivityMessages(next, ref.activityLog, refreshGeneration);
+      const patched = applySnapshotOverlays(next, ref, refreshGeneration);
       ref.snapshot = patched;
       setConnectionStates((current) => ({
         ...current,
@@ -3082,7 +3256,7 @@ export function App() {
           setSelectedBridgeId(runtime.id);
           rememberPaneSelection(runtime.id, created.pane_id, created.workspace_id);
           if (navigationIsShared) {
-            void syncSelectedPane(runtime.httpUrl, created.pane_id).catch(() => {});
+            publishSharedPaneSelection(runtime, created.pane_id);
           }
           if (isCompactLayout) {
             openMobileDetail();
@@ -3307,7 +3481,7 @@ export function App() {
           followSharedSelection={navigationIsShared}
           connectionRefs={connectionRefs}
           setConnectionStates={setConnectionStates}
-          onPaneSelection={rememberPaneSelection}
+          onPaneSelection={applySharedPaneSelection}
           onAgentActivityChanged={refreshAgentActivityForBridge}
           onAgentPinsChanged={refreshAgentPinsForBridge}
           onNotesChanged={refreshNotesForBridge}
@@ -3870,6 +4044,7 @@ export function App() {
 }
 
 const SNAPSHOT_REFRESH_INTERVAL_MS = 10000;
+const SHARED_SELECTION_SETTLE_TIMEOUT_MS = 2000;
 const NOTES_REFRESH_INTERVAL_MS = 15000;
 const MAX_PENDING_CREATED_PANE_NOTES = 32;
 const NOTE_DRAFT_STORAGE_PREFIX = "herdr-web:note-draft:v1:";
@@ -4007,7 +4182,7 @@ export function BridgeConnectionController({
         if (!currentRef || currentRef.connectionKey !== requestConnectionKey) {
           return;
         }
-        const patched = replayActivityMessages(next, currentRef.activityLog, refreshGeneration);
+        const patched = applySnapshotOverlays(next, currentRef, refreshGeneration);
         currentRef.snapshot = patched;
         setConnectionStates((current) => ({
           ...current,
@@ -4088,14 +4263,38 @@ export function BridgeConnectionController({
         }
         const paneId = selectionPaneId(event);
         if (paneId) {
-          if (!followSharedSelectionRef.current) {
-            refresh();
+          const currentRef = connectionRefs.current[runtime.id];
+          if (!currentRef) {
             return;
           }
-          const pane = connectionRefs.current[runtime.id]?.snapshot?.panes.find(
+          currentRef.activityGeneration += 1;
+          currentRef.resyncBarrierGeneration = currentRef.activityGeneration;
+          currentRef.sharedSelectionOverride = {
+            paneId,
+            expiresAtMs: Date.now() + SHARED_SELECTION_SETTLE_TIMEOUT_MS,
+          };
+          const currentSnapshot = currentRef.snapshot;
+          if (currentSnapshot) {
+            const patched = {
+              ...currentSnapshot,
+              selected_pane_id: paneId,
+            };
+            currentRef.snapshot = patched;
+            setConnectionStates((current) => ({
+              ...current,
+              [runtime.id]: {
+                connectionKey: requestConnectionKey,
+                snapshot: patched,
+                loadState: "ready",
+              },
+            }));
+          }
+          const pane = currentSnapshot?.panes.find(
             (item) => item.pane_id === paneId,
           );
-          onPaneSelection(runtime.id, paneId, pane?.workspace_id);
+          if (followSharedSelectionRef.current) {
+            onPaneSelection(runtime.id, paneId, pane?.workspace_id);
+          }
           refresh();
           return;
         }
@@ -4149,6 +4348,29 @@ export function stableBridgeRefreshOffsetMs(bridgeId: BridgeId) {
   return hash % SNAPSHOT_REFRESH_INTERVAL_MS;
 }
 
+export function applySnapshotOverlays(
+  snapshot: Snapshot,
+  ref: BridgeConnectionRef,
+  refreshGeneration: number,
+) {
+  const patched = replayActivityMessages(snapshot, ref.activityLog, refreshGeneration);
+  const selectionOverride = ref.sharedSelectionOverride;
+  if (!selectionOverride) {
+    return patched;
+  }
+  if (
+    patched.selected_pane_id === selectionOverride.paneId ||
+    Date.now() >= selectionOverride.expiresAtMs
+  ) {
+    ref.sharedSelectionOverride = null;
+    return patched;
+  }
+  return {
+    ...patched,
+    selected_pane_id: selectionOverride.paneId,
+  };
+}
+
 function ensureBridgeConnectionRef(
   connectionRefs: MutableRefObject<Record<string, BridgeConnectionRef>>,
   runtime: BridgeRuntime,
@@ -4163,6 +4385,7 @@ function ensureBridgeConnectionRef(
     activityGeneration: 0,
     resyncBarrierGeneration: 0,
     activityLog: [],
+    sharedSelectionOverride: null,
   };
   connectionRefs.current[runtime.id] = next;
   return next;

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -516,7 +516,7 @@ export function BackendSettingsDialog({
               <div className="settings-section settings-section-flat">
                 <div className="settings-label">Sidebar</div>
                 <div className="settings-row">
-                  <span title="Choose whether this window follows pane selections from other clients">
+                  <span title="Choose whether this browser follows pane selections from other clients">
                     Sync navigation
                   </span>
                   <div

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -74,9 +74,18 @@ describe("BridgeConnectionController sockets", () => {
 
   it("stops applying shared selection events without recreating event sockets", async () => {
     vi.stubGlobal("WebSocket", FakeWebSocket);
+    let sharedPaneId: string | null = null;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response(JSON.stringify(emptySnapshot()), { status: 200 })),
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ...emptySnapshot(),
+            selected_pane_id: sharedPaneId,
+          }),
+          { status: 200 },
+        ),
+      ),
     );
     const connectionRefs = { current: {} } as MutableRefObject<Record<string, BridgeConnectionRef>>;
     const setConnectionStates = vi.fn() as unknown as Dispatch<
@@ -95,6 +104,7 @@ describe("BridgeConnectionController sockets", () => {
     if (!uiEvents) {
       throw new Error("missing UI events socket");
     }
+    sharedPaneId = "pane-a";
     await act(async () => {
       uiEvents.dispatchEvent(
         new MessageEvent("message", {
@@ -106,6 +116,7 @@ describe("BridgeConnectionController sockets", () => {
     expect(onPaneSelection).toHaveBeenCalledTimes(1);
 
     await render(vi.fn(), false);
+    sharedPaneId = "pane-b";
     await act(async () => {
       uiEvents.dispatchEvent(
         new MessageEvent("message", {
@@ -116,6 +127,7 @@ describe("BridgeConnectionController sockets", () => {
     });
 
     expect(onPaneSelection).toHaveBeenCalledTimes(1);
+    expect(connectionRefs.current["bridge-a"]?.snapshot?.selected_pane_id).toBe("pane-b");
     expect(FakeWebSocket.instances).toHaveLength(3);
     expect(FakeWebSocket.instances.filter((socket) => socket.closed)).toHaveLength(0);
   });

--- a/web/src/navigationPrefs.test.ts
+++ b/web/src/navigationPrefs.test.ts
@@ -1,26 +1,27 @@
 import { describe, expect, it } from "vitest";
 import {
-  CLIENT_NAVIGATION_PREFS_KEY,
   DEFAULT_NAVIGATION_SYNC_MODE,
+  NAVIGATION_SYNC_MODE_KEY,
+  navigationSyncModeForStorageEvent,
   parseNavigationSyncMode,
-  readClientNavigationPrefs,
+  readNavigationSyncMode,
   sharesNavigation,
-  writeClientNavigationPrefs,
+  writeNavigationSyncMode,
 } from "./navigationPrefs";
 
 function memoryStorage(initial?: string) {
   let value = initial ?? null;
   return {
-    getItem: (key: string) => (key === CLIENT_NAVIGATION_PREFS_KEY ? value : null),
+    getItem: (key: string) => (key === NAVIGATION_SYNC_MODE_KEY ? value : null),
     setItem: (key: string, next: string) => {
-      if (key === CLIENT_NAVIGATION_PREFS_KEY) {
+      if (key === NAVIGATION_SYNC_MODE_KEY) {
         value = next;
       }
     },
   };
 }
 
-describe("client navigation preferences", () => {
+describe("navigation synchronization preference", () => {
   it("defaults navigation synchronization to shared", () => {
     expect(parseNavigationSyncMode(undefined)).toBe(DEFAULT_NAVIGATION_SYNC_MODE);
     expect(parseNavigationSyncMode("other")).toBe(DEFAULT_NAVIGATION_SYNC_MODE);
@@ -28,41 +29,22 @@ describe("client navigation preferences", () => {
     expect(sharesNavigation("independent")).toBe(false);
   });
 
-  it("round-trips per-client navigation state", () => {
+  it("round-trips only the browser-wide synchronization mode", () => {
     const storage = memoryStorage();
-    const prefs = {
-      mode: "independent" as const,
-      selectedBridgeId: "bridge-a",
-      selectedPane: { bridgeId: "bridge-a", paneId: "pane-a" },
-      activeWorkspace: { bridgeId: "bridge-a", workspaceId: "workspace-a" },
-      selectedPanesByBridgeId: { "bridge-a": "pane-a" },
-      activeWorkspacesByBridgeId: { "bridge-a": "workspace-a" },
-    };
 
-    writeClientNavigationPrefs(prefs, storage);
+    writeNavigationSyncMode("independent", storage);
 
-    expect(readClientNavigationPrefs(storage)).toEqual(prefs);
+    expect(readNavigationSyncMode(storage)).toBe("independent");
   });
 
-  it("drops malformed client selection data", () => {
-    const storage = memoryStorage(
-      JSON.stringify({
-        mode: "independent",
-        selectedBridgeId: 3,
-        selectedPane: { bridgeId: "bridge-a" },
-        activeWorkspace: "workspace-a",
-        selectedPanesByBridgeId: { "bridge-a": "pane-a", invalid: 4 },
-        activeWorkspacesByBridgeId: null,
-      }),
-    );
+  it("defaults malformed stored modes to shared", () => {
+    expect(readNavigationSyncMode(memoryStorage("invalid"))).toBe("shared");
+  });
 
-    expect(readClientNavigationPrefs(storage)).toEqual({
-      mode: "independent",
-      selectedBridgeId: null,
-      selectedPane: null,
-      activeWorkspace: null,
-      selectedPanesByBridgeId: { "bridge-a": "pane-a" },
-      activeWorkspacesByBridgeId: {},
-    });
+  it("ignores delayed events that no longer match the stored mode", () => {
+    const storage = memoryStorage("shared");
+
+    expect(navigationSyncModeForStorageEvent("independent", storage)).toBeNull();
+    expect(navigationSyncModeForStorageEvent("shared", storage)).toBe("shared");
   });
 });

--- a/web/src/navigationPrefs.ts
+++ b/web/src/navigationPrefs.ts
@@ -1,31 +1,7 @@
 export type NavigationSyncMode = "shared" | "independent";
 
-export type ClientNavigationPrefs = {
-  mode: NavigationSyncMode;
-  selectedBridgeId: string | null;
-  selectedPane: {
-    bridgeId: string;
-    paneId: string;
-  } | null;
-  activeWorkspace: {
-    bridgeId: string;
-    workspaceId: string;
-  } | null;
-  selectedPanesByBridgeId: Record<string, string>;
-  activeWorkspacesByBridgeId: Record<string, string>;
-};
-
 export const DEFAULT_NAVIGATION_SYNC_MODE: NavigationSyncMode = "shared";
-export const CLIENT_NAVIGATION_PREFS_KEY = "herdrWeb.clientNavigation.v1";
-
-const DEFAULT_CLIENT_NAVIGATION_PREFS: ClientNavigationPrefs = {
-  mode: DEFAULT_NAVIGATION_SYNC_MODE,
-  selectedBridgeId: null,
-  selectedPane: null,
-  activeWorkspace: null,
-  selectedPanesByBridgeId: {},
-  activeWorkspacesByBridgeId: {},
-};
+export const NAVIGATION_SYNC_MODE_KEY = "herdrWeb.navigationSyncMode.v1";
 
 export function parseNavigationSyncMode(value: unknown): NavigationSyncMode {
   return value === "independent" || value === "shared"
@@ -37,90 +13,55 @@ export function sharesNavigation(mode: NavigationSyncMode) {
   return mode === "shared";
 }
 
-export function readClientNavigationPrefs(
-  storage: Pick<Storage, "getItem"> | null = browserSessionStorage(),
-): ClientNavigationPrefs {
+export function readNavigationSyncMode(
+  storage: Pick<Storage, "getItem"> | null = browserLocalStorage(),
+): NavigationSyncMode {
   if (!storage) {
-    return DEFAULT_CLIENT_NAVIGATION_PREFS;
+    return DEFAULT_NAVIGATION_SYNC_MODE;
   }
   try {
-    const raw = storage.getItem(CLIENT_NAVIGATION_PREFS_KEY);
-    if (!raw) {
-      return DEFAULT_CLIENT_NAVIGATION_PREFS;
-    }
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    return {
-      mode: parseNavigationSyncMode(parsed.mode),
-      selectedBridgeId:
-        typeof parsed.selectedBridgeId === "string" ? parsed.selectedBridgeId : null,
-      selectedPane: parsePaneRef(parsed.selectedPane),
-      activeWorkspace: parseWorkspaceRef(parsed.activeWorkspace),
-      selectedPanesByBridgeId: parseStringRecord(parsed.selectedPanesByBridgeId),
-      activeWorkspacesByBridgeId: parseStringRecord(parsed.activeWorkspacesByBridgeId),
-    };
+    return parseNavigationSyncMode(storage.getItem(NAVIGATION_SYNC_MODE_KEY));
   } catch {
-    return DEFAULT_CLIENT_NAVIGATION_PREFS;
+    return DEFAULT_NAVIGATION_SYNC_MODE;
   }
 }
 
-export function writeClientNavigationPrefs(
-  prefs: ClientNavigationPrefs,
-  storage: Pick<Storage, "setItem"> | null = browserSessionStorage(),
+export function writeNavigationSyncMode(
+  mode: NavigationSyncMode,
+  storage: Pick<Storage, "setItem"> | null = browserLocalStorage(),
 ) {
   if (!storage) {
     return;
   }
   try {
-    storage.setItem(CLIENT_NAVIGATION_PREFS_KEY, JSON.stringify(prefs));
+    storage.setItem(NAVIGATION_SYNC_MODE_KEY, mode);
   } catch {
-    // Session storage can be unavailable in private or locked-down browser contexts.
+    // Local storage can be unavailable in private or locked-down browser contexts.
   }
 }
 
-function browserSessionStorage() {
+export function navigationSyncModeForStorageEvent(
+  eventValue: string | null,
+  storage: Pick<Storage, "getItem"> | null = browserLocalStorage(),
+): NavigationSyncMode | null {
+  if (!storage) {
+    return null;
+  }
+  try {
+    const storedValue = storage.getItem(NAVIGATION_SYNC_MODE_KEY);
+    return eventValue === storedValue ? parseNavigationSyncMode(storedValue) : null;
+  } catch {
+    return null;
+  }
+}
+
+function browserLocalStorage() {
   if (typeof window === "undefined") {
     return null;
   }
   try {
-    return window.sessionStorage;
+    return window.localStorage;
   } catch {
     return null;
   }
-}
-
-function parsePaneRef(value: unknown): ClientNavigationPrefs["selectedPane"] {
-  if (
-    !isRecord(value) ||
-    typeof value.bridgeId !== "string" ||
-    typeof value.paneId !== "string"
-  ) {
-    return null;
-  }
-  return { bridgeId: value.bridgeId, paneId: value.paneId };
-}
-
-function parseWorkspaceRef(value: unknown): ClientNavigationPrefs["activeWorkspace"] {
-  if (
-    !isRecord(value) ||
-    typeof value.bridgeId !== "string" ||
-    typeof value.workspaceId !== "string"
-  ) {
-    return null;
-  }
-  return { bridgeId: value.bridgeId, workspaceId: value.workspaceId };
-}
-
-function parseStringRecord(value: unknown): Record<string, string> {
-  if (!isRecord(value)) {
-    return {};
-  }
-  return Object.fromEntries(
-    Object.entries(value).filter(
-      (entry): entry is [string, string] => typeof entry[1] === "string",
-    ),
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   canClearTabName,
   canClearWorkspaceName,
+  chooseDirectionalPane,
   choosePaneForTab,
   choosePaneForWorkspace,
   chooseSelectedPane,
@@ -102,6 +103,20 @@ describe("chooseSelectedPane", () => {
     ).toBe("1-2");
   });
 
+  it("uses the authoritative shared selection when no local publication is pending", () => {
+    expect(
+      chooseSelectedPane(
+        {
+          ...snapshot([pane("1-1"), pane("1-2", true)]),
+          selected_pane_id: "1-1",
+        },
+        "1-2",
+        true,
+        true,
+      ),
+    ).toBe("1-1");
+  });
+
   it("uses the snapshot selection when there is no current pane", () => {
     expect(
       chooseSelectedPane(
@@ -164,6 +179,17 @@ describe("chooseSelectedPaneForActiveWorkspace", () => {
 
     expect(chooseSelectedPaneForActiveWorkspace(data, "1-1", "missing")).toBe("1-1");
   });
+
+  it("uses the shared selection instead of a stale persisted workspace", () => {
+    const data = {
+      ...multiWorkspaceSnapshot(),
+      selected_pane_id: "2-2",
+    };
+
+    expect(
+      chooseSelectedPaneForActiveWorkspace(data, "1-1", "1", true, true),
+    ).toBe("2-2");
+  });
 });
 
 describe("projection selection helpers", () => {
@@ -183,6 +209,55 @@ describe("projection selection helpers", () => {
     ]);
 
     expect(choosePaneForTab(data, "1-2")).toBe("1-3");
+  });
+});
+
+describe("chooseDirectionalPane", () => {
+  const data = {
+    ...snapshot([
+      pane("top-left"),
+      pane("bottom-left"),
+      pane("right"),
+    ]),
+    layouts: [
+      {
+        workspace_id: "1",
+        tab_id: "1-1",
+        zoomed: false,
+        area: { x: 0, y: 0, width: 100, height: 100 },
+        focused_pane_id: "top-left",
+        panes: [
+          {
+            pane_id: "top-left",
+            focused: true,
+            rect: { x: 0, y: 0, width: 50, height: 50 },
+          },
+          {
+            pane_id: "bottom-left",
+            focused: false,
+            rect: { x: 0, y: 50, width: 50, height: 50 },
+          },
+          {
+            pane_id: "right",
+            focused: false,
+            rect: { x: 50, y: 0, width: 50, height: 100 },
+          },
+        ],
+        splits: [],
+      },
+    ],
+  } satisfies Snapshot;
+
+  it("chooses an adjacent pane without changing Herdr focus", () => {
+    expect(chooseDirectionalPane(data, "top-left", "right")?.pane_id).toBe("right");
+    expect(chooseDirectionalPane(data, "top-left", "down")?.pane_id).toBe("bottom-left");
+    expect(chooseDirectionalPane(data, "right", "left")?.pane_id).toBe("top-left");
+    expect(chooseDirectionalPane(data, "bottom-left", "up")?.pane_id).toBe("top-left");
+  });
+
+  it("returns null at an outer layout edge", () => {
+    expect(chooseDirectionalPane(data, "right", "right")).toBeNull();
+    expect(chooseDirectionalPane(data, "top-left", "up")).toBeNull();
   });
 });
 

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -1,4 +1,12 @@
-import type { AgentStatus, PaneInfo, Snapshot, TabInfo, WorkspaceInfo } from "./types";
+import type {
+  AgentStatus,
+  LayoutRect,
+  PaneInfo,
+  Snapshot,
+  TabInfo,
+  WorkspaceInfo,
+} from "./types";
+import type { PaneFocusDirection } from "./commands";
 
 const statusRank: Record<AgentStatus, number> = {
   blocked: 0,
@@ -12,19 +20,25 @@ export function chooseSelectedPane(
   snapshot: Snapshot | null,
   currentPaneId: string | null,
   useSharedSelection = true,
+  preferSharedSelection = false,
 ) {
   if (!snapshot || snapshot.panes.length === 0) {
     return null;
   }
-  if (currentPaneId && snapshot.panes.some((pane) => pane.pane_id === currentPaneId)) {
-    return currentPaneId;
-  }
-  if (
+  const sharedPaneId =
     useSharedSelection &&
     snapshot.selected_pane_id &&
     snapshot.panes.some((pane) => pane.pane_id === snapshot.selected_pane_id)
-  ) {
-    return snapshot.selected_pane_id;
+      ? snapshot.selected_pane_id
+      : null;
+  if (preferSharedSelection && sharedPaneId) {
+    return sharedPaneId;
+  }
+  if (currentPaneId && snapshot.panes.some((pane) => pane.pane_id === currentPaneId)) {
+    return currentPaneId;
+  }
+  if (sharedPaneId) {
+    return sharedPaneId;
   }
   return snapshot.panes.find((pane) => pane.focused)?.pane_id ?? snapshot.panes[0].pane_id;
 }
@@ -34,20 +48,130 @@ export function chooseSelectedPaneForActiveWorkspace(
   currentPaneId: string | null,
   activeWorkspaceId: string | null,
   useSharedSelection = true,
+  preferSharedSelection = false,
 ) {
+  if (
+    preferSharedSelection &&
+    snapshot?.selected_pane_id &&
+    snapshot.panes.some((pane) => pane.pane_id === snapshot.selected_pane_id)
+  ) {
+    return snapshot.selected_pane_id;
+  }
   if (!snapshot || !activeWorkspaceId) {
-    return chooseSelectedPane(snapshot, currentPaneId, useSharedSelection);
+    return chooseSelectedPane(
+      snapshot,
+      currentPaneId,
+      useSharedSelection,
+      preferSharedSelection,
+    );
   }
   if (!snapshot.workspaces.some((workspace) => workspace.workspace_id === activeWorkspaceId)) {
-    return chooseSelectedPane(snapshot, currentPaneId, useSharedSelection);
+    return chooseSelectedPane(
+      snapshot,
+      currentPaneId,
+      useSharedSelection,
+      preferSharedSelection,
+    );
   }
   const currentPane = currentPaneId
     ? snapshot.panes.find((pane) => pane.pane_id === currentPaneId)
     : null;
   if (currentPane?.workspace_id === activeWorkspaceId) {
-    return chooseSelectedPane(snapshot, currentPaneId, useSharedSelection);
+    return chooseSelectedPane(
+      snapshot,
+      currentPaneId,
+      useSharedSelection,
+      preferSharedSelection,
+    );
   }
   return choosePaneForWorkspace(snapshot, activeWorkspaceId);
+}
+
+export function chooseDirectionalPane(
+  snapshot: Snapshot,
+  currentPaneId: string,
+  direction: PaneFocusDirection,
+) {
+  const layout = snapshot.layouts.find((candidate) =>
+    candidate.panes.some((pane) => pane.pane_id === currentPaneId),
+  );
+  const current = layout?.panes.find((pane) => pane.pane_id === currentPaneId);
+  if (!layout || !current) {
+    return null;
+  }
+
+  const candidates = layout.panes
+    .filter((pane) => pane.pane_id !== currentPaneId)
+    .map((pane) => ({
+      pane,
+      score: directionalPaneScore(current.rect, pane.rect, direction),
+    }))
+    .filter(
+      (
+        candidate,
+      ): candidate is {
+        pane: (typeof layout.panes)[number];
+        score: [number, number, number];
+      } => candidate.score !== null,
+    )
+    .sort((left, right) => compareDirectionScores(left.score, right.score));
+
+  const paneId = candidates[0]?.pane.pane_id;
+  return paneId ? snapshot.panes.find((pane) => pane.pane_id === paneId) ?? null : null;
+}
+
+function directionalPaneScore(
+  current: LayoutRect,
+  candidate: LayoutRect,
+  direction: PaneFocusDirection,
+): [number, number, number] | null {
+  const currentRight = current.x + current.width;
+  const currentBottom = current.y + current.height;
+  const candidateRight = candidate.x + candidate.width;
+  const candidateBottom = candidate.y + candidate.height;
+  const horizontal = direction === "left" || direction === "right";
+  const primaryGap =
+    direction === "left"
+      ? current.x - candidateRight
+      : direction === "right"
+        ? candidate.x - currentRight
+        : direction === "up"
+          ? current.y - candidateBottom
+          : candidate.y - currentBottom;
+  if (primaryGap < -Number.EPSILON) {
+    return null;
+  }
+
+  const currentOrthogonalStart = horizontal ? current.y : current.x;
+  const currentOrthogonalEnd = horizontal ? currentBottom : currentRight;
+  const candidateOrthogonalStart = horizontal ? candidate.y : candidate.x;
+  const candidateOrthogonalEnd = horizontal ? candidateBottom : candidateRight;
+  const orthogonalGap = Math.max(
+    0,
+    currentOrthogonalStart - candidateOrthogonalEnd,
+    candidateOrthogonalStart - currentOrthogonalEnd,
+  );
+  const currentOrthogonalCenter = (currentOrthogonalStart + currentOrthogonalEnd) / 2;
+  const candidateOrthogonalCenter =
+    (candidateOrthogonalStart + candidateOrthogonalEnd) / 2;
+
+  return [
+    orthogonalGap > 0 ? 1 : 0,
+    Math.max(0, primaryGap),
+    Math.abs(candidateOrthogonalCenter - currentOrthogonalCenter),
+  ];
+}
+
+function compareDirectionScores(
+  left: [number, number, number],
+  right: [number, number, number],
+) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+  return 0;
 }
 
 export function choosePaneForWorkspace(snapshot: Snapshot, workspaceId: string) {


### PR DESCRIPTION
## Summary

- keep sync-off pane selection entirely client-local and in memory while storing the Sync setting browser-wide
- make shared navigation recover from the focused Herdr pane after bridge restarts and ignore stale browser storage events
- persist the Sync setting through Capacitor Preferences on Android

## Verification

- `npm run check`
- two-tab browser verification for sync-on and sync-off navigation
- Keel review with the `claude-default` profile (clean after fixes)
