### PR TITLE
Improve workspace grouping and collapsible sidebar groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Changed
 
+- Simplified Workspace grouping in the Agents and Tabs sidebars to show workspace-only group
+  headers and move host context into each detail row. Host + workspace grouping keeps its nested
+  host and workspace headers.
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@
 - Added persistent expand/collapse controls to grouped Agents, Tabs, and Spaces headers, including
   independent, visually nested host and workspace controls for Host + workspace grouping and a
   bulk expand/collapse control for the current Agents or Tabs list.
+  [PR #47](https://github.com/kcosr/herdr-web/pull/47)
 - Added a default-off Display setting that combines same-named workspaces across hosts when using
   Workspace grouping, while retaining host context on each agent or pane row.
+  [PR #47](https://github.com/kcosr/herdr-web/pull/47)
 
 ### Changed
 
 - Simplified Workspace grouping in the Agents and Tabs sidebars to show workspace-only group
   headers and move host context into each detail row. Host + workspace grouping keeps its nested
-  host and workspace headers.
+  host and workspace headers. [PR #47](https://github.com/kcosr/herdr-web/pull/47)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added persistent expand/collapse controls to grouped Agents, Tabs, and Spaces headers, including
+  independent host and workspace controls for Host + workspace grouping.
 - Added a default-off Display setting that combines same-named workspaces across hosts when using
   Workspace grouping, while retaining host context on each agent or pane row.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Added
 
 - Added persistent expand/collapse controls to grouped Agents, Tabs, and Spaces headers, including
-  independent host and workspace controls for Host + workspace grouping.
+  independent, visually nested host and workspace controls for Host + workspace grouping and a
+  bulk expand/collapse control for the current Agents or Tabs list.
 - Added a default-off Display setting that combines same-named workspaces across hosts when using
   Workspace grouping, while retaining host context on each agent or pane row.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- Added a default-off sidebar option that combines same-named workspaces across hosts when using
+  Workspace grouping, while retaining host context on each agent or pane row.
+
 ### Changed
 
 - Simplified Workspace grouping in the Agents and Tabs sidebars to show workspace-only group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- Added a default-off sidebar option that combines same-named workspaces across hosts when using
+- Added a default-off Display setting that combines same-named workspaces across hosts when using
   Workspace grouping, while retaining host context on each agent or pane row.
 
 ### Changed

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -10,10 +10,13 @@ import {
   buildVisibleTabEntries,
   buildVisibleTabWorkspaceGroups,
   canAddNoteFromPaneMenu,
+  filterCollapsedAgentPaneEntries,
+  filterCollapsedTabEntries,
   mergeCreatedPaneNoteList,
   mergePendingPaneNotesIntoList,
   noteDraftStorageKey,
   parseCombineMatchingWorkspaceNames,
+  parseCollapsedSidebarGroups,
   isInFlightNoteSaveVisible,
   launcherEmptyMessage,
   menuItems,
@@ -31,6 +34,7 @@ import {
   shouldShowSidebarSort,
   shouldShowTabDivider,
   shouldShowLastStatusChangeSort,
+  sidebarGroupCollapseKey,
   sortScopedAgentPanes,
   stableBridgeRefreshOffsetMs,
 } from "./App";
@@ -502,6 +506,75 @@ describe("App multi-bridge helpers", () => {
     expect(parseCombineMatchingWorkspaceNames("true", true)).toBe(true);
     expect(parseCombineMatchingWorkspaceNames(false, true)).toBe(false);
     expect(parseCombineMatchingWorkspaceNames(true)).toBe(true);
+  });
+
+  it("parses persisted collapsed groups as a bounded unique string list", () => {
+    expect(parseCollapsedSidebarGroups(undefined)).toEqual([]);
+    expect(parseCollapsedSidebarGroups(undefined, ["existing-group"])).toEqual([
+      "existing-group",
+    ]);
+    expect(parseCollapsedSidebarGroups(["group-a", 3, "", "group-a", "group-b"])).toEqual([
+      "group-a",
+      "group-b",
+    ]);
+    expect(parseCollapsedSidebarGroups(Array.from({ length: 300 }, (_, index) => `g-${index}`)))
+      .toHaveLength(256);
+  });
+
+  it("hides keyboard-navigation entries inside collapsed nested groups", () => {
+    const bridgeViews = agentParityBridgeViews();
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "bridge-a",
+      "all",
+      "all",
+      null,
+      {},
+    );
+    const agentEntries = buildVisibleAgentPaneEntries(
+      scopedWorkspaces,
+      bridgeViews,
+      "all",
+      "hostWorkspace",
+      "workspace",
+    );
+    const collapsedAgentGroups = new Set([
+      sidebarGroupCollapseKey("agents", "hostWorkspace", "workspace", "bridge-a:workspace-a"),
+      sidebarGroupCollapseKey("agents", "hostWorkspace", "host", "bridge-b"),
+    ]);
+    expect(
+      filterCollapsedAgentPaneEntries(
+        agentEntries,
+        "hostWorkspace",
+        "all",
+        false,
+        collapsedAgentGroups,
+      ).map((entry) => `${entry.bridgeId}:${entry.pane.pane_id}`),
+    ).toEqual(["bridge-a:pane-b"]);
+
+    const tabEntries = buildVisibleTabEntries(
+      scopedWorkspaces,
+      bridgeViews,
+      "all",
+      "workspace",
+    );
+    const collapsedTabGroups = new Set([
+      sidebarGroupCollapseKey(
+        "tabs",
+        "workspace",
+        "workspace",
+        "workspace-name:workspace-a",
+      ),
+    ]);
+    expect(
+      filterCollapsedTabEntries(
+        tabEntries,
+        "workspace",
+        "all",
+        true,
+        collapsedTabGroups,
+      ).map((entry) => `${entry.bridgeId}:${entry.tab.tab_id}`),
+    ).toEqual(["bridge-a:tab-b"]);
   });
 
   it("moves host context into rows only for flat and workspace grouping", () => {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -37,6 +37,7 @@ import {
   sidebarGroupCollapseKey,
   sortScopedAgentPanes,
   stableBridgeRefreshOffsetMs,
+  updateCollapsedSidebarGroups,
 } from "./App";
 import type { BridgeConnectionRef, BridgeConnectionView } from "./App";
 import type { BridgeRuntime } from "./bridge";
@@ -519,6 +520,23 @@ describe("App multi-bridge helpers", () => {
     ]);
     expect(parseCollapsedSidebarGroups(Array.from({ length: 300 }, (_, index) => `g-${index}`)))
       .toHaveLength(256);
+  });
+
+  it("collapses and expands a visible set of sidebar groups without changing other groups", () => {
+    expect(
+      updateCollapsedSidebarGroups(
+        ["other-group", "visible-a"],
+        ["visible-a", "visible-b"],
+        true,
+      ),
+    ).toEqual(["other-group", "visible-a", "visible-b"]);
+    expect(
+      updateCollapsedSidebarGroups(
+        ["other-group", "visible-a", "visible-b"],
+        ["visible-a", "visible-b"],
+        false,
+      ),
+    ).toEqual(["other-group"]);
   });
 
   it("hides keyboard-navigation entries inside collapsed nested groups", () => {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -3,6 +3,7 @@ import {
   agentSubtitle,
   applySnapshotOverlays,
   buildVisibleAgentPaneEntries,
+  buildScopedAgentGroups,
   buildVisibleScopedNotes,
   canAddNoteFromPaneMenu,
   mergeCreatedPaneNoteList,
@@ -23,6 +24,7 @@ import {
   shouldBlockDirtyNoteAutosave,
   shouldCollapseHostScope,
   shouldRenderAgentRowInTabs,
+  sidebarRowContext,
   shouldOfferSpaceHostGrouping,
   shouldShowSidebarSort,
   shouldShowTabDivider,
@@ -392,6 +394,45 @@ describe("App multi-bridge helpers", () => {
         "attention",
       ).map((item) => `${item.bridgeId}:${item.pane.pane_id}`),
     ).toEqual(["bridge-a:pane-a", "bridge-b:pane-b"]);
+  });
+
+  it("uses workspace-only headers when grouping workspaces across hosts", () => {
+    const sharedWorkspace = workspace("shared-workspace", 1);
+    const groups = buildScopedAgentGroups(
+      [
+        entry("host-a", 0, sharedWorkspace, pane("pane-a", "shared-workspace", "tab-a"), 1),
+        entry("host-b", 1, sharedWorkspace, pane("pane-b", "shared-workspace", "tab-b"), 1),
+      ],
+      "workspace",
+    );
+
+    expect(groups.map((group) => group.label)).toEqual([
+      "shared-workspace",
+      "shared-workspace",
+    ]);
+  });
+
+  it("moves host context into rows only for flat and workspace grouping", () => {
+    expect(sidebarRowContext("none", "all", "host-a", "workspace-a")).toEqual({
+      bridgeLabel: "host-a",
+      workspaceLabel: "workspace-a",
+    });
+    expect(sidebarRowContext("host", "all", "host-a", "workspace-a")).toEqual({
+      bridgeLabel: undefined,
+      workspaceLabel: "workspace-a",
+    });
+    expect(sidebarRowContext("workspace", "all", "host-a", "workspace-a")).toEqual({
+      bridgeLabel: "host-a",
+      workspaceLabel: undefined,
+    });
+    expect(sidebarRowContext("hostWorkspace", "all", "host-a", "workspace-a")).toEqual({
+      bridgeLabel: undefined,
+      workspaceLabel: undefined,
+    });
+    expect(sidebarRowContext("workspace", "selected", "host-a", "workspace-a")).toEqual({
+      bridgeLabel: undefined,
+      workspaceLabel: undefined,
+    });
   });
 
   it("allows flat all-host agent shortcuts to follow attention priority across hosts", () => {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  areAllVisibleSidebarGroupsCollapsed,
   agentSubtitle,
   applySnapshotOverlays,
   buildCombinedTabWorkspaceGroups,
@@ -518,8 +519,8 @@ describe("App multi-bridge helpers", () => {
       "group-a",
       "group-b",
     ]);
-    expect(parseCollapsedSidebarGroups(Array.from({ length: 300 }, (_, index) => `g-${index}`)))
-      .toHaveLength(256);
+    expect(parseCollapsedSidebarGroups(Array.from({ length: 5000 }, (_, index) => `g-${index}`)))
+      .toHaveLength(4096);
   });
 
   it("collapses and expands a visible set of sidebar groups without changing other groups", () => {
@@ -537,6 +538,52 @@ describe("App multi-bridge helpers", () => {
         false,
       ),
     ).toEqual(["other-group"]);
+
+    const manyVisibleGroups = Array.from({ length: 300 }, (_, index) => `visible-${index}`);
+    const collapsed = updateCollapsedSidebarGroups(
+      ["other-group"],
+      manyVisibleGroups,
+      true,
+    );
+    expect(collapsed).toEqual(["other-group", ...manyVisibleGroups]);
+    expect(updateCollapsedSidebarGroups(collapsed, manyVisibleGroups, false)).toEqual([
+      "other-group",
+    ]);
+  });
+
+  it("uses visible host state to choose the nested bulk group action", () => {
+    const hostKey = sidebarGroupCollapseKey("agents", "hostWorkspace", "host", "bridge-a");
+    const workspaceKey = sidebarGroupCollapseKey(
+      "agents",
+      "hostWorkspace",
+      "workspace",
+      "bridge-a:workspace-a",
+    );
+
+    expect(
+      areAllVisibleSidebarGroupsCollapsed(
+        [hostKey, workspaceKey],
+        "hostWorkspace",
+        "all",
+        new Set([hostKey]),
+      ),
+    ).toBe(true);
+    expect(
+      areAllVisibleSidebarGroupsCollapsed(
+        [hostKey, workspaceKey],
+        "hostWorkspace",
+        "all",
+        new Set([workspaceKey]),
+      ),
+    ).toBe(false);
+    expect(
+      areAllVisibleSidebarGroupsCollapsed(
+        [workspaceKey],
+        "workspace",
+        "all",
+        new Set([workspaceKey]),
+      ),
+    ).toBe(true);
   });
 
   it("hides keyboard-navigation entries inside collapsed nested groups", () => {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -2,16 +2,18 @@ import { describe, expect, it } from "vitest";
 import {
   agentSubtitle,
   applySnapshotOverlays,
-  buildVisibleAgentPaneEntries,
+  buildCombinedTabWorkspaceGroups,
   buildScopedAgentGroups,
+  buildVisibleAgentPaneEntries,
+  buildVisibleScopedWorkspaces,
   buildVisibleScopedNotes,
+  buildVisibleTabEntries,
+  buildVisibleTabWorkspaceGroups,
   canAddNoteFromPaneMenu,
   mergeCreatedPaneNoteList,
   mergePendingPaneNotesIntoList,
   noteDraftStorageKey,
-  buildVisibleScopedWorkspaces,
-  buildVisibleTabEntries,
-  buildVisibleTabWorkspaceGroups,
+  parseCombineMatchingWorkspaceNames,
   isInFlightNoteSaveVisible,
   launcherEmptyMessage,
   menuItems,
@@ -398,18 +400,108 @@ describe("App multi-bridge helpers", () => {
 
   it("uses workspace-only headers when grouping workspaces across hosts", () => {
     const sharedWorkspace = workspace("shared-workspace", 1);
-    const groups = buildScopedAgentGroups(
-      [
-        entry("host-a", 0, sharedWorkspace, pane("pane-a", "shared-workspace", "tab-a"), 1),
-        entry("host-b", 1, sharedWorkspace, pane("pane-b", "shared-workspace", "tab-b"), 1),
-      ],
-      "workspace",
-    );
+    const entries = [
+      entry("host-a", 0, sharedWorkspace, pane("pane-a", "shared-workspace", "tab-a"), 1),
+      entry(
+        "host-b",
+        1,
+        sharedWorkspace,
+        pane("pane-b", "shared-workspace", "tab-b", "blocked"),
+        1,
+      ),
+    ];
+    const groups = buildScopedAgentGroups(entries, "workspace");
 
     expect(groups.map((group) => group.label)).toEqual([
       "shared-workspace",
       "shared-workspace",
     ]);
+
+    const combinedGroups = buildScopedAgentGroups(entries, "workspace", true);
+    expect(combinedGroups).toHaveLength(1);
+    expect(combinedGroups[0]).toMatchObject({
+      key: "workspace-name:shared-workspace",
+      label: "shared-workspace",
+      status: "blocked",
+    });
+    expect(combinedGroups[0].panes.map((item) => item.bridgeId)).toEqual(["host-a", "host-b"]);
+  });
+
+  it("combines matching Tab workspace groups across hosts without merging their entries", () => {
+    const bridgeViews = [
+      bridgeView(
+        "host-a",
+        bridgeSnapshot("shared-workspace", "tab-a", pane("pane-a", "shared-workspace", "tab-a")),
+      ),
+      bridgeView(
+        "host-b",
+        bridgeSnapshot("shared-workspace", "tab-b", pane("pane-b", "shared-workspace", "tab-b")),
+      ),
+    ];
+    const scopedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViews,
+      "host-a",
+      "all",
+      "all",
+      null,
+      {},
+    );
+
+    const combinedGroups = buildCombinedTabWorkspaceGroups(
+      buildVisibleTabWorkspaceGroups(scopedWorkspaces),
+    );
+
+    expect(combinedGroups).toHaveLength(1);
+    expect(combinedGroups[0].label).toBe("shared-workspace");
+    expect(combinedGroups[0].workspaces.map((group) => group.bridgeId)).toEqual([
+      "host-a",
+      "host-b",
+    ]);
+
+    const bridgeViewsWithInterleavedWorkspace = [
+      bridgeView(
+        "host-a",
+        multiPaneSnapshot(
+          [workspace("shared-workspace", 1), workspace("unique-workspace", 2)],
+          [
+            pane("pane-a", "shared-workspace", "tab-a"),
+            pane("pane-unique", "unique-workspace", "tab-unique"),
+          ],
+        ),
+      ),
+      bridgeViews[1],
+    ];
+    const interleavedWorkspaces = buildVisibleScopedWorkspaces(
+      bridgeViewsWithInterleavedWorkspace,
+      "host-a",
+      "all",
+      "all",
+      null,
+      {},
+    );
+    expect(
+      buildVisibleTabEntries(
+        interleavedWorkspaces,
+        bridgeViewsWithInterleavedWorkspace,
+        "all",
+        "workspace",
+        new Set(),
+        false,
+        true,
+        "workspace",
+        new Map(),
+        false,
+        true,
+      ).map((item) => `${item.bridgeId}:${item.tab.tab_id}`),
+    ).toEqual(["host-a:tab-a", "host-b:tab-b", "host-a:tab-unique"]);
+  });
+
+  it("keeps the matching-name preference default-off and boolean-only", () => {
+    expect(parseCombineMatchingWorkspaceNames(undefined)).toBe(false);
+    expect(parseCombineMatchingWorkspaceNames("true")).toBe(false);
+    expect(parseCombineMatchingWorkspaceNames("true", true)).toBe(true);
+    expect(parseCombineMatchingWorkspaceNames(false, true)).toBe(false);
+    expect(parseCombineMatchingWorkspaceNames(true)).toBe(true);
   });
 
   it("moves host context into rows only for flat and workspace grouping", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3569,7 +3569,6 @@ export function App() {
           onAgentActiveOnly={setAgentActiveOnly}
           onAgentSort={setAgentSort}
           onAgentGroup={setAgentGroup}
-          onCombineMatchingWorkspaceNames={setCombineMatchingWorkspaceNames}
           onSpaceGroup={setSpaceGroup}
           onSelectBridge={setSelectedBridgeId}
           onSelectSpace={selectSpace}
@@ -4043,6 +4042,8 @@ export function App() {
           onNavigationSyncMode={changeNavigationSyncMode}
           agentFeaturesInTabs={agentFeaturesInTabs}
           onAgentFeaturesInTabs={setAgentFeaturesInTabs}
+          combineMatchingWorkspaceNames={combineMatchingWorkspaceNames}
+          onCombineMatchingWorkspaceNames={setCombineMatchingWorkspaceNames}
           multiHostSpaceSelection={multiHostSpaceSelection}
           onMultiHostSpaceSelection={setMultiHostSpaceSelection}
           terminalFontSizePx={terminalFontSizePx}
@@ -5576,7 +5577,6 @@ function Switcher({
   onAgentActiveOnly,
   onAgentSort,
   onAgentGroup,
-  onCombineMatchingWorkspaceNames,
   onSpaceGroup,
   onSelectBridge,
   onSelectSpace,
@@ -5627,7 +5627,6 @@ function Switcher({
   onAgentActiveOnly: (activeOnly: boolean) => void;
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
-  onCombineMatchingWorkspaceNames: (combine: boolean) => void;
   onSpaceGroup: (group: SpaceGroup) => void;
   onSelectBridge: (bridgeId: BridgeId) => void;
   onSelectSpace: (bridgeId: BridgeId, workspaceId: string) => void;
@@ -6561,12 +6560,9 @@ function Switcher({
           showGroup={showGroupControl}
           agentSort={agentSort}
           agentGroup={agentGroup}
-          combineMatchingWorkspaceNames={combineMatchingWorkspaceNames}
-          showCombineMatchingWorkspaceNames={hostScope === "all" && agentGroup === "workspace"}
           showLastStatusChangeSort={showLastStatusChangeSort}
           onAgentSort={onAgentSort}
           onAgentGroup={onAgentGroup}
-          onCombineMatchingWorkspaceNames={onCombineMatchingWorkspaceNames}
           onClose={() => setOptionsMenu(null)}
         />
       ) : null}
@@ -6591,12 +6587,9 @@ function SidebarOptionsMenu({
   showGroup,
   agentSort,
   agentGroup,
-  combineMatchingWorkspaceNames,
-  showCombineMatchingWorkspaceNames,
   showLastStatusChangeSort,
   onAgentSort,
   onAgentGroup,
-  onCombineMatchingWorkspaceNames,
   onClose,
 }: {
   x: number;
@@ -6606,12 +6599,9 @@ function SidebarOptionsMenu({
   showGroup: boolean;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
-  combineMatchingWorkspaceNames: boolean;
-  showCombineMatchingWorkspaceNames: boolean;
   showLastStatusChangeSort: boolean;
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
-  onCombineMatchingWorkspaceNames: (combine: boolean) => void;
   onClose: () => void;
 }) {
   return (
@@ -6650,19 +6640,6 @@ function SidebarOptionsMenu({
             <option value="hostWorkspace">Host + workspace</option>
           </select>
         </label>
-      ) : null}
-      {showCombineMatchingWorkspaceNames ? (
-        <button
-          className="sidebar-option-toggle"
-          type="button"
-          role="switch"
-          aria-checked={combineMatchingWorkspaceNames}
-          data-on={combineMatchingWorkspaceNames ? "true" : undefined}
-          onClick={() => onCombineMatchingWorkspaceNames(!combineMatchingWorkspaceNames)}
-        >
-          <span>Combine matching names</span>
-          <strong>{combineMatchingWorkspaceNames ? "On" : "Off"}</strong>
-        </button>
       ) : null}
     </OptionsMenuShell>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,8 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  ChevronsDown,
+  ChevronsUp,
   Link2,
   MoreVertical,
   PanelLeft,
@@ -958,6 +960,14 @@ export function App() {
         : [...current, key].slice(-256),
     );
   }, []);
+  const setVisibleSidebarGroupsCollapsed = useCallback(
+    (keys: readonly string[], collapsed: boolean) => {
+      setCollapsedSidebarGroups((current) =>
+        updateCollapsedSidebarGroups(current, keys, collapsed),
+      );
+    },
+    [],
+  );
   const [spaceGroup, setSpaceGroup] = useState<SpaceGroup>(initialPrefs.spaceGroup);
   const [agentPinnedOnly, setAgentPinnedOnly] = useState(initialPrefs.agentPinnedOnly);
   const [agentActiveOnly, setAgentActiveOnly] = useState(initialPrefs.agentActiveOnly);
@@ -3624,6 +3634,7 @@ export function App() {
           onAgentSort={setAgentSort}
           onAgentGroup={setAgentGroup}
           onToggleCollapsedGroup={toggleCollapsedSidebarGroup}
+          onSetCollapsedGroups={setVisibleSidebarGroupsCollapsed}
           onSpaceGroup={setSpaceGroup}
           onSelectBridge={setSelectedBridgeId}
           onSelectSpace={selectSpace}
@@ -4729,6 +4740,25 @@ export function sidebarGroupCollapseKey(
   return [view, grouping, level, identity].map(encodeURIComponent).join(":");
 }
 
+export function updateCollapsedSidebarGroups(
+  current: readonly string[],
+  keys: readonly string[],
+  collapsed: boolean,
+) {
+  const targetKeys = new Set(keys);
+  if (!collapsed) {
+    return current.filter((key) => !targetKeys.has(key));
+  }
+  const next = [...current];
+  const knownKeys = new Set(current);
+  for (const key of targetKeys) {
+    if (!knownKeys.has(key)) {
+      next.push(key);
+    }
+  }
+  return next.slice(-256);
+}
+
 function workspaceGroupIdentity(
   bridgeId: BridgeId,
   workspaceId: string,
@@ -5731,6 +5761,7 @@ function Switcher({
   onAgentSort,
   onAgentGroup,
   onToggleCollapsedGroup,
+  onSetCollapsedGroups,
   onSpaceGroup,
   onSelectBridge,
   onSelectSpace,
@@ -5783,6 +5814,7 @@ function Switcher({
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
   onToggleCollapsedGroup: (key: string) => void;
+  onSetCollapsedGroups: (keys: readonly string[], collapsed: boolean) => void;
   onSpaceGroup: (group: SpaceGroup) => void;
   onSelectBridge: (bridgeId: BridgeId) => void;
   onSelectSpace: (bridgeId: BridgeId, workspaceId: string) => void;
@@ -6011,6 +6043,89 @@ function Switcher({
   const showActiveOnlyControl =
     sidebarView === "agents" || (sidebarView === "tabs" && agentFeaturesInTabs);
   const pinnedOnlyLabel = sidebarView === "tabs" ? "pinned panes" : "pinned agents";
+  const paneGroupCollapseKeys = (() => {
+    if (sidebarView === "agents") {
+      if (agentGroup === "none") {
+        return [];
+      }
+      if (agentGroup === "hostWorkspace" && hostScope === "all") {
+        return hostBridgeViews.flatMap((view) => {
+          const groups = agentGroups.filter((group) => group.bridgeId === view.runtime.id);
+          if (groups.length === 0) {
+            return [];
+          }
+          return [
+            sidebarGroupCollapseKey("agents", agentGroup, "host", view.runtime.id),
+            ...groups.map((group) =>
+              sidebarGroupCollapseKey("agents", agentGroup, "workspace", group.key),
+            ),
+          ];
+        });
+      }
+      const level = agentGroup === "host" ? "host" : "workspace";
+      return agentGroups.map((group) =>
+        sidebarGroupCollapseKey("agents", agentGroup, level, group.key),
+      );
+    }
+
+    if (sidebarView !== "tabs" || agentGroup === "none") {
+      return [];
+    }
+    if (agentGroup === "host") {
+      return hostBridgeViews.flatMap((view) =>
+        flatTabEntries.some(
+          (entry) => entry.bridgeId === view.runtime.id && entry.panes.length > 0,
+        )
+          ? [sidebarGroupCollapseKey("tabs", agentGroup, "host", view.runtime.id)]
+          : [],
+      );
+    }
+    if (agentGroup === "hostWorkspace" && hostScope === "all") {
+      return hostBridgeViews.flatMap((view) => {
+        const groups = spaceGroups.filter(
+          (group) => group.bridgeId === view.runtime.id && group.tabs.length > 0,
+        );
+        if (groups.length === 0) {
+          return [];
+        }
+        return [
+          sidebarGroupCollapseKey("tabs", agentGroup, "host", view.runtime.id),
+          ...groups.map((group) =>
+            sidebarGroupCollapseKey(
+              "tabs",
+              agentGroup,
+              "workspace",
+              `${group.bridgeId}:${group.workspace.workspace_id}`,
+            ),
+          ),
+        ];
+      });
+    }
+    if (combineWorkspaceGroups) {
+      return combinedTabWorkspaceGroups.map((group) =>
+        sidebarGroupCollapseKey("tabs", agentGroup, "workspace", group.key),
+      );
+    }
+    return spaceGroups.flatMap((group) =>
+      group.tabs.length > 0
+        ? [
+            sidebarGroupCollapseKey(
+              "tabs",
+              agentGroup,
+              "workspace",
+              `${group.bridgeId}:${group.workspace.workspace_id}`,
+            ),
+          ]
+        : [],
+    );
+  })();
+  const paneGroupToggleStateKeys =
+    agentGroup === "hostWorkspace" && hostScope === "all"
+      ? paneGroupCollapseKeys.filter((key) => key.split(":")[2] === "host")
+      : paneGroupCollapseKeys;
+  const allPaneGroupsCollapsed =
+    paneGroupToggleStateKeys.length > 0 &&
+    paneGroupToggleStateKeys.every((key) => collapsedSidebarGroupKeys.has(key));
 
   useEffect(() => {
     if (optionsMenu && !showOptionsControl) {
@@ -6032,6 +6147,7 @@ function Switcher({
     showBridgeInWorkspaceHeader = showGroupedHostContext,
     key = `${group.bridgeId}:${group.workspace.workspace_id}`,
     collapseKey?: string,
+    nestedHeader = false,
   ) => {
     const collapsed = collapseKey ? collapsedSidebarGroupKeys.has(collapseKey) : false;
     const paneCount = group.tabs.reduce((total, tab) => total + tab.panes.length, 0);
@@ -6136,6 +6252,7 @@ function Switcher({
             status={group.workspace.agent_status}
             count={paneCount}
             collapsed={collapsed}
+            nested={nestedHeader}
             onToggle={() => {
               if (collapseKey) {
                 onToggleCollapsedGroup(collapseKey);
@@ -6235,6 +6352,7 @@ function Switcher({
                       "workspace",
                       `${group.bridgeId}:${group.workspace.workspace_id}`,
                     ),
+                    true,
                   ),
                 )
               : null}
@@ -6379,7 +6497,7 @@ function Switcher({
     );
   };
   const renderAgentGroupRows = () => {
-    const renderGroup = (group: ScopedAgentGroup) => {
+    const renderGroup = (group: ScopedAgentGroup, nested = false) => {
       const level = agentGroup === "host" ? "host" : "workspace";
       const collapseKey = sidebarGroupCollapseKey(
         "agents",
@@ -6396,6 +6514,7 @@ function Switcher({
             status={group.status}
             count={group.panes.length}
             collapsed={collapsed}
+            nested={nested}
             onToggle={() => onToggleCollapsedGroup(collapseKey)}
           />
           {!collapsed
@@ -6406,7 +6525,7 @@ function Switcher({
     };
 
     if (agentGroup !== "hostWorkspace" || hostScope !== "all") {
-      return agentGroups.map(renderGroup);
+      return agentGroups.map((group) => renderGroup(group));
     }
 
     return hostBridgeViews.map((view) => {
@@ -6433,7 +6552,7 @@ function Switcher({
             collapsed={collapsed}
             onToggle={() => onToggleCollapsedGroup(collapseKey)}
           />
-          {!collapsed ? groups.map(renderGroup) : null}
+          {!collapsed ? groups.map((group) => renderGroup(group, true)) : null}
         </Fragment>
       );
     });
@@ -6796,6 +6915,25 @@ function Switcher({
                     onClick={() => onAgentActiveOnly(!agentActiveOnly)}
                   >
                     <Activity size={13} />
+                  </button>
+                ) : null}
+                {paneGroupCollapseKeys.length > 0 ? (
+                  <button
+                    className="sec-add"
+                    type="button"
+                    aria-label={
+                      allPaneGroupsCollapsed ? "Expand all groups" : "Collapse all groups"
+                    }
+                    title={allPaneGroupsCollapsed ? "Expand all groups" : "Collapse all groups"}
+                    onClick={() =>
+                      onSetCollapsedGroups(paneGroupCollapseKeys, !allPaneGroupsCollapsed)
+                    }
+                  >
+                    {allPaneGroupsCollapsed ? (
+                      <ChevronsDown size={14} />
+                    ) : (
+                      <ChevronsUp size={14} />
+                    )}
                   </button>
                 ) : null}
                 {showOptionsControl ? (
@@ -8031,6 +8169,7 @@ function GroupHeader({
   status,
   count,
   collapsed,
+  nested = false,
   onToggle,
 }: {
   label: string;
@@ -8038,6 +8177,7 @@ function GroupHeader({
   status?: AgentStatus;
   count: number;
   collapsed: boolean;
+  nested?: boolean;
   onToggle: () => void;
 }) {
   return (
@@ -8045,6 +8185,7 @@ function GroupHeader({
       className="grp-space"
       type="button"
       data-group-header="true"
+      data-nested={nested ? "true" : undefined}
       aria-expanded={!collapsed}
       aria-label={`${collapsed ? "Expand" : "Collapse"} ${label} group`}
       title={`${collapsed ? "Expand" : "Collapse"} ${label}`}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4592,7 +4592,7 @@ export function buildVisibleAgentPaneEntries(
 
   if (agentSort === "lastStatusChange" && agentGroup !== "none") {
     const agentPanes = filterAgentEntries(buildRows("workspace"), pinnedOnly, activeOnly);
-    const groups = buildScopedAgentGroups(agentPanes, agentGroup, hostScope).map((group) => ({
+    const groups = buildScopedAgentGroups(agentPanes, agentGroup).map((group) => ({
       ...group,
       panes: sortedAgentEntriesWithinGroup(sortScopedAgentPanes(group.panes, agentSort)),
     }));
@@ -4613,7 +4613,7 @@ export function buildVisibleAgentPaneEntries(
     return agentPanes;
   }
 
-  const groups = buildScopedAgentGroups(agentPanes, agentGroup, hostScope).map((group) => ({
+  const groups = buildScopedAgentGroups(agentPanes, agentGroup).map((group) => ({
     ...group,
     panes: sortedAgentEntriesWithinGroup(group.panes),
   }));
@@ -4640,7 +4640,6 @@ function filterAgentEntries(
 export function buildScopedAgentGroups(
   agentPanes: ScopedAgentPane[],
   agentGroup: AgentGroup,
-  hostScope: HostScope,
 ) {
   const paneBuckets = new Map<string, ScopedAgentGroup>();
   const groupByWorkspace = agentGroup === "workspace" || agentGroup === "hostWorkspace";
@@ -4649,13 +4648,7 @@ export function buildScopedAgentGroups(
       ? `${entry.bridgeId}:${entry.pane.workspace_id}`
       : entry.bridgeId;
     const label =
-      agentGroup === "host"
-        ? entry.bridgeLabel
-        : agentGroup === "hostWorkspace"
-          ? (entry.workspace?.label ?? "workspace")
-          : hostScope === "all"
-            ? `${entry.bridgeLabel} / ${entry.workspace?.label ?? "workspace"}`
-            : (entry.workspace?.label ?? "workspace");
+      agentGroup === "host" ? entry.bridgeLabel : (entry.workspace?.label ?? "workspace");
     const existing =
       paneBuckets.get(key) ??
       {
@@ -4825,6 +4818,22 @@ export function shouldShowTabDivider(
   paneCount: number,
 ) {
   return agentGroup !== "none" && (workspaceTabCount > 1 || paneCount > 1);
+}
+
+export function sidebarRowContext(
+  agentGroup: AgentGroup,
+  hostScope: HostScope,
+  bridgeLabel: string,
+  workspaceLabel: string,
+) {
+  return {
+    bridgeLabel:
+      hostScope === "all" && (agentGroup === "none" || agentGroup === "workspace")
+        ? bridgeLabel
+        : undefined,
+    workspaceLabel:
+      agentGroup === "none" || agentGroup === "host" ? workspaceLabel : undefined,
+  };
 }
 
 export function buildVisibleScopedNotes(
@@ -5704,8 +5713,8 @@ function Switcher({
     if (agentGroup === "none") {
       return [];
     }
-    return buildScopedAgentGroups(agentPanes, agentGroup, hostScope);
-  }, [agentGroup, agentPanes, hostScope]);
+    return buildScopedAgentGroups(agentPanes, agentGroup);
+  }, [agentGroup, agentPanes]);
 
   const spaceGroups = useMemo<ScopedTabWorkspace[]>(
     () =>
@@ -5801,6 +5810,12 @@ function Switcher({
       ) : null}
       {group.tabs.map(({ tab, panes: tabPanes }) => {
         const tabLabel = displayTabLabel(tab, group.snapshot.panes);
+        const rowContext = sidebarRowContext(
+          agentGroup,
+          hostScope,
+          group.bridgeLabel,
+          group.workspace.label,
+        );
         const paneRows = tabPanes.map((pane) => {
           const index = paneIndex++;
           const pinned = isAgentPinned(pinnedAgentKeys, group.bridgeId, pane.pane_id);
@@ -5825,11 +5840,9 @@ function Switcher({
                 key={`${group.bridgeId}:${pane.pane_id}`}
                 index={index}
                 pane={pane}
-                workspace={group.workspace}
+                workspace={rowContext.workspaceLabel ? group.workspace : undefined}
                 tabLabel={tabLabel}
-                bridgeLabel={
-                  agentGroup === "none" && hostScope === "all" ? group.bridgeLabel : undefined
-                }
+                bridgeLabel={rowContext.bridgeLabel}
                 pinned={pinned}
                 active={active}
                 onSelect={onSelect}
@@ -5842,17 +5855,11 @@ function Switcher({
               key={`${group.bridgeId}:${pane.pane_id}`}
               index={index}
               pane={pane}
-              workspaceLabel={
-                agentGroup === "none" || agentGroup === "host"
-                  ? group.workspace.label
-                  : undefined
-              }
+              workspaceLabel={rowContext.workspaceLabel}
               tabLabel={
                 agentGroup === "none" || agentGroup === "host" ? tabLabel : undefined
               }
-              bridgeLabel={
-                agentGroup === "none" && hostScope === "all" ? group.bridgeLabel : undefined
-              }
+              bridgeLabel={rowContext.bridgeLabel}
               pinned={pinned}
               active={active}
               onSelect={onSelect}
@@ -5934,7 +5941,11 @@ function Switcher({
       });
     }
 
-    if (agentGroup === "workspace" || agentGroup === "hostWorkspace") {
+    if (agentGroup === "workspace") {
+      return spaceGroups.map((group) => renderTabWorkspaceGroup(group, true, false));
+    }
+
+    if (agentGroup === "hostWorkspace") {
       return spaceGroups.map((group) => renderTabWorkspaceGroup(group, true));
     }
 
@@ -5966,35 +5977,42 @@ function Switcher({
         onRetry={() => onRefreshBridge(view.runtime.id)}
       />
     ));
-  const showAgentRowBridgeLabel = showGroupedHostContext && agentGroup === "none";
-  const renderAgentRow = (entry: ScopedAgentPane, index: number) => (
-    <AgentRow
-      key={`${entry.bridgeId}:${entry.pane.pane_id}`}
-      index={index}
-      pane={entry.pane}
-      workspace={entry.workspace}
-      tabLabel={entry.tabLabel}
-      bridgeLabel={showAgentRowBridgeLabel ? entry.bridgeLabel : undefined}
-      pinned={entry.pinned === true}
-      active={
-        entry.bridgeId === selectedBridgeId &&
-        entry.pane.pane_id === selectedPane?.pane_id
-      }
-      onSelect={() => onSelectPane(entry.bridgeId, entry.pane)}
-      onMenu={(x, y) =>
-        onScopedMenu(
-          "pane",
-          entry.bridgeId,
-          entry.pane.pane_id,
-          paneTitle(entry.pane),
-          x,
-          y,
-          undefined,
-          "agent",
-        )
-      }
-    />
-  );
+  const renderAgentRow = (entry: ScopedAgentPane, index: number) => {
+    const rowContext = sidebarRowContext(
+      agentGroup,
+      hostScope,
+      entry.bridgeLabel,
+      entry.workspace?.label ?? "workspace",
+    );
+    return (
+      <AgentRow
+        key={`${entry.bridgeId}:${entry.pane.pane_id}`}
+        index={index}
+        pane={entry.pane}
+        workspace={rowContext.workspaceLabel ? entry.workspace : undefined}
+        tabLabel={entry.tabLabel}
+        bridgeLabel={rowContext.bridgeLabel}
+        pinned={entry.pinned === true}
+        active={
+          entry.bridgeId === selectedBridgeId &&
+          entry.pane.pane_id === selectedPane?.pane_id
+        }
+        onSelect={() => onSelectPane(entry.bridgeId, entry.pane)}
+        onMenu={(x, y) =>
+          onScopedMenu(
+            "pane",
+            entry.bridgeId,
+            entry.pane.pane_id,
+            paneTitle(entry.pane),
+            x,
+            y,
+            undefined,
+            "agent",
+          )
+        }
+      />
+    );
+  };
   const renderAgentGroupRows = () => {
     const renderGroup = (group: ScopedAgentGroup) => (
       <Fragment key={group.key}>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,9 @@
 import {
   Activity,
   Archive,
+  ChevronDown,
   ChevronLeft,
+  ChevronRight,
   Link2,
   MoreVertical,
   PanelLeft,
@@ -368,6 +370,7 @@ type DisplayPrefs = {
   agentSort: AgentSort;
   agentGroup: AgentGroup;
   combineMatchingWorkspaceNames: boolean;
+  collapsedSidebarGroups: string[];
   spaceGroup: SpaceGroup;
   agentPinnedOnly: boolean;
   agentActiveOnly: boolean;
@@ -430,6 +433,7 @@ function readDisplayPrefs(): DisplayPrefs {
     agentSort: "attention",
     agentGroup: "none",
     combineMatchingWorkspaceNames: false,
+    collapsedSidebarGroups: [],
     spaceGroup: "none",
     agentPinnedOnly: false,
     agentActiveOnly: false,
@@ -597,6 +601,10 @@ function parseDisplayPrefsValue(
     combineMatchingWorkspaceNames: parseCombineMatchingWorkspaceNames(
       parsed.combineMatchingWorkspaceNames,
       fallback.combineMatchingWorkspaceNames,
+    ),
+    collapsedSidebarGroups: parseCollapsedSidebarGroups(
+      parsed.collapsedSidebarGroups,
+      fallback.collapsedSidebarGroups,
     ),
     spaceGroup:
       parsed.spaceGroup === "none" || parsed.spaceGroup === "host"
@@ -808,6 +816,17 @@ export function parseCombineMatchingWorkspaceNames(value: unknown, fallback = fa
   return typeof value === "boolean" ? value : fallback;
 }
 
+export function parseCollapsedSidebarGroups(value: unknown, fallback: string[] = []) {
+  if (!Array.isArray(value)) {
+    return fallback;
+  }
+  return [
+    ...new Set(
+      value.filter((item): item is string => typeof item === "string" && item.length > 0),
+    ),
+  ].slice(-256);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -925,6 +944,20 @@ export function App() {
   const [combineMatchingWorkspaceNames, setCombineMatchingWorkspaceNames] = useState(
     initialPrefs.combineMatchingWorkspaceNames,
   );
+  const [collapsedSidebarGroups, setCollapsedSidebarGroups] = useState(
+    initialPrefs.collapsedSidebarGroups,
+  );
+  const collapsedSidebarGroupKeys = useMemo(
+    () => new Set(collapsedSidebarGroups),
+    [collapsedSidebarGroups],
+  );
+  const toggleCollapsedSidebarGroup = useCallback((key: string) => {
+    setCollapsedSidebarGroups((current) =>
+      current.includes(key)
+        ? current.filter((item) => item !== key)
+        : [...current, key].slice(-256),
+    );
+  }, []);
   const [spaceGroup, setSpaceGroup] = useState<SpaceGroup>(initialPrefs.spaceGroup);
   const [agentPinnedOnly, setAgentPinnedOnly] = useState(initialPrefs.agentPinnedOnly);
   const [agentActiveOnly, setAgentActiveOnly] = useState(initialPrefs.agentActiveOnly);
@@ -1065,6 +1098,7 @@ export function App() {
       setAgentSort(prefs.agentSort);
       setAgentGroup(prefs.agentGroup);
       setCombineMatchingWorkspaceNames(prefs.combineMatchingWorkspaceNames);
+      setCollapsedSidebarGroups(prefs.collapsedSidebarGroups);
       setSpaceGroup(prefs.spaceGroup);
       setAgentPinnedOnly(prefs.agentPinnedOnly);
       setAgentActiveOnly(prefs.agentActiveOnly);
@@ -1569,6 +1603,7 @@ export function App() {
       agentSort,
       agentGroup,
       combineMatchingWorkspaceNames,
+      collapsedSidebarGroups,
       spaceGroup,
       agentPinnedOnly,
       agentActiveOnly,
@@ -1603,6 +1638,7 @@ export function App() {
     agentSort,
     agentGroup,
     combineMatchingWorkspaceNames,
+    collapsedSidebarGroups,
     spaceGroup,
     agentPinnedOnly,
     agentActiveOnly,
@@ -2861,25 +2897,33 @@ export function App() {
       }
 
       if (event.key === "ArrowUp" || event.key === "ArrowDown") {
-        const agentEntries = buildVisibleAgentPaneEntries(
-          buildVisibleScopedWorkspaces(
+        const combineWorkspaceGroupsForShortcut =
+          combineMatchingWorkspaceNames && hostScope === "all" && agentGroup === "workspace";
+        const agentEntries = filterCollapsedAgentPaneEntries(
+          buildVisibleAgentPaneEntries(
+            buildVisibleScopedWorkspaces(
+              bridgeViews,
+              selectedRuntime?.id ?? null,
+              hostScope,
+              scope,
+              activeSpace,
+              activeWorkspacesByBridgeId,
+              multiHostSpaceSelection,
+            ),
             bridgeViews,
-            selectedRuntime?.id ?? null,
             hostScope,
-            scope,
-            activeSpace,
-            activeWorkspacesByBridgeId,
-            multiHostSpaceSelection,
+            agentGroup,
+            agentSort,
+            pinnedAgentKeys,
+            effectiveAgentPinnedOnly,
+            agentActivityTransitions,
+            agentActiveOnly,
+            combineWorkspaceGroupsForShortcut,
           ),
-          bridgeViews,
-          hostScope,
           agentGroup,
-          agentSort,
-          pinnedAgentKeys,
-          effectiveAgentPinnedOnly,
-          agentActivityTransitions,
-          agentActiveOnly,
-          combineMatchingWorkspaceNames && hostScope === "all" && agentGroup === "workspace",
+          hostScope,
+          combineWorkspaceGroupsForShortcut,
+          collapsedSidebarGroupKeys,
         );
         if (agentEntries.length === 0) {
           return;
@@ -2904,26 +2948,34 @@ export function App() {
       if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
         return;
       }
-      const tabEntries = buildVisibleTabEntries(
-        buildVisibleScopedWorkspaces(
+      const combineWorkspaceGroupsForShortcut =
+        combineMatchingWorkspaceNames && hostScope === "all" && agentGroup === "workspace";
+      const tabEntries = filterCollapsedTabEntries(
+        buildVisibleTabEntries(
+          buildVisibleScopedWorkspaces(
+            bridgeViews,
+            selectedRuntime?.id ?? null,
+            hostScope,
+            scope,
+            activeSpace,
+            activeWorkspacesByBridgeId,
+            multiHostSpaceSelection,
+          ),
           bridgeViews,
-          selectedRuntime?.id ?? null,
           hostScope,
-          scope,
-          activeSpace,
-          activeWorkspacesByBridgeId,
-          multiHostSpaceSelection,
+          agentGroup,
+          pinnedAgentKeys,
+          sidebarView === "tabs" && effectiveAgentPinnedOnly,
+          sidebarView === "tabs" && agentFeaturesInTabs,
+          agentSort,
+          agentActivityTransitions,
+          sidebarView === "tabs" && agentFeaturesInTabs && agentActiveOnly,
+          combineWorkspaceGroupsForShortcut,
         ),
-        bridgeViews,
-        hostScope,
         agentGroup,
-        pinnedAgentKeys,
-        sidebarView === "tabs" && effectiveAgentPinnedOnly,
-        sidebarView === "tabs" && agentFeaturesInTabs,
-        agentSort,
-        agentActivityTransitions,
-        sidebarView === "tabs" && agentFeaturesInTabs && agentActiveOnly,
-        combineMatchingWorkspaceNames && hostScope === "all" && agentGroup === "workspace",
+        hostScope,
+        combineWorkspaceGroupsForShortcut,
+        collapsedSidebarGroupKeys,
       );
       const tabs = tabEntries;
       if (tabs.length === 0) {
@@ -2961,6 +3013,7 @@ export function App() {
     agentGroup,
     agentSort,
     combineMatchingWorkspaceNames,
+    collapsedSidebarGroupKeys,
     bridgeViews,
     busy,
     dialog,
@@ -3555,6 +3608,7 @@ export function App() {
           agentSort={agentSort}
           agentGroup={agentGroup}
           combineMatchingWorkspaceNames={combineMatchingWorkspaceNames}
+          collapsedSidebarGroupKeys={collapsedSidebarGroupKeys}
           spaceGroup={spaceGroup}
           multiHostSpaceSelection={multiHostSpaceSelection}
           activeSpace={activeSpace}
@@ -3569,6 +3623,7 @@ export function App() {
           onAgentActiveOnly={setAgentActiveOnly}
           onAgentSort={setAgentSort}
           onAgentGroup={setAgentGroup}
+          onToggleCollapsedGroup={toggleCollapsedSidebarGroup}
           onSpaceGroup={setSpaceGroup}
           onSelectBridge={setSelectedBridgeId}
           onSelectSpace={selectSpace}
@@ -4662,6 +4717,100 @@ export function buildVisibleAgentPaneEntries(
   return groups.flatMap((group) => group.panes);
 }
 
+type CollapsibleSidebarView = "agents" | "tabs" | "spaces";
+type CollapsibleGroupLevel = "host" | "workspace";
+
+export function sidebarGroupCollapseKey(
+  view: CollapsibleSidebarView,
+  grouping: AgentGroup | SpaceGroup,
+  level: CollapsibleGroupLevel,
+  identity: string,
+) {
+  return [view, grouping, level, identity].map(encodeURIComponent).join(":");
+}
+
+function workspaceGroupIdentity(
+  bridgeId: BridgeId,
+  workspaceId: string,
+  workspaceLabel: string,
+  combineMatchingWorkspaceNames: boolean,
+) {
+  return combineMatchingWorkspaceNames
+    ? `workspace-name:${workspaceLabel.trim() || "workspace"}`
+    : `${bridgeId}:${workspaceId}`;
+}
+
+function entryCollapseKeys(
+  view: "agents" | "tabs",
+  bridgeId: BridgeId,
+  workspaceId: string,
+  workspaceLabel: string,
+  agentGroup: AgentGroup,
+  hostScope: HostScope,
+  combineMatchingWorkspaceNames: boolean,
+) {
+  if (agentGroup === "none") {
+    return [];
+  }
+  if (agentGroup === "host") {
+    return [sidebarGroupCollapseKey(view, agentGroup, "host", bridgeId)];
+  }
+  const workspaceKey = sidebarGroupCollapseKey(
+    view,
+    agentGroup,
+    "workspace",
+    workspaceGroupIdentity(
+      bridgeId,
+      workspaceId,
+      workspaceLabel,
+      agentGroup === "workspace" && combineMatchingWorkspaceNames,
+    ),
+  );
+  return agentGroup === "hostWorkspace" && hostScope === "all"
+    ? [sidebarGroupCollapseKey(view, agentGroup, "host", bridgeId), workspaceKey]
+    : [workspaceKey];
+}
+
+export function filterCollapsedAgentPaneEntries(
+  entries: ScopedAgentPane[],
+  agentGroup: AgentGroup,
+  hostScope: HostScope,
+  combineMatchingWorkspaceNames: boolean,
+  collapsedGroupKeys: ReadonlySet<string>,
+) {
+  return entries.filter((entry) =>
+    entryCollapseKeys(
+      "agents",
+      entry.bridgeId,
+      entry.pane.workspace_id,
+      entry.workspace?.label ?? "workspace",
+      agentGroup,
+      hostScope,
+      combineMatchingWorkspaceNames,
+    ).every((key) => !collapsedGroupKeys.has(key)),
+  );
+}
+
+export function filterCollapsedTabEntries(
+  entries: ScopedTabEntry[],
+  agentGroup: AgentGroup,
+  hostScope: HostScope,
+  combineMatchingWorkspaceNames: boolean,
+  collapsedGroupKeys: ReadonlySet<string>,
+) {
+  return entries.filter((entry) =>
+    entryCollapseKeys(
+      "tabs",
+      entry.bridgeId,
+      entry.workspace.workspace_id,
+      entry.workspace.label,
+      agentGroup,
+      hostScope,
+      combineMatchingWorkspaceNames,
+    ).every((key) => !collapsedGroupKeys.has(key)),
+  );
+}
+
 function filterAgentEntries(
   entries: ScopedAgentPane[],
   pinnedOnly: boolean,
@@ -5371,6 +5520,9 @@ function isShortcutTextEntryTarget(target: EventTarget | null) {
   if (target.classList.contains("ghostty-hidden-input")) {
     return false;
   }
+  if (target.closest("[data-group-header='true']")) {
+    return true;
+  }
   if (target.isContentEditable) {
     return true;
   }
@@ -5563,6 +5715,7 @@ function Switcher({
   agentSort,
   agentGroup,
   combineMatchingWorkspaceNames,
+  collapsedSidebarGroupKeys,
   spaceGroup,
   multiHostSpaceSelection,
   activeSpace,
@@ -5577,6 +5730,7 @@ function Switcher({
   onAgentActiveOnly,
   onAgentSort,
   onAgentGroup,
+  onToggleCollapsedGroup,
   onSpaceGroup,
   onSelectBridge,
   onSelectSpace,
@@ -5613,6 +5767,7 @@ function Switcher({
   agentSort: AgentSort;
   agentGroup: AgentGroup;
   combineMatchingWorkspaceNames: boolean;
+  collapsedSidebarGroupKeys: ReadonlySet<string>;
   spaceGroup: SpaceGroup;
   multiHostSpaceSelection: boolean;
   activeSpace: WorkspaceInfo | null;
@@ -5627,6 +5782,7 @@ function Switcher({
   onAgentActiveOnly: (activeOnly: boolean) => void;
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
+  onToggleCollapsedGroup: (key: string) => void;
   onSpaceGroup: (group: SpaceGroup) => void;
   onSelectBridge: (bridgeId: BridgeId) => void;
   onSelectSpace: (bridgeId: BridgeId, workspaceId: string) => void;
@@ -5875,53 +6031,63 @@ function Switcher({
     showWorkspaceHeader: boolean,
     showBridgeInWorkspaceHeader = showGroupedHostContext,
     key = `${group.bridgeId}:${group.workspace.workspace_id}`,
-  ) => (
-    <Fragment key={key}>
-      {showWorkspaceHeader ? (
-        <GroupHeader
-          label={
-            showBridgeInWorkspaceHeader
-              ? `${group.bridgeLabel} / ${group.workspace.label}`
-              : group.workspace.label
-          }
-          bridgeColor={showBridgeInWorkspaceHeader ? group.bridgeColor : undefined}
-          status={showBridgeInWorkspaceHeader ? undefined : group.workspace.agent_status}
-        />
-      ) : null}
-      {group.tabs.map(({ tab, panes: tabPanes }) => {
-        const tabLabel = displayTabLabel(tab, group.snapshot.panes);
-        const rowContext = sidebarRowContext(
-          agentGroup,
-          hostScope,
-          group.bridgeLabel,
-          group.workspace.label,
-        );
-        const paneRows = tabPanes.map((pane) => {
-          const index = paneIndex++;
-          const pinned = isAgentPinned(pinnedAgentKeys, group.bridgeId, pane.pane_id);
-          const renderAsAgent = shouldRenderAgentRowInTabs(pane, agentFeaturesInTabs);
-          const active =
-            group.bridgeId === selectedBridgeId && pane.pane_id === selectedPane?.pane_id;
-          const onSelect = () => onSelectPane(group.bridgeId, pane);
-          const onPaneMenu = (x: number, y: number) =>
-            onScopedMenu(
-              "pane",
-              group.bridgeId,
-              pane.pane_id,
-              paneTitle(pane),
-              x,
-              y,
-              undefined,
-              renderAsAgent ? "agent" : "pane",
-            );
-          if (renderAsAgent) {
+    collapseKey?: string,
+  ) => {
+    const collapsed = collapseKey ? collapsedSidebarGroupKeys.has(collapseKey) : false;
+    const paneCount = group.tabs.reduce((total, tab) => total + tab.panes.length, 0);
+    const tabRows = collapsed
+      ? null
+      : group.tabs.map(({ tab, panes: tabPanes }) => {
+          const tabLabel = displayTabLabel(tab, group.snapshot.panes);
+          const rowContext = sidebarRowContext(
+            agentGroup,
+            hostScope,
+            group.bridgeLabel,
+            group.workspace.label,
+          );
+          const paneRows = tabPanes.map((pane) => {
+            const index = paneIndex++;
+            const pinned = isAgentPinned(pinnedAgentKeys, group.bridgeId, pane.pane_id);
+            const renderAsAgent = shouldRenderAgentRowInTabs(pane, agentFeaturesInTabs);
+            const active =
+              group.bridgeId === selectedBridgeId && pane.pane_id === selectedPane?.pane_id;
+            const onSelect = () => onSelectPane(group.bridgeId, pane);
+            const onPaneMenu = (x: number, y: number) =>
+              onScopedMenu(
+                "pane",
+                group.bridgeId,
+                pane.pane_id,
+                paneTitle(pane),
+                x,
+                y,
+                undefined,
+                renderAsAgent ? "agent" : "pane",
+              );
+            if (renderAsAgent) {
+              return (
+                <AgentRow
+                  key={`${group.bridgeId}:${pane.pane_id}`}
+                  index={index}
+                  pane={pane}
+                  workspace={rowContext.workspaceLabel ? group.workspace : undefined}
+                  tabLabel={tabLabel}
+                  bridgeLabel={rowContext.bridgeLabel}
+                  pinned={pinned}
+                  active={active}
+                  onSelect={onSelect}
+                  onMenu={onPaneMenu}
+                />
+              );
+            }
             return (
-              <AgentRow
+              <PaneRow
                 key={`${group.bridgeId}:${pane.pane_id}`}
                 index={index}
                 pane={pane}
-                workspace={rowContext.workspaceLabel ? group.workspace : undefined}
-                tabLabel={tabLabel}
+                workspaceLabel={rowContext.workspaceLabel}
+                tabLabel={
+                  agentGroup === "none" || agentGroup === "host" ? tabLabel : undefined
+                }
                 bridgeLabel={rowContext.bridgeLabel}
                 pinned={pinned}
                 active={active}
@@ -5929,53 +6095,58 @@ function Switcher({
                 onMenu={onPaneMenu}
               />
             );
+          });
+          if (agentGroup === "none") {
+            return <Fragment key={`${group.bridgeId}:${tab.tab_id}`}>{paneRows}</Fragment>;
           }
           return (
-            <PaneRow
-              key={`${group.bridgeId}:${pane.pane_id}`}
-              index={index}
-              pane={pane}
-              workspaceLabel={rowContext.workspaceLabel}
-              tabLabel={
-                agentGroup === "none" || agentGroup === "host" ? tabLabel : undefined
-              }
-              bridgeLabel={rowContext.bridgeLabel}
-              pinned={pinned}
-              active={active}
-              onSelect={onSelect}
-              onMenu={onPaneMenu}
-            />
+            <div className="tabgrp" key={`${group.bridgeId}:${tab.tab_id}`}>
+              {shouldShowTabDivider(agentGroup, group.workspace.tab_count, tabPanes.length) ? (
+                <TabDivider
+                  label={tabLabel}
+                  count={tabPanes.length}
+                  onSelect={() => onSelectTab(group.bridgeId, tab.tab_id)}
+                  onMenu={(x, y) =>
+                    onScopedMenu(
+                      "tab",
+                      group.bridgeId,
+                      tab.tab_id,
+                      tabLabel,
+                      x,
+                      y,
+                      canClearTabName(tab),
+                    )
+                  }
+                />
+              ) : null}
+              {paneRows}
+            </div>
           );
         });
-        if (agentGroup === "none") {
-          return <Fragment key={`${group.bridgeId}:${tab.tab_id}`}>{paneRows}</Fragment>;
-        }
-        return (
-          <div className="tabgrp" key={`${group.bridgeId}:${tab.tab_id}`}>
-            {shouldShowTabDivider(agentGroup, group.workspace.tab_count, tabPanes.length) ? (
-              <TabDivider
-                label={tabLabel}
-                count={tabPanes.length}
-                onSelect={() => onSelectTab(group.bridgeId, tab.tab_id)}
-                onMenu={(x, y) =>
-                  onScopedMenu(
-                    "tab",
-                    group.bridgeId,
-                    tab.tab_id,
-                    tabLabel,
-                    x,
-                    y,
-                    canClearTabName(tab),
-                  )
-                }
-              />
-            ) : null}
-            {paneRows}
-          </div>
-        );
-      })}
-    </Fragment>
-  );
+    return (
+      <Fragment key={key}>
+        {showWorkspaceHeader ? (
+          <GroupHeader
+            label={
+              showBridgeInWorkspaceHeader
+                ? `${group.bridgeLabel} / ${group.workspace.label}`
+                : group.workspace.label
+            }
+            bridgeColor={showBridgeInWorkspaceHeader ? group.bridgeColor : undefined}
+            status={group.workspace.agent_status}
+            count={paneCount}
+            collapsed={collapsed}
+            onToggle={() => {
+              if (collapseKey) {
+                onToggleCollapsedGroup(collapseKey);
+              }
+            }}
+          />
+        ) : null}
+        {tabRows}
+      </Fragment>
+    );
+  };
   const renderTabGroups = () => {
     if (agentGroup === "host") {
       return hostBridgeViews.map((view) => {
@@ -5985,20 +6156,36 @@ function Switcher({
         if (entries.length === 0) {
           return null;
         }
+        const collapseKey = sidebarGroupCollapseKey(
+          "tabs",
+          agentGroup,
+          "host",
+          view.runtime.id,
+        );
+        const collapsed = collapsedSidebarGroupKeys.has(collapseKey);
         return (
           <Fragment key={view.runtime.id}>
-            <GroupHeader label={view.runtime.label} bridgeColor={view.runtime.color} />
-            {entries.map((entry) =>
-              renderTabWorkspaceGroup(
-                {
-                  ...entry,
-                  tabs: [{ tab: entry.tab, panes: entry.panes }],
-                },
-                false,
-                false,
-                `${entry.bridgeId}:${entry.tab.tab_id}`,
-              ),
-            )}
+            <GroupHeader
+              label={view.runtime.label}
+              bridgeColor={view.runtime.color}
+              status={aggregateStatus(entries.flatMap((entry) => entry.panes))}
+              count={entries.reduce((total, entry) => total + entry.panes.length, 0)}
+              collapsed={collapsed}
+              onToggle={() => onToggleCollapsedGroup(collapseKey)}
+            />
+            {!collapsed
+              ? entries.map((entry) =>
+                  renderTabWorkspaceGroup(
+                    {
+                      ...entry,
+                      tabs: [{ tab: entry.tab, panes: entry.panes }],
+                    },
+                    false,
+                    false,
+                    `${entry.bridgeId}:${entry.tab.tab_id}`,
+                  ),
+                )
+              : null}
           </Fragment>
         );
       });
@@ -6012,10 +6199,45 @@ function Switcher({
         if (groups.length === 0) {
           return null;
         }
+        const collapseKey = sidebarGroupCollapseKey(
+          "tabs",
+          agentGroup,
+          "host",
+          view.runtime.id,
+        );
+        const collapsed = collapsedSidebarGroupKeys.has(collapseKey);
         return (
           <Fragment key={view.runtime.id}>
-            <GroupHeader label={view.runtime.label} bridgeColor={view.runtime.color} />
-            {groups.map((group) => renderTabWorkspaceGroup(group, true, false))}
+            <GroupHeader
+              label={view.runtime.label}
+              bridgeColor={view.runtime.color}
+              status={aggregateStatus(
+                groups.flatMap((group) => group.tabs.flatMap((tab) => tab.panes)),
+              )}
+              count={groups.reduce(
+                (total, group) =>
+                  total + group.tabs.reduce((subtotal, tab) => subtotal + tab.panes.length, 0),
+                0,
+              )}
+              collapsed={collapsed}
+              onToggle={() => onToggleCollapsedGroup(collapseKey)}
+            />
+            {!collapsed
+              ? groups.map((group) =>
+                  renderTabWorkspaceGroup(
+                    group,
+                    true,
+                    false,
+                    undefined,
+                    sidebarGroupCollapseKey(
+                      "tabs",
+                      agentGroup,
+                      "workspace",
+                      `${group.bridgeId}:${group.workspace.workspace_id}`,
+                    ),
+                  ),
+                )
+              : null}
           </Fragment>
         );
       });
@@ -6023,25 +6245,73 @@ function Switcher({
 
     if (agentGroup === "workspace") {
       if (combineWorkspaceGroups) {
-        return combinedTabWorkspaceGroups.map((combinedGroup) => (
-          <Fragment key={combinedGroup.key}>
-            <GroupHeader label={combinedGroup.label} status={combinedGroup.status} />
-            {combinedGroup.workspaces.map((group) =>
-              renderTabWorkspaceGroup(
-                group,
-                false,
-                false,
-                `${combinedGroup.key}:${group.bridgeId}:${group.workspace.workspace_id}`,
-              ),
-            )}
-          </Fragment>
-        ));
+        return combinedTabWorkspaceGroups.map((combinedGroup) => {
+          const collapseKey = sidebarGroupCollapseKey(
+            "tabs",
+            agentGroup,
+            "workspace",
+            combinedGroup.key,
+          );
+          const collapsed = collapsedSidebarGroupKeys.has(collapseKey);
+          const count = combinedGroup.workspaces.reduce(
+            (total, group) =>
+              total + group.tabs.reduce((subtotal, tab) => subtotal + tab.panes.length, 0),
+            0,
+          );
+          return (
+            <Fragment key={combinedGroup.key}>
+              <GroupHeader
+                label={combinedGroup.label}
+                status={combinedGroup.status}
+                count={count}
+                collapsed={collapsed}
+                onToggle={() => onToggleCollapsedGroup(collapseKey)}
+              />
+              {!collapsed
+                ? combinedGroup.workspaces.map((group) =>
+                    renderTabWorkspaceGroup(
+                      group,
+                      false,
+                      false,
+                      `${combinedGroup.key}:${group.bridgeId}:${group.workspace.workspace_id}`,
+                    ),
+                  )
+                : null}
+            </Fragment>
+          );
+        });
       }
-      return spaceGroups.map((group) => renderTabWorkspaceGroup(group, true, false));
+      return spaceGroups.map((group) =>
+        renderTabWorkspaceGroup(
+          group,
+          true,
+          false,
+          undefined,
+          sidebarGroupCollapseKey(
+            "tabs",
+            agentGroup,
+            "workspace",
+            `${group.bridgeId}:${group.workspace.workspace_id}`,
+          ),
+        ),
+      );
     }
 
     if (agentGroup === "hostWorkspace") {
-      return spaceGroups.map((group) => renderTabWorkspaceGroup(group, true));
+      return spaceGroups.map((group) =>
+        renderTabWorkspaceGroup(
+          group,
+          true,
+          true,
+          undefined,
+          sidebarGroupCollapseKey(
+            "tabs",
+            agentGroup,
+            "workspace",
+            `${group.bridgeId}:${group.workspace.workspace_id}`,
+          ),
+        ),
+      );
     }
 
     return flatTabEntries.map((entry) =>
@@ -6109,16 +6379,31 @@ function Switcher({
     );
   };
   const renderAgentGroupRows = () => {
-    const renderGroup = (group: ScopedAgentGroup) => (
-      <Fragment key={group.key}>
-        <GroupHeader
-          label={group.label}
-          bridgeColor={agentGroup === "host" ? group.bridgeColor : undefined}
-          status={agentGroup === "workspace" || agentGroup === "hostWorkspace" ? group.status : undefined}
-        />
-        {group.panes.map((entry) => renderAgentRow(entry, agentPaneIndex++))}
-      </Fragment>
-    );
+    const renderGroup = (group: ScopedAgentGroup) => {
+      const level = agentGroup === "host" ? "host" : "workspace";
+      const collapseKey = sidebarGroupCollapseKey(
+        "agents",
+        agentGroup,
+        level,
+        group.key,
+      );
+      const collapsed = collapsedSidebarGroupKeys.has(collapseKey);
+      return (
+        <Fragment key={group.key}>
+          <GroupHeader
+            label={group.label}
+            bridgeColor={agentGroup === "host" ? group.bridgeColor : undefined}
+            status={group.status}
+            count={group.panes.length}
+            collapsed={collapsed}
+            onToggle={() => onToggleCollapsedGroup(collapseKey)}
+          />
+          {!collapsed
+            ? group.panes.map((entry) => renderAgentRow(entry, agentPaneIndex++))
+            : null}
+        </Fragment>
+      );
+    };
 
     if (agentGroup !== "hostWorkspace" || hostScope !== "all") {
       return agentGroups.map(renderGroup);
@@ -6129,10 +6414,26 @@ function Switcher({
       if (groups.length === 0) {
         return null;
       }
+      const collapseKey = sidebarGroupCollapseKey(
+        "agents",
+        agentGroup,
+        "host",
+        view.runtime.id,
+      );
+      const collapsed = collapsedSidebarGroupKeys.has(collapseKey);
       return (
         <Fragment key={view.runtime.id}>
-          <GroupHeader label={view.runtime.label} bridgeColor={view.runtime.color} />
-          {groups.map(renderGroup)}
+          <GroupHeader
+            label={view.runtime.label}
+            bridgeColor={view.runtime.color}
+            status={aggregateStatus(
+              groups.flatMap((group) => group.panes.map((entry) => entry.pane)),
+            )}
+            count={groups.reduce((total, group) => total + group.panes.length, 0)}
+            collapsed={collapsed}
+            onToggle={() => onToggleCollapsedGroup(collapseKey)}
+          />
+          {!collapsed ? groups.map(renderGroup) : null}
         </Fragment>
       );
     });
@@ -6393,10 +6694,26 @@ function Switcher({
                   if (entries.length === 0) {
                     return null;
                   }
+                  const collapseKey = sidebarGroupCollapseKey(
+                    "spaces",
+                    effectiveSpaceGroup,
+                    "host",
+                    view.runtime.id,
+                  );
+                  const collapsed = collapsedSidebarGroupKeys.has(collapseKey);
                   return (
                     <Fragment key={view.runtime.id}>
-                      <GroupHeader label={view.runtime.label} bridgeColor={view.runtime.color} />
-                      {entries.map((entry, index) => renderSpaceEntry(entry, index, false))}
+                      <GroupHeader
+                        label={view.runtime.label}
+                        bridgeColor={view.runtime.color}
+                        status={aggregateStatus(entries.flatMap((entry) => entry.workspacePanes))}
+                        count={entries.length}
+                        collapsed={collapsed}
+                        onToggle={() => onToggleCollapsedGroup(collapseKey)}
+                      />
+                      {!collapsed
+                        ? entries.map((entry, index) => renderSpaceEntry(entry, index, false))
+                        : null}
                     </Fragment>
                   );
                 })
@@ -7711,26 +8028,47 @@ export function NoteEditor({
 function GroupHeader({
   label,
   bridgeColor,
-  status = "unknown",
+  status,
+  count,
+  collapsed,
+  onToggle,
 }: {
   label: string;
   bridgeColor?: string;
   status?: AgentStatus;
+  count: number;
+  collapsed: boolean;
+  onToggle: () => void;
 }) {
   return (
-    <div className="grp-space">
+    <button
+      className="grp-space"
+      type="button"
+      data-group-header="true"
+      aria-expanded={!collapsed}
+      aria-label={`${collapsed ? "Expand" : "Collapse"} ${label} group`}
+      title={`${collapsed ? "Expand" : "Collapse"} ${label}`}
+      onClick={onToggle}
+    >
+      {collapsed ? (
+        <ChevronRight className="grp-space-chevron" size={13} aria-hidden="true" />
+      ) : (
+        <ChevronDown className="grp-space-chevron" size={13} aria-hidden="true" />
+      )}
       {bridgeColor ? (
         <span
           className="bridge-chip-dot grp-bridge-dot"
           style={{ "--bridge-color": bridgeColor } as CSSProperties}
           aria-hidden="true"
         />
-      ) : (
+      ) : status ? (
         <span className="dot" data-status={status} />
-      )}
+      ) : null}
+      {bridgeColor && status ? <span className="dot" data-status={status} /> : null}
       <span className="grp-space-name">{label}</span>
+      <span className="grp-space-count mono">{count}</span>
       <span className="grp-space-line" />
-    </div>
+    </button>
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -298,6 +298,12 @@ type ScopedWorkspace = {
 type ScopedTabWorkspace = ScopedWorkspace & {
   tabs: { tab: TabInfo; panes: PaneInfo[] }[];
 };
+type CombinedTabWorkspaceGroup = {
+  key: string;
+  label: string;
+  status: AgentStatus;
+  workspaces: ScopedTabWorkspace[];
+};
 export type ScopedTabEntry = ScopedWorkspace & {
   tab: TabInfo;
   panes: PaneInfo[];
@@ -361,6 +367,7 @@ type DisplayPrefs = {
   sidebarView: SidebarView;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
+  combineMatchingWorkspaceNames: boolean;
   spaceGroup: SpaceGroup;
   agentPinnedOnly: boolean;
   agentActiveOnly: boolean;
@@ -422,6 +429,7 @@ function readDisplayPrefs(): DisplayPrefs {
     sidebarView: "agents",
     agentSort: "attention",
     agentGroup: "none",
+    combineMatchingWorkspaceNames: false,
     spaceGroup: "none",
     agentPinnedOnly: false,
     agentActiveOnly: false,
@@ -586,6 +594,10 @@ function parseDisplayPrefsValue(
       parsed.agentGroup === "hostWorkspace"
         ? parsed.agentGroup
         : fallback.agentGroup,
+    combineMatchingWorkspaceNames: parseCombineMatchingWorkspaceNames(
+      parsed.combineMatchingWorkspaceNames,
+      fallback.combineMatchingWorkspaceNames,
+    ),
     spaceGroup:
       parsed.spaceGroup === "none" || parsed.spaceGroup === "host"
         ? parsed.spaceGroup
@@ -792,6 +804,10 @@ function parseStoredMobileLongPressBehavior(
   return DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR;
 }
 
+export function parseCombineMatchingWorkspaceNames(value: unknown, fallback = false) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -906,6 +922,9 @@ export function App() {
   const [sidebarView, setSidebarView] = useState<SidebarView>(initialPrefs.sidebarView);
   const [agentSort, setAgentSort] = useState<AgentSort>(initialPrefs.agentSort);
   const [agentGroup, setAgentGroup] = useState<AgentGroup>(initialPrefs.agentGroup);
+  const [combineMatchingWorkspaceNames, setCombineMatchingWorkspaceNames] = useState(
+    initialPrefs.combineMatchingWorkspaceNames,
+  );
   const [spaceGroup, setSpaceGroup] = useState<SpaceGroup>(initialPrefs.spaceGroup);
   const [agentPinnedOnly, setAgentPinnedOnly] = useState(initialPrefs.agentPinnedOnly);
   const [agentActiveOnly, setAgentActiveOnly] = useState(initialPrefs.agentActiveOnly);
@@ -1045,6 +1064,7 @@ export function App() {
       setSidebarView(prefs.sidebarView);
       setAgentSort(prefs.agentSort);
       setAgentGroup(prefs.agentGroup);
+      setCombineMatchingWorkspaceNames(prefs.combineMatchingWorkspaceNames);
       setSpaceGroup(prefs.spaceGroup);
       setAgentPinnedOnly(prefs.agentPinnedOnly);
       setAgentActiveOnly(prefs.agentActiveOnly);
@@ -1548,6 +1568,7 @@ export function App() {
       sidebarView,
       agentSort,
       agentGroup,
+      combineMatchingWorkspaceNames,
       spaceGroup,
       agentPinnedOnly,
       agentActiveOnly,
@@ -1581,6 +1602,7 @@ export function App() {
     sidebarView,
     agentSort,
     agentGroup,
+    combineMatchingWorkspaceNames,
     spaceGroup,
     agentPinnedOnly,
     agentActiveOnly,
@@ -2857,6 +2879,7 @@ export function App() {
           effectiveAgentPinnedOnly,
           agentActivityTransitions,
           agentActiveOnly,
+          combineMatchingWorkspaceNames && hostScope === "all" && agentGroup === "workspace",
         );
         if (agentEntries.length === 0) {
           return;
@@ -2900,6 +2923,7 @@ export function App() {
         agentSort,
         agentActivityTransitions,
         sidebarView === "tabs" && agentFeaturesInTabs && agentActiveOnly,
+        combineMatchingWorkspaceNames && hostScope === "all" && agentGroup === "workspace",
       );
       const tabs = tabEntries;
       if (tabs.length === 0) {
@@ -2936,6 +2960,7 @@ export function App() {
     effectiveAgentPinnedOnly,
     agentGroup,
     agentSort,
+    combineMatchingWorkspaceNames,
     bridgeViews,
     busy,
     dialog,
@@ -3529,6 +3554,7 @@ export function App() {
           agentFeaturesInTabs={agentFeaturesInTabs}
           agentSort={agentSort}
           agentGroup={agentGroup}
+          combineMatchingWorkspaceNames={combineMatchingWorkspaceNames}
           spaceGroup={spaceGroup}
           multiHostSpaceSelection={multiHostSpaceSelection}
           activeSpace={activeSpace}
@@ -3543,6 +3569,7 @@ export function App() {
           onAgentActiveOnly={setAgentActiveOnly}
           onAgentSort={setAgentSort}
           onAgentGroup={setAgentGroup}
+          onCombineMatchingWorkspaceNames={setCombineMatchingWorkspaceNames}
           onSpaceGroup={setSpaceGroup}
           onSelectBridge={setSelectedBridgeId}
           onSelectSpace={selectSpace}
@@ -4560,6 +4587,7 @@ export function buildVisibleAgentPaneEntries(
   pinnedOnly = false,
   agentActivityTransitions: ReadonlyMap<string, number> = EMPTY_AGENT_ACTIVITY_TRANSITIONS,
   activeOnly = false,
+  combineMatchingWorkspaceNames = false,
 ) {
   const buildRows = (sort: AgentSort) =>
     scopedWorkspaces.flatMap((entry) => {
@@ -4592,7 +4620,11 @@ export function buildVisibleAgentPaneEntries(
 
   if (agentSort === "lastStatusChange" && agentGroup !== "none") {
     const agentPanes = filterAgentEntries(buildRows("workspace"), pinnedOnly, activeOnly);
-    const groups = buildScopedAgentGroups(agentPanes, agentGroup).map((group) => ({
+    const groups = buildScopedAgentGroups(
+      agentPanes,
+      agentGroup,
+      combineMatchingWorkspaceNames,
+    ).map((group) => ({
       ...group,
       panes: sortedAgentEntriesWithinGroup(sortScopedAgentPanes(group.panes, agentSort)),
     }));
@@ -4613,7 +4645,11 @@ export function buildVisibleAgentPaneEntries(
     return agentPanes;
   }
 
-  const groups = buildScopedAgentGroups(agentPanes, agentGroup).map((group) => ({
+  const groups = buildScopedAgentGroups(
+    agentPanes,
+    agentGroup,
+    combineMatchingWorkspaceNames,
+  ).map((group) => ({
     ...group,
     panes: sortedAgentEntriesWithinGroup(group.panes),
   }));
@@ -4640,15 +4676,18 @@ function filterAgentEntries(
 export function buildScopedAgentGroups(
   agentPanes: ScopedAgentPane[],
   agentGroup: AgentGroup,
+  combineMatchingWorkspaceNames = false,
 ) {
   const paneBuckets = new Map<string, ScopedAgentGroup>();
   const groupByWorkspace = agentGroup === "workspace" || agentGroup === "hostWorkspace";
   for (const entry of agentPanes) {
+    const workspaceLabel = entry.workspace?.label.trim() || "workspace";
     const key = groupByWorkspace
-      ? `${entry.bridgeId}:${entry.pane.workspace_id}`
+      ? agentGroup === "workspace" && combineMatchingWorkspaceNames
+        ? `workspace-name:${workspaceLabel}`
+        : `${entry.bridgeId}:${entry.pane.workspace_id}`
       : entry.bridgeId;
-    const label =
-      agentGroup === "host" ? entry.bridgeLabel : (entry.workspace?.label ?? "workspace");
+    const label = agentGroup === "host" ? entry.bridgeLabel : workspaceLabel;
     const existing =
       paneBuckets.get(key) ??
       {
@@ -4656,7 +4695,10 @@ export function buildScopedAgentGroups(
         bridgeId: entry.bridgeId,
         label,
         bridgeColor: entry.bridgeColor,
-        status: groupByWorkspace ? entry.workspace?.agent_status : undefined,
+        status:
+          groupByWorkspace && !(agentGroup === "workspace" && combineMatchingWorkspaceNames)
+            ? entry.workspace?.agent_status
+            : undefined,
         panes: [],
       };
     existing.panes.push(entry);
@@ -4712,6 +4754,27 @@ export function buildVisibleTabWorkspaceGroups(
     .filter((group) => group.tabs.length > 0);
 }
 
+export function buildCombinedTabWorkspaceGroups(
+  workspaceGroups: ScopedTabWorkspace[],
+): CombinedTabWorkspaceGroup[] {
+  const buckets = new Map<string, Omit<CombinedTabWorkspaceGroup, "status">>();
+  for (const workspaceGroup of workspaceGroups) {
+    const label = workspaceGroup.workspace.label.trim() || "workspace";
+    const key = `workspace-name:${label}`;
+    const bucket = buckets.get(key) ?? { key, label, workspaces: [] };
+    bucket.workspaces.push(workspaceGroup);
+    buckets.set(key, bucket);
+  }
+  return [...buckets.values()].map((bucket) => ({
+    ...bucket,
+    status: aggregateStatus(
+      bucket.workspaces.flatMap((workspace) =>
+        workspace.tabs.flatMap((tab) => tab.panes),
+      ),
+    ),
+  }));
+}
+
 export function buildVisibleTabEntries(
   scopedWorkspaces: ScopedWorkspace[],
   bridgeViews: BridgeConnectionView[],
@@ -4723,6 +4786,7 @@ export function buildVisibleTabEntries(
   agentSort: AgentSort = "workspace",
   agentActivityTransitions: ReadonlyMap<string, number> = EMPTY_AGENT_ACTIVITY_TRANSITIONS,
   activeOnly = false,
+  combineMatchingWorkspaceNames = false,
 ): ScopedTabEntry[] {
   const spaceGroups = buildVisibleTabWorkspaceGroups(
     scopedWorkspaces,
@@ -4751,6 +4815,11 @@ export function buildVisibleTabEntries(
         agentFeaturesInTabs ? agentSort : "workspace",
         agentActivityTransitions,
       ),
+    );
+  }
+  if (agentGroup === "workspace" && hostScope === "all" && combineMatchingWorkspaceNames) {
+    return buildCombinedTabWorkspaceGroups(spaceGroups).flatMap((group) =>
+      group.workspaces.flatMap(flattenGroup),
     );
   }
   return spaceGroups.flatMap(flattenGroup);
@@ -5492,6 +5561,7 @@ function Switcher({
   agentFeaturesInTabs,
   agentSort,
   agentGroup,
+  combineMatchingWorkspaceNames,
   spaceGroup,
   multiHostSpaceSelection,
   activeSpace,
@@ -5506,6 +5576,7 @@ function Switcher({
   onAgentActiveOnly,
   onAgentSort,
   onAgentGroup,
+  onCombineMatchingWorkspaceNames,
   onSpaceGroup,
   onSelectBridge,
   onSelectSpace,
@@ -5541,6 +5612,7 @@ function Switcher({
   agentFeaturesInTabs: boolean;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
+  combineMatchingWorkspaceNames: boolean;
   spaceGroup: SpaceGroup;
   multiHostSpaceSelection: boolean;
   activeSpace: WorkspaceInfo | null;
@@ -5555,6 +5627,7 @@ function Switcher({
   onAgentActiveOnly: (activeOnly: boolean) => void;
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
+  onCombineMatchingWorkspaceNames: (combine: boolean) => void;
   onSpaceGroup: (group: SpaceGroup) => void;
   onSelectBridge: (bridgeId: BridgeId) => void;
   onSelectSpace: (bridgeId: BridgeId, workspaceId: string) => void;
@@ -5667,6 +5740,8 @@ function Switcher({
     agentSort,
   );
   const effectiveAgentPinnedOnly = agentPinsSupported && agentPinnedOnly;
+  const combineWorkspaceGroups =
+    combineMatchingWorkspaceNames && hostScope === "all" && agentGroup === "workspace";
   const notesLoading = notesEnabled && hostBridgeViews.some(
     (view) => notesStates[view.runtime.id]?.loadState === "loading",
   );
@@ -5696,6 +5771,7 @@ function Switcher({
       effectiveAgentPinnedOnly,
       agentActivityTransitions,
       agentActiveOnly,
+      combineWorkspaceGroups,
     );
   }, [
     agentActivityTransitions,
@@ -5704,6 +5780,7 @@ function Switcher({
     effectiveAgentPinnedOnly,
     agentSort,
     bridgeViews,
+    combineWorkspaceGroups,
     hostScope,
     pinnedAgentKeys,
     scopedWorkspaces,
@@ -5713,8 +5790,8 @@ function Switcher({
     if (agentGroup === "none") {
       return [];
     }
-    return buildScopedAgentGroups(agentPanes, agentGroup);
-  }, [agentGroup, agentPanes]);
+    return buildScopedAgentGroups(agentPanes, agentGroup, combineWorkspaceGroups);
+  }, [agentGroup, agentPanes, combineWorkspaceGroups]);
 
   const spaceGroups = useMemo<ScopedTabWorkspace[]>(
     () =>
@@ -5737,6 +5814,10 @@ function Switcher({
       scopedWorkspaces,
       sidebarView,
     ],
+  );
+  const combinedTabWorkspaceGroups = useMemo(
+    () => (combineWorkspaceGroups ? buildCombinedTabWorkspaceGroups(spaceGroups) : []),
+    [combineWorkspaceGroups, spaceGroups],
   );
   const flatTabEntries = useMemo(
     () =>
@@ -5942,6 +6023,21 @@ function Switcher({
     }
 
     if (agentGroup === "workspace") {
+      if (combineWorkspaceGroups) {
+        return combinedTabWorkspaceGroups.map((combinedGroup) => (
+          <Fragment key={combinedGroup.key}>
+            <GroupHeader label={combinedGroup.label} status={combinedGroup.status} />
+            {combinedGroup.workspaces.map((group) =>
+              renderTabWorkspaceGroup(
+                group,
+                false,
+                false,
+                `${combinedGroup.key}:${group.bridgeId}:${group.workspace.workspace_id}`,
+              ),
+            )}
+          </Fragment>
+        ));
+      }
       return spaceGroups.map((group) => renderTabWorkspaceGroup(group, true, false));
     }
 
@@ -6465,9 +6561,12 @@ function Switcher({
           showGroup={showGroupControl}
           agentSort={agentSort}
           agentGroup={agentGroup}
+          combineMatchingWorkspaceNames={combineMatchingWorkspaceNames}
+          showCombineMatchingWorkspaceNames={hostScope === "all" && agentGroup === "workspace"}
           showLastStatusChangeSort={showLastStatusChangeSort}
           onAgentSort={onAgentSort}
           onAgentGroup={onAgentGroup}
+          onCombineMatchingWorkspaceNames={onCombineMatchingWorkspaceNames}
           onClose={() => setOptionsMenu(null)}
         />
       ) : null}
@@ -6492,9 +6591,12 @@ function SidebarOptionsMenu({
   showGroup,
   agentSort,
   agentGroup,
+  combineMatchingWorkspaceNames,
+  showCombineMatchingWorkspaceNames,
   showLastStatusChangeSort,
   onAgentSort,
   onAgentGroup,
+  onCombineMatchingWorkspaceNames,
   onClose,
 }: {
   x: number;
@@ -6504,9 +6606,12 @@ function SidebarOptionsMenu({
   showGroup: boolean;
   agentSort: AgentSort;
   agentGroup: AgentGroup;
+  combineMatchingWorkspaceNames: boolean;
+  showCombineMatchingWorkspaceNames: boolean;
   showLastStatusChangeSort: boolean;
   onAgentSort: (sort: AgentSort) => void;
   onAgentGroup: (group: AgentGroup) => void;
+  onCombineMatchingWorkspaceNames: (combine: boolean) => void;
   onClose: () => void;
 }) {
   return (
@@ -6545,6 +6650,19 @@ function SidebarOptionsMenu({
             <option value="hostWorkspace">Host + workspace</option>
           </select>
         </label>
+      ) : null}
+      {showCombineMatchingWorkspaceNames ? (
+        <button
+          className="sidebar-option-toggle"
+          type="button"
+          role="switch"
+          aria-checked={combineMatchingWorkspaceNames}
+          data-on={combineMatchingWorkspaceNames ? "true" : undefined}
+          onClick={() => onCombineMatchingWorkspaceNames(!combineMatchingWorkspaceNames)}
+        >
+          <span>Combine matching names</span>
+          <strong>{combineMatchingWorkspaceNames ? "On" : "Off"}</strong>
+        </button>
       ) : null}
     </OptionsMenuShell>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,9 +4,9 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
-  ChevronsDown,
-  ChevronsUp,
   Link2,
+  ListCollapse,
+  ListRestart,
   MoreVertical,
   PanelLeft,
   Pin,
@@ -818,6 +818,8 @@ export function parseCombineMatchingWorkspaceNames(value: unknown, fallback = fa
   return typeof value === "boolean" ? value : fallback;
 }
 
+const MAX_COLLAPSED_SIDEBAR_GROUPS = 4096;
+
 export function parseCollapsedSidebarGroups(value: unknown, fallback: string[] = []) {
   if (!Array.isArray(value)) {
     return fallback;
@@ -826,7 +828,7 @@ export function parseCollapsedSidebarGroups(value: unknown, fallback: string[] =
     ...new Set(
       value.filter((item): item is string => typeof item === "string" && item.length > 0),
     ),
-  ].slice(-256);
+  ].slice(-MAX_COLLAPSED_SIDEBAR_GROUPS);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -955,9 +957,7 @@ export function App() {
   );
   const toggleCollapsedSidebarGroup = useCallback((key: string) => {
     setCollapsedSidebarGroups((current) =>
-      current.includes(key)
-        ? current.filter((item) => item !== key)
-        : [...current, key].slice(-256),
+      updateCollapsedSidebarGroups(current, [key], !current.includes(key)),
     );
   }, []);
   const setVisibleSidebarGroupsCollapsed = useCallback(
@@ -4749,14 +4749,22 @@ export function updateCollapsedSidebarGroups(
   if (!collapsed) {
     return current.filter((key) => !targetKeys.has(key));
   }
-  const next = [...current];
-  const knownKeys = new Set(current);
-  for (const key of targetKeys) {
-    if (!knownKeys.has(key)) {
-      next.push(key);
-    }
-  }
-  return next.slice(-256);
+  const unrelatedKeys = current.filter((key) => !targetKeys.has(key));
+  const limit = Math.max(MAX_COLLAPSED_SIDEBAR_GROUPS, targetKeys.size);
+  return [...unrelatedKeys, ...targetKeys].slice(-limit);
+}
+
+export function areAllVisibleSidebarGroupsCollapsed(
+  keys: readonly string[],
+  grouping: AgentGroup,
+  hostScope: HostScope,
+  collapsedKeys: ReadonlySet<string>,
+) {
+  const stateKeys =
+    grouping === "hostWorkspace" && hostScope === "all"
+      ? keys.filter((key) => key.split(":")[2] === "host")
+      : keys;
+  return stateKeys.length > 0 && stateKeys.every((key) => collapsedKeys.has(key));
 }
 
 function workspaceGroupIdentity(
@@ -5550,9 +5558,6 @@ function isShortcutTextEntryTarget(target: EventTarget | null) {
   if (target.classList.contains("ghostty-hidden-input")) {
     return false;
   }
-  if (target.closest("[data-group-header='true']")) {
-    return true;
-  }
   if (target.isContentEditable) {
     return true;
   }
@@ -6119,13 +6124,12 @@ function Switcher({
         : [],
     );
   })();
-  const paneGroupToggleStateKeys =
-    agentGroup === "hostWorkspace" && hostScope === "all"
-      ? paneGroupCollapseKeys.filter((key) => key.split(":")[2] === "host")
-      : paneGroupCollapseKeys;
-  const allPaneGroupsCollapsed =
-    paneGroupToggleStateKeys.length > 0 &&
-    paneGroupToggleStateKeys.every((key) => collapsedSidebarGroupKeys.has(key));
+  const allPaneGroupsCollapsed = areAllVisibleSidebarGroupsCollapsed(
+    paneGroupCollapseKeys,
+    agentGroup,
+    hostScope,
+    collapsedSidebarGroupKeys,
+  );
 
   useEffect(() => {
     if (optionsMenu && !showOptionsControl) {
@@ -6930,9 +6934,9 @@ function Switcher({
                     }
                   >
                     {allPaneGroupsCollapsed ? (
-                      <ChevronsDown size={14} />
+                      <ListRestart size={14} />
                     ) : (
-                      <ChevronsUp size={14} />
+                      <ListCollapse size={14} />
                     )}
                   </button>
                 ) : null}

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -65,6 +65,8 @@ type Props = {
   onNavigationSyncMode: (mode: NavigationSyncMode) => void;
   agentFeaturesInTabs: boolean;
   onAgentFeaturesInTabs: (enabled: boolean) => void;
+  combineMatchingWorkspaceNames: boolean;
+  onCombineMatchingWorkspaceNames: (enabled: boolean) => void;
   multiHostSpaceSelection: boolean;
   onMultiHostSpaceSelection: (enabled: boolean) => void;
   terminalFontSizePx: number;
@@ -117,6 +119,8 @@ export function BackendSettingsDialog({
   onNavigationSyncMode,
   agentFeaturesInTabs,
   onAgentFeaturesInTabs,
+  combineMatchingWorkspaceNames,
+  onCombineMatchingWorkspaceNames,
   multiHostSpaceSelection,
   onMultiHostSpaceSelection,
   terminalFontSizePx,
@@ -562,6 +566,33 @@ export function BackendSettingsDialog({
                       data-on={agentFeaturesInTabs}
                       aria-pressed={agentFeaturesInTabs}
                       onClick={() => onAgentFeaturesInTabs(true)}
+                    >
+                      On
+                    </button>
+                  </div>
+                </div>
+                <div className="settings-row">
+                  <span title="Combine same-named workspaces across hosts when grouping by Workspace">
+                    Combine matching workspace names
+                  </span>
+                  <div
+                    className="segmented-control"
+                    role="group"
+                    aria-label="Combine matching workspace names"
+                  >
+                    <button
+                      type="button"
+                      data-on={!combineMatchingWorkspaceNames}
+                      aria-pressed={!combineMatchingWorkspaceNames}
+                      onClick={() => onCombineMatchingWorkspaceNames(false)}
+                    >
+                      Off
+                    </button>
+                    <button
+                      type="button"
+                      data-on={combineMatchingWorkspaceNames}
+                      aria-pressed={combineMatchingWorkspaceNames}
+                      onClick={() => onCombineMatchingWorkspaceNames(true)}
                     >
                       On
                     </button>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -611,9 +611,29 @@ button {
 /* group label when scope = all */
 .grp-space {
   display: flex;
+  width: 100%;
   align-items: center;
   gap: 9px;
   padding: 8px 10px 3px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  font: inherit;
+  text-align: left;
+}
+
+.grp-space:hover {
+  background: var(--row-hover);
+}
+
+.grp-space:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.grp-space-chevron {
+  flex: 0 0 auto;
+  color: var(--overlay0);
 }
 
 .grp-space-name {
@@ -629,6 +649,12 @@ button {
   height: 1px;
   flex: 1 1 auto;
   background: var(--line-soft);
+}
+
+.grp-space-count {
+  flex: 0 0 auto;
+  color: var(--overlay0);
+  font-size: 10px;
 }
 
 /* ------------------------------------------------------------- pane row */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2195,6 +2195,38 @@ button {
   background: var(--mantle);
 }
 
+.sidebar-option-toggle {
+  display: flex;
+  min-height: 34px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  background: var(--mantle);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+}
+
+.sidebar-option-toggle strong {
+  color: var(--overlay1);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.sidebar-option-toggle[data-on="true"] {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  background: var(--accent-soft);
+}
+
+.sidebar-option-toggle[data-on="true"] strong {
+  color: var(--accent);
+}
+
 .modal {
   position: relative;
   z-index: 1;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -626,6 +626,10 @@ button {
   background: var(--row-hover);
 }
 
+.grp-space[data-nested="true"] {
+  padding-left: 26px;
+}
+
 .grp-space:focus-visible {
   outline: 1px solid var(--accent);
   outline-offset: -1px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2195,38 +2195,6 @@ button {
   background: var(--mantle);
 }
 
-.sidebar-option-toggle {
-  display: flex;
-  min-height: 34px;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 7px 9px;
-  border: 1px solid var(--line);
-  border-radius: var(--r-sm);
-  color: var(--text);
-  background: var(--mantle);
-  font: inherit;
-  font-size: 12px;
-  text-align: left;
-}
-
-.sidebar-option-toggle strong {
-  color: var(--overlay1);
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.sidebar-option-toggle[data-on="true"] {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
-  background: var(--accent-soft);
-}
-
-.sidebar-option-toggle[data-on="true"] strong {
-  color: var(--accent);
-}
-
 .modal {
   position: relative;
   z-index: 1;


### PR DESCRIPTION
## Summary

- simplify Workspace grouping headers and keep host context in detail rows
- add a global Display setting to combine same-named workspaces across hosts
- add persistent expand/collapse controls for grouped Agents, Tabs, and Spaces, with nested Host + workspace hierarchy
- add bulk collapse/expand controls, keyboard-navigation filtering, and reviewed persistence bounds

## Validation

- `npm run check` (241 web tests, 112 compatibility tests, 130 bridge tests)
- headless browser interaction and persistence checks
- Keel `iterative-review` with `claude-default`, clean after fixes
- Android debug APK build, signing verification, metadata inspection, ZIP integrity check, and bundled asset inspection
- deployed smoke checks on srv and pc (`/`, `/api/capabilities`, and `/api/snapshot` returned HTTP 200)
