### PR TITLE
Fix stale mobile terminal command input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 ### Fixed
 
 - Cleared and remounted the mobile terminal command field after Send or Stage so stale native input
-  cannot prefix the next command.
+  cannot prefix the next command. [PR #44](https://github.com/kcosr/herdr-web/pull/44)
 - Fixed client-local navigation synchronization across reloads, reconnects, lagging snapshots, and
   rapid multi-client selection races. Sync-off split navigation now stays local, and independent
   clients no longer rewrite shared navigation persistence. After a bridge restart, the focused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 
 ### Fixed
 
+- Cleared and remounted the mobile terminal command field after Send or Stage so stale native input
+  cannot prefix the next command.
 - Fixed client-local navigation synchronization across reloads, reconnects, lagging snapshots, and
   rapid multi-client selection races. Sync-off split navigation now stays local, and independent
   clients no longer rewrite shared navigation persistence. After a bridge restart, the focused

--- a/web/src/MobileTerminalControls.test.tsx
+++ b/web/src/MobileTerminalControls.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MobileTerminalControls } from "./TerminalView";
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) {
+      root.unmount();
+    }
+  });
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("MobileTerminalControls", () => {
+  for (const expandingInput of [false, true]) {
+    it(`clears and remounts the ${
+      expandingInput ? "textarea" : "input"
+    } after Send`, async () => {
+      const { commandInputRef, container, onSubmitCommand } =
+        await renderControls(expandingInput);
+      const firstField = commandField(container);
+
+      await setCommandValue(firstField, "first prompt");
+      firstField.defaultValue = "first prompt";
+      firstField.focus();
+      await submitForm(container);
+
+      expect(onSubmitCommand).toHaveBeenLastCalledWith("first prompt");
+      expect(firstField.value).toBe("");
+      expect(firstField.defaultValue).toBe("");
+
+      const secondField = commandField(container);
+      expect(secondField).not.toBe(firstField);
+      expect(secondField.value).toBe("");
+      expect(secondField.defaultValue).toBe("");
+      expect(commandInputRef.current).toBe(secondField);
+      expect(document.activeElement).not.toBe(secondField);
+
+      await setCommandValue(secondField, "second prompt");
+      expect(secondField.value).toBe("second prompt");
+      await submitForm(container);
+
+      expect(onSubmitCommand).toHaveBeenLastCalledWith("second prompt");
+      expect(onSubmitCommand).toHaveBeenCalledTimes(2);
+    });
+  }
+
+  it("clears and remounts after Stage while keeping empty Stage disabled", async () => {
+    const { container, onStageCommand } = await renderControls(false);
+    const firstField = commandField(container);
+
+    await setCommandValue(firstField, "staged prompt");
+    firstField.defaultValue = "staged prompt";
+    await clickStage(container);
+
+    expect(onStageCommand).toHaveBeenCalledOnce();
+    expect(onStageCommand).toHaveBeenCalledWith("staged prompt");
+    expect(firstField.value).toBe("");
+    expect(firstField.defaultValue).toBe("");
+
+    const secondField = commandField(container);
+    expect(secondField).not.toBe(firstField);
+    expect(secondField.value).toBe("");
+    expect(secondField.defaultValue).toBe("");
+    expect(stageButton(container).disabled).toBe(true);
+
+    await clickStage(container);
+    expect(onStageCommand).toHaveBeenCalledOnce();
+  });
+
+  it("continues submitting an empty command as Enter", async () => {
+    const { container, onSubmitCommand } = await renderControls(false);
+
+    await submitForm(container);
+
+    expect(onSubmitCommand).toHaveBeenCalledWith("");
+  });
+});
+
+async function renderControls(expandingInput: boolean) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  const commandInputRef = createRef<HTMLInputElement | HTMLTextAreaElement>();
+  const onSubmitCommand = vi.fn();
+  const onStageCommand = vi.fn();
+
+  await act(async () => {
+    root.render(
+      <MobileTerminalControls
+        commandInputRef={commandInputRef}
+        disabled={false}
+        uploadDisabled={false}
+        expandingInput={expandingInput}
+        enterNewline={false}
+        controlsScalePercent={100}
+        onControlsHeightChange={vi.fn()}
+        onInput={vi.fn()}
+        onTerminalFocus={vi.fn()}
+        onUpload={vi.fn()}
+        onStageCommand={onStageCommand}
+        onSubmitCommand={onSubmitCommand}
+      />,
+    );
+  });
+
+  return {
+    commandInputRef,
+    container,
+    onStageCommand,
+    onSubmitCommand,
+  };
+}
+
+function commandField(container: HTMLElement) {
+  const field = container.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+    ".term-native-input",
+  );
+  if (!field) {
+    throw new Error("missing mobile command field");
+  }
+  return field;
+}
+
+async function setCommandValue(
+  field: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) {
+  await act(async () => {
+    const prototype =
+      field instanceof HTMLTextAreaElement
+        ? window.HTMLTextAreaElement.prototype
+        : window.HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+    setter?.call(field, value);
+    field.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function submitForm(container: HTMLElement) {
+  const form = container.querySelector("form");
+  if (!form) {
+    throw new Error("missing mobile command form");
+  }
+  await act(async () => {
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  });
+}
+
+function stageButton(container: HTMLElement) {
+  const button = container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Stage command in terminal"]',
+  );
+  if (!button) {
+    throw new Error("missing Stage button");
+  }
+  return button;
+}
+
+async function clickStage(container: HTMLElement) {
+  await act(async () => {
+    stageButton(container).click();
+  });
+}

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -1402,7 +1402,7 @@ function MobileSelectionActions({
   );
 }
 
-function MobileTerminalControls({
+export function MobileTerminalControls({
   commandInputRef,
   disabled,
   uploadDisabled,
@@ -1431,21 +1431,33 @@ function MobileTerminalControls({
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [value, setValue] = useState("");
+  const [fieldKey, setFieldKey] = useState(0);
   const [expanded, setExpanded] = useState(false);
   const [ctrlLatch, setCtrlLatch] = useState(false);
   const setCommandInputNode = (node: HTMLInputElement | HTMLTextAreaElement | null) => {
     commandInputRef.current = node;
   };
-  const submit = () => {
-    onSubmitCommand(value);
+  const clearCommandInput = () => {
     setValue("");
+    const node = commandInputRef.current;
+    if (node) {
+      node.value = "";
+      node.defaultValue = "";
+    }
+    setFieldKey((key) => key + 1);
+  };
+  const submit = () => {
+    const command = value;
+    clearCommandInput();
+    onSubmitCommand(command);
   };
   const stage = () => {
     if (value.length === 0) {
       return;
     }
-    onStageCommand(value);
-    setValue("");
+    const command = value;
+    clearCommandInput();
+    onStageCommand(command);
   };
   const sendKey = (key: TerminalKey) => {
     onInput(ctrlLatch && key.ctrlData ? key.ctrlData : key.data);
@@ -1455,10 +1467,18 @@ function MobileTerminalControls({
   };
 
   useLayoutEffect(() => {
+    const node = commandInputRef.current;
+    if (fieldKey > 0 && node) {
+      node.value = "";
+      node.defaultValue = "";
+    }
+  }, [commandInputRef, fieldKey]);
+
+  useLayoutEffect(() => {
     if (expandingInput) {
       autosizeMobileCommandTextarea(commandInputRef.current);
     }
-  }, [commandInputRef, controlsScalePercent, expandingInput, value]);
+  }, [commandInputRef, controlsScalePercent, expandingInput, fieldKey, value]);
 
   useLayoutEffect(() => {
     const root = rootRef.current;
@@ -1615,6 +1635,7 @@ function MobileTerminalControls({
       >
         {expandingInput ? (
           <textarea
+            key={fieldKey}
             ref={setCommandInputNode}
             className="term-native-input mono"
             rows={1}
@@ -1631,6 +1652,7 @@ function MobileTerminalControls({
           />
         ) : (
           <input
+            key={fieldKey}
             ref={setCommandInputNode}
             className="term-native-input mono"
             type="text"


### PR DESCRIPTION
## Summary

- clear the native mobile terminal command field when sending or staging a command
- remount the field to prevent browser autocorrect/composition state from repopulating stale text
- keep the replacement field unfocused so touch keyboards stay closed after submission
- cover input, textarea, stage, and empty-Enter behavior with component tests

## Testing

- `npm run check`
- Android debug APK build and integrity verification
- deployed smoke checks on srv and pc (`/` and `/api/capabilities` returned HTTP 200)
