### PR TITLE
Upgrade Herdr compatibility and add workspace reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 - Herdr `v0.8.0` or newer with terminal protocol exactly `19` is now required. The bridge rejects
   the previous protocol `17` baseline and other unreviewed protocols instead of attempting a
-  backward-compatible wire fallback.
+  backward-compatible wire fallback. [PR #48](https://github.com/kcosr/herdr-web/pull/48)
 
 ### Added
 
 - Added a contextual Move Space mode to the Spaces menu. The selected space card becomes draggable,
   retains a cancel control and arrow/Home/End keyboard support, mutes unrelated sidebar actions
   until the move is completed or canceled, and moves worktree groups atomically within their host's
-  canonical workspace order.
+  canonical workspace order. [PR #48](https://github.com/kcosr/herdr-web/pull/48)
 - Added persistent expand/collapse controls to grouped Agents, Tabs, and Spaces headers, including
   independent, visually nested host and workspace controls for Host + workspace grouping and a
   bulk expand/collapse control for the current Agents or Tabs list.
@@ -26,7 +26,9 @@
 
 - Refreshed the minimal vendored Herdr compatibility sources to the `v0.8.0`/protocol `19`
   baseline, including the current API schemas, terminal wire definitions, and input model shims.
+  [PR #48](https://github.com/kcosr/herdr-web/pull/48)
 - Follow Herdr's canonical workspace order when atomic worktree groups are reordered.
+  [PR #48](https://github.com/kcosr/herdr-web/pull/48)
 - Simplified Workspace grouping in the Agents and Tabs sidebars to show workspace-only group
   headers and move host context into each detail row. Host + workspace grouping keeps its nested
   host and workspace headers. [PR #47](https://github.com/kcosr/herdr-web/pull/47)
@@ -35,6 +37,7 @@
 
 - Fixed built-in agent launches against Herdr `v0.8.0` by waiting for a newly created pane's shell
   to become available before starting the managed agent.
+  [PR #48](https://github.com/kcosr/herdr-web/pull/48)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Breaking Changes
 
+- Herdr `v0.8.0` or newer with terminal protocol exactly `19` is now required. The bridge rejects
+  the previous protocol `17` baseline and other unreviewed protocols instead of attempting a
+  backward-compatible wire fallback.
+
 ### Added
 
 - Added persistent expand/collapse controls to grouped Agents, Tabs, and Spaces headers, including
@@ -16,6 +20,10 @@
 
 ### Changed
 
+- Refreshed the minimal vendored Herdr compatibility sources to the `v0.8.0`/protocol `19`
+  baseline, including the current API schemas, terminal wire definitions, and input model shims.
+- Follow Herdr's canonical workspace order when atomic worktree groups are reordered. The browser
+  observes these changes but does not expose workspace reordering controls.
 - Simplified Workspace grouping in the Agents and Tabs sidebars to show workspace-only group
   headers and move host context into each detail row. Host + workspace grouping keeps its nested
   host and workspace headers. [PR #47](https://github.com/kcosr/herdr-web/pull/47)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Added
 
+- Added a contextual Move Space mode to the Spaces menu. The selected space card becomes draggable,
+  retains a cancel control and arrow/Home/End keyboard support, mutes unrelated sidebar actions
+  until the move is completed or canceled, and moves worktree groups atomically within their host's
+  canonical workspace order.
 - Added persistent expand/collapse controls to grouped Agents, Tabs, and Spaces headers, including
   independent, visually nested host and workspace controls for Host + workspace grouping and a
   bulk expand/collapse control for the current Agents or Tabs list.
@@ -22,13 +26,15 @@
 
 - Refreshed the minimal vendored Herdr compatibility sources to the `v0.8.0`/protocol `19`
   baseline, including the current API schemas, terminal wire definitions, and input model shims.
-- Follow Herdr's canonical workspace order when atomic worktree groups are reordered. The browser
-  observes these changes but does not expose workspace reordering controls.
+- Follow Herdr's canonical workspace order when atomic worktree groups are reordered.
 - Simplified Workspace grouping in the Agents and Tabs sidebars to show workspace-only group
   headers and move host context into each detail row. Host + workspace grouping keeps its nested
   host and workspace headers. [PR #47](https://github.com/kcosr/herdr-web/pull/47)
 
 ### Fixed
+
+- Fixed built-in agent launches against Herdr `v0.8.0` by waiting for a newly created pane's shell
+  to become available before starting the managed agent.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The top-level scripts hide that detail.
 
 For release tarball users:
 
-- A running Herdr `v0.7.5` or newer daemon/session that reports terminal protocol `17`
+- A running Herdr `v0.8.0` or newer daemon/session that reports terminal protocol `19`
 - A supported host for the downloaded bridge tarball. Current planned desktop release artifacts are
   Linux x86_64, macOS ARM64, and macOS x86_64.
 
@@ -75,7 +75,7 @@ For source development:
 - Node.js 22 or newer
 - npm
 - Rust stable
-- A running Herdr `v0.7.5` or newer daemon/session that reports terminal protocol `17`
+- A running Herdr `v0.8.0` or newer daemon/session that reports terminal protocol `19`
 
 Android development also needs a JDK and Android SDK. See [docs/android.md](docs/android.md).
 
@@ -97,7 +97,7 @@ http://127.0.0.1:8787
 ```
 
 The desktop tarball includes the web assets and `herdr-web-bridge`; it does not include Herdr.
-Start or attach Herdr `v0.7.5` or newer with terminal protocol `17` separately before running the
+Start or attach Herdr `v0.8.0` or newer with terminal protocol `19` separately before running the
 bridge.
 
 For Android, install the APK from the same release and add the bridge URL in the Bridge area of
@@ -235,7 +235,7 @@ an agent command. This preserves wrappers, SSH commands, containers, and other e
 
 ## Run Locally
 
-Start or attach a normal Herdr `v0.7.5` or newer session with terminal protocol `17` first:
+Start or attach a normal Herdr `v0.8.0` or newer session with terminal protocol `19` first:
 
 ```bash
 herdr
@@ -386,7 +386,7 @@ local `vendor/herdr-compat` crate for copied Herdr protocol/schema/client/socket
 bridge HTTP/WebSocket behavior in `bridge/src/web_bridge.rs`. A separate upstream Herdr checkout can
 be used for refreshes and drift audits, but a full `vendor/herdr` snapshot is not part of this repo.
 The cost is that `vendor/herdr-compat` must be kept compatible with Herdr protocol changes.
-The current compatibility baseline is Herdr `v0.7.5` and terminal protocol `17`; the bridge requires
+The current compatibility baseline is Herdr `v0.8.0` and terminal protocol `19`; the bridge requires
 that exact protocol rather than attempting to decode older or newer private wire formats.
 
 See [docs/vendoring.md](docs/vendoring.md) for the refresh process.

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -61,8 +61,8 @@ const DEFAULT_PORT: u16 = 8787;
 const DEFAULT_COLS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
 const DEFAULT_STATIC_DIR: &str = "web/dist";
-const MIN_HERDR_VERSION: (u64, u64, u64) = (0, 7, 5);
-const MIN_HERDR_VERSION_LABEL: &str = "0.7.5";
+const MIN_HERDR_VERSION: (u64, u64, u64) = (0, 8, 0);
+const MIN_HERDR_VERSION_LABEL: &str = "0.8.0";
 const MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
 const MAX_NOTES_REQUEST_BYTES: usize = 512 * 1024;
 const MAX_TERMINAL_INPUT_CHUNK_BYTES: usize = 768 * 1024;
@@ -3909,6 +3909,7 @@ fn structural_event_subscriptions() -> Vec<Subscription> {
         Subscription::WorkspaceUpdated {},
         Subscription::WorkspaceRenamed {},
         Subscription::WorkspaceMoved {},
+        Subscription::WorkspaceReordered {},
         Subscription::WorkspaceClosed {},
         Subscription::WorkspaceFocused {},
         Subscription::WorktreeCreated {},
@@ -4223,6 +4224,7 @@ fn open_terminal_attach(
                 | ServerMessage::WindowTitle { .. }
                 | ServerMessage::ReloadSoundConfig
                 | ServerMessage::MouseCapture { .. }
+                | ServerMessage::KittyKeyboardReportAll { .. }
                 | ServerMessage::PrefixInputSource { .. }
                 | ServerMessage::Frame(_)
                 | ServerMessage::Graphics { .. } => {}
@@ -4935,6 +4937,7 @@ mod tests {
         assert!(!ALLOWED_COMMANDS.contains(&"server.stop"));
         assert!(!ALLOWED_COMMANDS.contains(&"pane.send_keys"));
         assert!(!ALLOWED_COMMANDS.contains(&"pane.send_input"));
+        assert!(!ALLOWED_COMMANDS.contains(&"workspace.move_block"));
         // pane.split is intentionally allowed so the web client can create splits.
         assert!(ALLOWED_COMMANDS.contains(&"pane.split"));
         assert!(ALLOWED_COMMANDS.contains(&"pane.focus_direction"));
@@ -5065,6 +5068,9 @@ mod tests {
             .any(|subscription| matches!(subscription, Subscription::WorkspaceMoved {})));
         assert!(subscriptions
             .iter()
+            .any(|subscription| matches!(subscription, Subscription::WorkspaceReordered {})));
+        assert!(subscriptions
+            .iter()
             .any(|subscription| matches!(subscription, Subscription::TabMoved {})));
         assert!(!subscriptions.iter().any(|subscription| matches!(
             subscription,
@@ -5120,7 +5126,7 @@ mod tests {
 
     fn test_session_snapshot() -> SessionSnapshot {
         SessionSnapshot {
-            version: "0.7.5".to_string(),
+            version: "0.8.0".to_string(),
             protocol: PROTOCOL_VERSION,
             focused_workspace_id: Some("workspace-1".to_string()),
             focused_tab_id: Some("tab-1".to_string()),
@@ -5746,7 +5752,7 @@ mod tests {
     #[test]
     fn daemon_status_accepts_minimum_version_and_exact_protocol() {
         assert_eq!(
-            validated_daemon_protocol(runtime_status("0.7.5", PROTOCOL_VERSION)).unwrap(),
+            validated_daemon_protocol(runtime_status("0.8.0", PROTOCOL_VERSION)).unwrap(),
             PROTOCOL_VERSION
         );
         assert_eq!(
@@ -5774,11 +5780,11 @@ mod tests {
             .contains("invalid version"));
 
         for version in [
-            "0.7.5-preview",
-            "0.7.5.1",
-            "0.7.5+",
-            "0.7.5+bad_meta",
-            "0.07.5",
+            "0.8.0-preview",
+            "0.8.0.1",
+            "0.8.0+",
+            "0.8.0+bad_meta",
+            "0.08.0",
         ] {
             let error = validated_daemon_protocol(runtime_status(version, PROTOCOL_VERSION))
                 .unwrap_err()
@@ -5792,7 +5798,7 @@ mod tests {
 
     #[test]
     fn daemon_status_accepts_version_prefix_and_build_metadata() {
-        for version in ["v0.7.5", "0.7.5+linux-x86-64"] {
+        for version in ["v0.8.0", "0.8.0+linux-x86-64"] {
             assert_eq!(
                 validated_daemon_protocol(runtime_status(version, PROTOCOL_VERSION)).unwrap(),
                 PROTOCOL_VERSION
@@ -5801,8 +5807,8 @@ mod tests {
     }
 
     #[test]
-    fn daemon_status_rejects_version_before_0_7_5() {
-        let error = validated_daemon_protocol(runtime_status("0.7.4", PROTOCOL_VERSION))
+    fn daemon_status_rejects_version_before_0_8_0() {
+        let error = validated_daemon_protocol(runtime_status("0.7.5", PROTOCOL_VERSION))
             .unwrap_err()
             .to_string();
         assert!(error.contains("too old"));
@@ -5824,7 +5830,7 @@ mod tests {
 
     #[test]
     fn daemon_status_rejects_any_other_protocol() {
-        let older = validated_daemon_protocol(runtime_status("0.7.5", PROTOCOL_VERSION - 1))
+        let older = validated_daemon_protocol(runtime_status("0.8.0", PROTOCOL_VERSION - 1))
             .unwrap_err()
             .to_string();
         assert!(older.contains("incompatible"));

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -80,6 +80,9 @@ const ACTIVITY_WATCHER_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const ACTIVITY_WATCHER_MAX_BACKOFF: Duration = Duration::from_secs(30);
 const ACTIVITY_RESUBSCRIBE_DEBOUNCE: Duration = Duration::from_millis(100);
 const ACTIVITY_READ_TIMEOUT: Duration = Duration::from_millis(250);
+const MANAGED_AGENT_SHELL_SETTLE_DELAY: Duration = Duration::from_millis(100);
+const MANAGED_AGENT_SHELL_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(300);
+const MANAGED_AGENT_SHELL_READY_TIMEOUT: Duration = Duration::from_secs(3);
 const MANAGED_AGENT_START_TIMEOUT: Duration = Duration::from_secs(30);
 const MANAGED_AGENT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 static UPLOAD_TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -1278,6 +1281,8 @@ const ALLOWED_COMMANDS: &[&str] = &[
     "workspace.rename",
     "workspace.close",
     "workspace.focus",
+    // Atomic same-session workspace ordering; the browser supplies explicit ids only.
+    "workspace.move_block",
     "tab.create",
     "tab.rename",
     "tab.close",
@@ -1510,6 +1515,38 @@ fn validate_web_command(method: &Method) -> Result<(), BridgeError> {
                 ));
             }
         }
+        Method::WorkspaceMoveBlock(params) => {
+            if params.workspace_ids.is_empty() || params.workspace_ids.len() > 256 {
+                return Err(BridgeError::BadRequest(
+                    "workspace.move_block requires between 1 and 256 workspace_ids".to_string(),
+                ));
+            }
+            let mut unique_ids = HashSet::with_capacity(params.workspace_ids.len());
+            if params.workspace_ids.iter().any(|workspace_id| {
+                workspace_id.trim().is_empty()
+                    || workspace_id.len() > 256
+                    || !unique_ids.insert(workspace_id.as_str())
+            }) {
+                return Err(BridgeError::BadRequest(
+                    "workspace.move_block workspace_ids must be unique, non-empty, and at most 256 bytes"
+                        .to_string(),
+                ));
+            }
+            if params
+                .before_workspace_id
+                .as_deref()
+                .is_some_and(|workspace_id| {
+                    workspace_id.trim().is_empty()
+                        || workspace_id.len() > 256
+                        || unique_ids.contains(workspace_id)
+                })
+            {
+                return Err(BridgeError::BadRequest(
+                    "workspace.move_block before_workspace_id must be a distinct valid workspace id"
+                        .to_string(),
+                ));
+            }
+        }
         Method::TabCreate(params) => {
             if params
                 .workspace_id
@@ -1705,6 +1742,7 @@ struct LauncherPresetError {
     status: StatusCode,
     code: &'static str,
     message: String,
+    herdr_code: Option<String>,
 }
 
 impl LauncherPresetError {
@@ -1713,6 +1751,7 @@ impl LauncherPresetError {
             status: StatusCode::BAD_REQUEST,
             code: "invalid_preset_launch",
             message: message.into(),
+            herdr_code: None,
         }
     }
 
@@ -1721,6 +1760,7 @@ impl LauncherPresetError {
             status: StatusCode::FORBIDDEN,
             code: "forbidden",
             message: message.into(),
+            herdr_code: None,
         }
     }
 
@@ -1729,6 +1769,7 @@ impl LauncherPresetError {
             status: StatusCode::NOT_FOUND,
             code: "preset_not_found",
             message: message.into(),
+            herdr_code: None,
         }
     }
 
@@ -1737,6 +1778,7 @@ impl LauncherPresetError {
             status: StatusCode::CONFLICT,
             code: "layout_changed",
             message: message.into(),
+            herdr_code: None,
         }
     }
 
@@ -1745,6 +1787,16 @@ impl LauncherPresetError {
             status: StatusCode::BAD_GATEWAY,
             code: "herdr_launch_failed",
             message: message.into(),
+            herdr_code: None,
+        }
+    }
+
+    fn from_herdr_error(code: String, message: String) -> Self {
+        Self {
+            status: StatusCode::BAD_GATEWAY,
+            code: "herdr_launch_failed",
+            message,
+            herdr_code: Some(code),
         }
     }
 
@@ -1904,14 +1956,26 @@ fn launch_preset_blocking(
 
 trait LauncherApiRequest {
     fn request(&mut self, id: &str, method: Method) -> Result<ResponseResult, LauncherPresetError>;
+
+    fn now(&self) -> std::time::Instant {
+        std::time::Instant::now()
+    }
+
+    fn wait(&mut self, duration: Duration) {
+        thread::sleep(duration);
+    }
 }
 
 struct HerdrLauncherApi<'a>(&'a ApiClient);
 
 impl LauncherApiRequest for HerdrLauncherApi<'_> {
     fn request(&mut self, id: &str, method: Method) -> Result<ResponseResult, LauncherPresetError> {
-        api_request(self.0, id, method)
-            .map_err(|err| LauncherPresetError::launch_failed(err.to_string()))
+        api_request(self.0, id, method).map_err(|err| match err {
+            BridgeError::Api(ApiClientError::ErrorResponse(response)) => {
+                LauncherPresetError::from_herdr_error(response.error.code, response.error.message)
+            }
+            err => LauncherPresetError::launch_failed(err.to_string()),
+        })
     }
 }
 
@@ -2145,16 +2209,35 @@ fn start_managed_agent(
     args: &[String],
 ) -> Result<(), LauncherPresetError> {
     let name = managed_agent_name(kind, pane_id);
-    let result = api.request(
-        "herdr-web:launcher:start-managed-agent",
-        Method::AgentStart(AgentStartParams {
-            name: name.clone(),
-            kind: kind.as_str().to_string(),
-            pane_id: pane_id.to_string(),
-            args: args.to_vec(),
-            timeout_ms: None,
-        }),
-    )?;
+    // Herdr v0.8 can acknowledge pane creation before its process detector sees the shell as the
+    // pane's foreground job. The API exposes no shell-ready event or authoritative readiness flag,
+    // so allow that shell to settle and retry only the transient `agent_pane_busy` response.
+    let deadline = api.now() + MANAGED_AGENT_SHELL_READY_TIMEOUT;
+    api.wait(MANAGED_AGENT_SHELL_SETTLE_DELAY);
+    let mut retry_delay = MANAGED_AGENT_SHELL_RETRY_INITIAL_DELAY;
+    let result = loop {
+        match api.request(
+            "herdr-web:launcher:start-managed-agent",
+            Method::AgentStart(AgentStartParams {
+                name: name.clone(),
+                kind: kind.as_str().to_string(),
+                pane_id: pane_id.to_string(),
+                args: args.to_vec(),
+                timeout_ms: None,
+            }),
+        ) {
+            Ok(result) => break result,
+            Err(error)
+                if error.herdr_code.as_deref() == Some("agent_pane_busy")
+                    && api.now() < deadline =>
+            {
+                let remaining = deadline.saturating_duration_since(api.now());
+                api.wait(retry_delay.min(remaining));
+                retry_delay = retry_delay.saturating_mul(3);
+            }
+            Err(error) => return Err(error),
+        }
+    };
     let ResponseResult::AgentStarted { agent, .. } = result else {
         return Err(LauncherPresetError::launch_failed(
             "unexpected response for managed agent launch",
@@ -4937,7 +5020,7 @@ mod tests {
         assert!(!ALLOWED_COMMANDS.contains(&"server.stop"));
         assert!(!ALLOWED_COMMANDS.contains(&"pane.send_keys"));
         assert!(!ALLOWED_COMMANDS.contains(&"pane.send_input"));
-        assert!(!ALLOWED_COMMANDS.contains(&"workspace.move_block"));
+        assert!(ALLOWED_COMMANDS.contains(&"workspace.move_block"));
         // pane.split is intentionally allowed so the web client can create splits.
         assert!(ALLOWED_COMMANDS.contains(&"pane.split"));
         assert!(ALLOWED_COMMANDS.contains(&"pane.focus_direction"));
@@ -5528,6 +5611,38 @@ mod tests {
     }
 
     #[test]
+    fn validates_atomic_workspace_reorder_commands() {
+        let valid: Request = serde_json::from_value(serde_json::json!({
+            "id": "test",
+            "method": "workspace.move_block",
+            "params": {
+                "workspace_ids": ["w1", "w1-child"],
+                "before_workspace_id": "w3"
+            }
+        }))
+        .unwrap();
+        assert!(validate_web_command(&valid.method).is_ok());
+
+        for params in [
+            serde_json::json!({ "workspace_ids": [] }),
+            serde_json::json!({ "workspace_ids": ["w1", "w1"] }),
+            serde_json::json!({ "workspace_ids": [""] }),
+            serde_json::json!({
+                "workspace_ids": ["w1"],
+                "before_workspace_id": "w1"
+            }),
+        ] {
+            let invalid: Request = serde_json::from_value(serde_json::json!({
+                "id": "test",
+                "method": "workspace.move_block",
+                "params": params
+            }))
+            .unwrap();
+            assert!(validate_web_command(&invalid.method).is_err());
+        }
+    }
+
+    #[test]
     fn validates_narrow_workspace_and_tab_rename_commands() {
         let request: Request = serde_json::from_value(serde_json::json!({
             "id": "test",
@@ -5920,6 +6035,74 @@ mod tests {
         };
         assert_eq!(params.target, name);
         assert_eq!(api.requests.len(), 4);
+        assert_eq!(api.waits, vec![MANAGED_AGENT_SHELL_SETTLE_DELAY]);
+    }
+
+    #[test]
+    fn managed_agent_launch_waits_for_new_shell_before_retrying_start() {
+        let pane = launcher_test_pane("pane-new", "workspace-1", "tab-new");
+        let tab = launcher_test_tab("tab-new", "workspace-1");
+        let name = managed_agent_name(ManagedAgentKind::Claude, "pane-new");
+        let mut pending = launcher_test_agent("pane-new", "workspace-1", "tab-new");
+        pending.name = Some(name);
+        pending.agent = None;
+        let mut ready = pending.clone();
+        ready.agent = Some("claude".into());
+        ready.launch_pending = false;
+        ready.interactive_ready = true;
+        let mut api = MockLauncherApi::new([
+            Ok(ResponseResult::TabCreated {
+                tab,
+                root_pane: pane,
+            }),
+            Ok(ResponseResult::Ok {}),
+            Err(LauncherPresetError::from_herdr_error(
+                "agent_pane_busy".into(),
+                "agent target pane pane-new is not an available shell".into(),
+            )),
+            Err(LauncherPresetError::from_herdr_error(
+                "agent_pane_busy".into(),
+                "agent target pane pane-new is not an available shell".into(),
+            )),
+            Err(LauncherPresetError::from_herdr_error(
+                "agent_pane_busy".into(),
+                "agent target pane pane-new is not an available shell".into(),
+            )),
+            Ok(ResponseResult::AgentStarted {
+                agent: pending,
+                argv: vec!["claude".into()],
+            }),
+            Ok(ResponseResult::AgentInfo { agent: ready }),
+        ]);
+        let preset = launcher_test_managed_preset(ManagedAgentKind::Claude);
+
+        let response = launch_preset_with(
+            &mut api,
+            &preset,
+            "Claude",
+            LauncherPresetLaunchTarget::Tab {
+                workspace_id: "workspace-1".into(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(response.pane_id, "pane-new");
+        assert_eq!(
+            api.requests
+                .iter()
+                .filter(|request| matches!(request, Method::AgentStart(_)))
+                .count(),
+            4
+        );
+        assert_eq!(
+            api.waits,
+            vec![
+                MANAGED_AGENT_SHELL_SETTLE_DELAY,
+                MANAGED_AGENT_SHELL_RETRY_INITIAL_DELAY,
+                Duration::from_millis(900),
+                Duration::from_millis(1700),
+            ]
+        );
     }
 
     #[test]
@@ -6045,6 +6228,8 @@ mod tests {
     struct MockLauncherApi {
         results: std::collections::VecDeque<Result<ResponseResult, LauncherPresetError>>,
         requests: Vec<Method>,
+        waits: Vec<Duration>,
+        clock: std::time::Instant,
     }
 
     impl MockLauncherApi {
@@ -6054,6 +6239,8 @@ mod tests {
             Self {
                 results: results.into_iter().collect(),
                 requests: Vec::new(),
+                waits: Vec::new(),
+                clock: std::time::Instant::now(),
             }
         }
     }
@@ -6068,6 +6255,15 @@ mod tests {
             self.results
                 .pop_front()
                 .expect("mock launcher response missing")
+        }
+
+        fn now(&self) -> std::time::Instant {
+            self.clock
+        }
+
+        fn wait(&mut self, duration: Duration) {
+            self.waits.push(duration);
+            self.clock += duration;
         }
     }
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -2,8 +2,8 @@
 
 `herdr-web` ships as separate desktop bridge/web tarballs and an Android APK.
 
-The desktop tarball does not include Herdr itself. Users still need a running Herdr `v0.7.5` or
-newer session or daemon that reports terminal protocol `17`; the bundled bridge connects to the
+The desktop tarball does not include Herdr itself. Users still need a running Herdr `v0.8.0` or
+newer session or daemon that reports terminal protocol `19`; the bundled bridge connects to the
 normal Herdr socket.
 
 ## Release Artifacts
@@ -88,8 +88,8 @@ cat dist-packages/herdr-web-vX.Y.Z-PLATFORM.tar.gz.sha256
 Confirm the archive contains the expected root directory, `bin/herdr-web`,
 `bin/herdr-web-bridge`, bundled `share/herdr-web/web/` assets, and `README.md`.
 
-Before release, run the unpacked wrapper against a Herdr `v0.7.5` or newer daemon reporting protocol
-`17`. Confirm the bridge accepts that combination and rejects a daemon reporting any other terminal
+Before release, run the unpacked wrapper against a Herdr `v0.8.0` or newer daemon reporting protocol
+`19`. Confirm the bridge accepts that combination and rejects a daemon reporting any other terminal
 protocol. Complete the launcher checks in [docs/release.md](release.md) with the packaged bridge, not
 only a development build.
 
@@ -127,7 +127,7 @@ dist-packages/herdr-web-vX.Y.Z-android.apk
 
 ## User Quick Start From Tarball
 
-Start or attach Herdr `v0.7.5` or newer with terminal protocol `17` first:
+Start or attach Herdr `v0.8.0` or newer with terminal protocol `19` first:
 
 ```bash
 herdr

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,7 +10,7 @@ They do not publish npm packages, and the package versions are not release versi
 - Rust stable.
 - JDK 21 and Android SDK when validating the Android shell.
 - GitHub CLI authenticated as a user that can create releases.
-- A local Herdr `v0.7.5` or newer session reporting terminal protocol `17` for browser and packaged
+- A local Herdr `v0.8.0` or newer session reporting terminal protocol `19` for browser and packaged
   bridge smoke testing.
 
 ## Prepare
@@ -96,7 +96,7 @@ dist-packages/herdr-web-vX.Y.Z-android.apk
 
 ## Browser Smoke
 
-Start or attach a Herdr `v0.7.5` or newer session reporting terminal protocol `17`:
+Start or attach a Herdr `v0.8.0` or newer session reporting terminal protocol `19`:
 
 ```bash
 herdr
@@ -125,7 +125,7 @@ Open `http://127.0.0.1:8787` and verify:
 - Binding to `HOST=0.0.0.0` is only used on a trusted network.
 
 Repeat the startup, terminal attach, and launcher checks with an unpacked desktop tarball before
-uploading it. Confirm the bridge rejects protocol `16` and unreviewed protocols newer than `17`
+uploading it. Confirm the bridge rejects every protocol other than `19`
 instead of serving a partially compatible UI.
 
 ## Cut

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -2,8 +2,8 @@
 
 This bundle contains the `herdr-web` browser UI assets and the `herdr-web-bridge` executable.
 
-It does not include Herdr itself. Start or attach a Herdr `v0.7.5` or newer session that reports
-terminal protocol `17` separately before running this bundle.
+It does not include Herdr itself. Start or attach a Herdr `v0.8.0` or newer session that reports
+terminal protocol `19` separately before running this bundle.
 
 ## Run
 

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -32,8 +32,8 @@ The browser app is not vendored into Herdr. It lives at `web/`, and `herdr-web-b
 ## Current Reference
 
 - Upstream checkout: a clean Herdr source checkout outside this repository
-- Upstream release baseline: `v0.7.5`
-- Terminal wire baseline: protocol `17`
+- Upstream release baseline: `v0.8.0`
+- Terminal wire baseline: protocol `19`
 
 Use the upstream checkout as an external reference for audits and refreshes. It is not required to
 build `herdr-web`.
@@ -62,7 +62,7 @@ bridge narrows the drift check to only the terminal attach message regions.
 
 ## Refresh Process
 
-Use a clean Herdr checkout at the reviewed `v0.7.5` release tag as the source reference. Do not
+Use a clean Herdr checkout at the reviewed `v0.8.0` release tag as the source reference. Do not
 refresh from an experimental tree that may contain unrelated local drift. Copy the reviewed
 upstream source files into the minimal compatibility crate; do not make the bridge compile against
 the external checkout or recreate a full upstream vendor snapshot.
@@ -87,6 +87,8 @@ src/api/status.rs          -> vendor/herdr-compat/src/api/status.rs
 src/api/schema.rs          -> vendor/herdr-compat/src/api/schema.rs
 src/api/schema/*.rs        -> vendor/herdr-compat/src/api/schema/*.rs
 src/protocol/wire.rs       -> vendor/herdr-compat/src/protocol/wire.rs
+src/input/model.rs         -> vendor/herdr-compat/src/input.rs (minimal protocol shim)
+src/raw_input.rs           -> vendor/herdr-compat/src/raw_input.rs (minimal protocol shim)
 src/ipc.rs                 -> vendor/herdr-compat/src/ipc.rs
 src/logging.rs             -> vendor/herdr-compat/src/logging.rs
 src/popup_size.rs          -> vendor/herdr-compat/src/popup_size.rs
@@ -104,6 +106,8 @@ src/server/socket_paths.rs -> vendor/herdr-compat/src/server/socket_paths.rs
 - `PopupSize` is public in the compatibility crate because copied public plugin schema fields expose
   it, while upstream keeps the type crate-visible inside the full Herdr crate. This visibility-only
   adaptation is expected by the vendor drift check.
+- `input.rs` and `raw_input.rs` retain only the model surface required by the copied wire protocol;
+  terminal parsing and host input behavior remain owned by Herdr.
 - `protocol.rs` and schema tests include bridge fixture tests for the reviewed protocol/schema
   baseline.
 
@@ -138,8 +142,8 @@ the refit button after changing browser sizes.
 
 ## Compatibility Policy
 
-The bridge pings Herdr's status API at startup and requires Herdr `v0.7.5` or newer with daemon
-protocol exactly `17`. Older daemons and any unreviewed newer protocol are rejected before serving
+The bridge pings Herdr's status API at startup and requires Herdr `v0.8.0` or newer with daemon
+protocol exactly `19`. Older daemons and any unreviewed newer protocol are rejected before serving
 the web app. The version floor covers the private JSON API shape, including the managed
 `agent.start` contract; the exact protocol check protects the copied bincode terminal wire format.
 This is not a complete stability guarantee because the bridge mirrors private APIs.

--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPAT="$ROOT/vendor/herdr-compat"
-EXPECTED_HERDR_COMMIT="ef4c23f5775bb8cfec05f05d0844226ff959a07a"
+EXPECTED_HERDR_COMMIT="346411fa21afd297f5ed3b3fa56f9e3fbf7654b7"
 
 if ! command -v rg >/dev/null; then
   echo "ripgrep (rg) is required for vendor checks" >&2
@@ -31,10 +31,12 @@ required=(
   "$COMPAT/src/api/schema/workspaces.rs"
   "$COMPAT/src/api/schema/worktrees.rs"
   "$COMPAT/src/ipc.rs"
+  "$COMPAT/src/input.rs"
   "$COMPAT/src/logging.rs"
   "$COMPAT/src/popup_size.rs"
   "$COMPAT/src/protocol.rs"
   "$COMPAT/src/protocol/wire.rs"
+  "$COMPAT/src/raw_input.rs"
   "$COMPAT/src/server/socket_paths.rs"
 )
 
@@ -57,7 +59,7 @@ if rg -n '#\[path[[:space:]]*=' "$ROOT/bridge" "$COMPAT" >/dev/null; then
 fi
 
 if rg -n '\bcustom_status\b' "$COMPAT" >/dev/null; then
-  echo "obsolete custom_status fields are not allowed in the Herdr 0.7.5 compatibility copy" >&2
+  echo "obsolete custom_status fields are not allowed in the Herdr 0.8.0 compatibility copy" >&2
   rg -n '\bcustom_status\b' "$COMPAT" >&2
   exit 1
 fi
@@ -82,13 +84,13 @@ if [[ -n "${HERDR_SRC:-}" ]]; then
 
   upstream_commit="$(git -C "$HERDR_SRC" rev-parse HEAD 2>/dev/null || true)"
   if [[ "$upstream_commit" != "$EXPECTED_HERDR_COMMIT" ]]; then
-    echo "HERDR_SRC must be a Herdr v0.7.5 checkout at $EXPECTED_HERDR_COMMIT" >&2
+    echo "HERDR_SRC must be a Herdr v0.8.0 checkout at $EXPECTED_HERDR_COMMIT" >&2
     echo "found: ${upstream_commit:-not a git checkout}" >&2
     exit 1
   fi
 
   if [[ -n "$(git -C "$HERDR_SRC" status --short)" ]]; then
-    echo "HERDR_SRC must be a clean Herdr v0.7.5 checkout" >&2
+    echo "HERDR_SRC must be a clean Herdr v0.8.0 checkout" >&2
     git -C "$HERDR_SRC" status --short >&2
     exit 1
   fi
@@ -161,8 +163,8 @@ if [[ -n "${HERDR_SRC:-}" ]]; then
   compare_popup_size
   compare_wire_body
 
-  echo "Herdr v0.7.5 compatibility vendor layout and HERDR_SRC drift checks passed"
+  echo "Herdr v0.8.0 compatibility vendor layout and HERDR_SRC drift checks passed"
 else
-  echo "Herdr v0.7.5 compatibility vendor layout looks clean"
-  echo "Set HERDR_SRC=/path/to/clean/herdr-v0.7.5 to compare exact upstream schema/wire copies"
+  echo "Herdr v0.8.0 compatibility vendor layout looks clean"
+  echo "Set HERDR_SRC=/path/to/clean/herdr-v0.8.0 to compare exact upstream schema/wire copies"
 fi

--- a/vendor/herdr-compat/src/api/schema.rs
+++ b/vendor/herdr-compat/src/api/schema.rs
@@ -75,6 +75,8 @@ pub enum Method {
     WorkspaceRename(WorkspaceRenameParams),
     #[serde(rename = "workspace.move")]
     WorkspaceMove(WorkspaceMoveParams),
+    #[serde(rename = "workspace.move_block")]
+    WorkspaceMoveBlock(WorkspaceMoveBlockParams),
     #[serde(rename = "workspace.report_metadata")]
     WorkspaceReportMetadata(WorkspaceReportMetadataParams),
     #[serde(rename = "workspace.close")]

--- a/vendor/herdr-compat/src/api/schema/common.rs
+++ b/vendor/herdr-compat/src/api/schema/common.rs
@@ -66,6 +66,13 @@ pub enum ReadSource {
     Detection,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum ReadIntent {
+    #[default]
+    Interactive,
+    Passive,
+}
+
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Default,
 )]

--- a/vendor/herdr-compat/src/api/schema/events.rs
+++ b/vendor/herdr-compat/src/api/schema/events.rs
@@ -26,6 +26,8 @@ pub enum Subscription {
     WorkspaceRenamed {},
     #[serde(rename = "workspace.moved")]
     WorkspaceMoved {},
+    #[serde(rename = "workspace.reordered")]
+    WorkspaceReordered {},
     #[serde(rename = "workspace.closed")]
     WorkspaceClosed {},
     #[serde(rename = "workspace.focused")]
@@ -196,6 +198,7 @@ pub enum EventKind {
     WorkspaceClosed,
     WorkspaceRenamed,
     WorkspaceMoved,
+    WorkspaceReordered,
     WorkspaceFocused,
     WorktreeCreated,
     WorktreeOpened,
@@ -226,6 +229,7 @@ impl EventKind {
             EventKind::WorkspaceClosed => "workspace.closed",
             EventKind::WorkspaceRenamed => "workspace.renamed",
             EventKind::WorkspaceMoved => "workspace.moved",
+            EventKind::WorkspaceReordered => "workspace.reordered",
             EventKind::WorkspaceFocused => "workspace.focused",
             EventKind::WorktreeCreated => "worktree.created",
             EventKind::WorktreeOpened => "worktree.opened",
@@ -257,6 +261,7 @@ pub const KNOWN_EVENT_KINDS: &[EventKind] = &[
     EventKind::WorkspaceClosed,
     EventKind::WorkspaceRenamed,
     EventKind::WorkspaceMoved,
+    EventKind::WorkspaceReordered,
     EventKind::WorkspaceFocused,
     EventKind::WorktreeCreated,
     EventKind::WorktreeOpened,
@@ -284,6 +289,7 @@ pub const PLUGIN_HOOK_EVENT_KINDS: &[EventKind] = &[
     EventKind::WorkspaceClosed,
     EventKind::WorkspaceRenamed,
     EventKind::WorkspaceMoved,
+    EventKind::WorkspaceReordered,
     EventKind::WorkspaceFocused,
     EventKind::WorktreeCreated,
     EventKind::WorktreeOpened,
@@ -435,6 +441,12 @@ pub enum EventData {
     WorkspaceMoved {
         workspace_id: String,
         insert_index: usize,
+        workspaces: Vec<WorkspaceInfo>,
+    },
+    WorkspaceReordered {
+        workspace_ids: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        before_workspace_id: Option<String>,
         workspaces: Vec<WorkspaceInfo>,
     },
     WorkspaceFocused {

--- a/vendor/herdr-compat/src/api/schema/integrations.rs
+++ b/vendor/herdr-compat/src/api/schema/integrations.rs
@@ -27,10 +27,12 @@ pub enum IntegrationTarget {
     Qodercli,
     Cursor,
     Mastracode,
+    AntigravityCli,
+    Grok,
 }
 
 impl IntegrationTarget {
-    pub(crate) const ALL: [Self; 14] = [
+    pub(crate) const ALL: [Self; 16] = [
         Self::Pi,
         Self::Omp,
         Self::Claude,
@@ -45,6 +47,8 @@ impl IntegrationTarget {
         Self::Qodercli,
         Self::Cursor,
         Self::Mastracode,
+        Self::AntigravityCli,
+        Self::Grok,
     ];
 }
 

--- a/vendor/herdr-compat/src/api/schema/panes.rs
+++ b/vendor/herdr-compat/src/api/schema/panes.rs
@@ -258,6 +258,9 @@ pub struct PaneReadParams {
     pub format: ReadFormat,
     #[serde(default = "super::default_true")]
     pub strip_ansi: bool,
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub(crate) intent: super::common::ReadIntent,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]

--- a/vendor/herdr-compat/src/api/schema/tests.rs
+++ b/vendor/herdr-compat/src/api/schema/tests.rs
@@ -384,10 +384,13 @@ fn pane_read_defaults_to_text_format() {
     "#;
 
     let request: Request = serde_json::from_str(json).unwrap();
+    let serialized = serde_json::to_value(&request).unwrap();
+    assert!(serialized["params"].get("intent").is_none());
     let Method::PaneRead(params) = request.method else {
         panic!("wrong method parsed");
     };
     assert_eq!(params.format, ReadFormat::Text);
+    assert_eq!(params.intent, ReadIntent::Interactive);
 }
 
 #[test]
@@ -438,6 +441,14 @@ fn event_envelope_round_trips() {
             data: EventData::WorkspaceMoved {
                 workspace_id: "w_1".into(),
                 insert_index: 2,
+                workspaces: vec![],
+            },
+        },
+        EventEnvelope {
+            event: EventKind::WorkspaceReordered,
+            data: EventData::WorkspaceReordered {
+                workspace_ids: vec!["w_1".into(), "w_2".into()],
+                before_workspace_id: Some("w_3".into()),
                 workspaces: vec![],
             },
         },
@@ -1035,6 +1046,18 @@ fn authority_mutation_requests_round_trip() {
     let restored: Request = serde_json::from_value(json).unwrap();
     assert_eq!(restored, workspace_move);
 
+    let workspace_move_block = Request {
+        id: "move_ws_block".into(),
+        method: Method::WorkspaceMoveBlock(WorkspaceMoveBlockParams {
+            workspace_ids: vec!["w1".into(), "w2".into()],
+            before_workspace_id: Some("w3".into()),
+        }),
+    };
+    let json = serde_json::to_value(&workspace_move_block).unwrap();
+    assert_eq!(json["method"], "workspace.move_block");
+    let restored: Request = serde_json::from_value(json).unwrap();
+    assert_eq!(restored, workspace_move_block);
+
     let tab_move = Request {
         id: "move_tab".into(),
         method: Method::TabMove(TabMoveParams {
@@ -1077,6 +1100,7 @@ fn authority_mutation_requests_round_trip() {
         method: Method::EventsSubscribe(EventsSubscribeParams {
             subscriptions: vec![
                 Subscription::WorkspaceMoved {},
+                Subscription::WorkspaceReordered {},
                 Subscription::TabMoved {},
                 Subscription::LayoutUpdated {},
             ],
@@ -1084,6 +1108,7 @@ fn authority_mutation_requests_round_trip() {
     };
     let json = serde_json::to_string(&subscription).unwrap();
     assert!(json.contains("\"type\":\"workspace.moved\""));
+    assert!(json.contains("\"type\":\"workspace.reordered\""));
     assert!(json.contains("\"type\":\"tab.moved\""));
     assert!(json.contains("\"type\":\"layout.updated\""));
     let restored: Request = serde_json::from_str(&json).unwrap();

--- a/vendor/herdr-compat/src/api/schema/workspaces.rs
+++ b/vendor/herdr-compat/src/api/schema/workspaces.rs
@@ -30,6 +30,13 @@ pub struct WorkspaceMoveParams {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct WorkspaceMoveBlockParams {
+    pub workspace_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before_workspace_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkspaceReportMetadataParams {
     pub workspace_id: String,
     pub source: String,

--- a/vendor/herdr-compat/src/input.rs
+++ b/vendor/herdr-compat/src/input.rs
@@ -1,9 +1,42 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowsKeyRecord {
+    pub key_down: bool,
+    pub repeat_count: u16,
+    pub virtual_key_code: u16,
+    pub virtual_scan_code: u16,
+    pub unicode: u16,
+    pub control_key_state: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextCommit {
+    text: String,
+}
+
+impl TextCommit {
+    pub fn new(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum KeySource {
+    Synthesized,
+    Vt { bytes: Vec<u8> },
+    WindowsConsole { record: WindowsKeyRecord },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TerminalKey {
     pub code: crossterm::event::KeyCode,
     pub modifiers: crossterm::event::KeyModifiers,
     pub kind: crossterm::event::KeyEventKind,
+    pub repeat_count: u16,
     pub shifted_codepoint: Option<u32>,
+    pub generated_text: Option<String>,
+    source: KeySource,
 }
 
 impl TerminalKey {
@@ -12,12 +45,60 @@ impl TerminalKey {
             code,
             modifiers,
             kind: crossterm::event::KeyEventKind::Press,
+            repeat_count: 1,
             shifted_codepoint: None,
+            generated_text: None,
+            source: KeySource::Synthesized,
         }
     }
 
     pub fn with_kind(mut self, kind: crossterm::event::KeyEventKind) -> Self {
+        if kind == crossterm::event::KeyEventKind::Release {
+            self.repeat_count = 1;
+            self.generated_text = None;
+        }
         self.kind = kind;
         self
+    }
+
+    pub fn with_repeat_count(mut self, repeat_count: u16) -> Self {
+        self.repeat_count = if self.kind == crossterm::event::KeyEventKind::Release {
+            1
+        } else {
+            repeat_count.max(1)
+        };
+        self
+    }
+
+    pub(crate) fn with_generated_text(mut self, text: Option<String>) -> Self {
+        self.generated_text = if self.kind == crossterm::event::KeyEventKind::Release {
+            None
+        } else {
+            text
+        };
+        self
+    }
+
+    pub(crate) fn with_vt_bytes(mut self, bytes: Vec<u8>) -> Self {
+        self.source = KeySource::Vt { bytes };
+        self
+    }
+
+    pub fn with_windows_record(mut self, record: WindowsKeyRecord) -> Self {
+        self.repeat_count = if self.kind == crossterm::event::KeyEventKind::Release {
+            1
+        } else {
+            record.repeat_count.max(1)
+        };
+        self.source = KeySource::WindowsConsole { record };
+        self
+    }
+
+    #[cfg(any(windows, test))]
+    pub(crate) fn windows_record(&self) -> Option<WindowsKeyRecord> {
+        match self.source {
+            KeySource::WindowsConsole { record } => Some(record),
+            KeySource::Synthesized | KeySource::Vt { .. } => None,
+        }
     }
 }

--- a/vendor/herdr-compat/src/protocol.rs
+++ b/vendor/herdr-compat/src/protocol.rs
@@ -8,7 +8,7 @@ mod bridge_fixture_tests {
 
     #[test]
     fn protocol_version_matches_reviewed_herdr_snapshot() {
-        assert_eq!(PROTOCOL_VERSION, 17);
+        assert_eq!(PROTOCOL_VERSION, 19);
     }
 
     #[test]
@@ -26,7 +26,7 @@ mod bridge_fixture_tests {
         let mut frame = Vec::new();
         write_message(&mut frame, &msg).unwrap();
 
-        assert_eq!(frame, vec![9, 0, 0, 0, 0, 17, 80, 24, 8, 16, 0, 0, 1]);
+        assert_eq!(frame, vec![9, 0, 0, 0, 0, 19, 80, 24, 8, 16, 0, 0, 1]);
         let decoded: ClientMessage = read_message(&mut frame.as_slice(), MAX_FRAME_SIZE).unwrap();
         assert_eq!(decoded, msg);
     }
@@ -41,7 +41,7 @@ mod bridge_fixture_tests {
         let mut frame = Vec::new();
         write_message(&mut frame, &msg).unwrap();
 
-        assert_eq!(frame, vec![4, 0, 0, 0, 0, 17, 1, 0]);
+        assert_eq!(frame, vec![4, 0, 0, 0, 0, 19, 1, 0]);
         let decoded: ServerMessage = read_message(&mut frame.as_slice(), MAX_FRAME_SIZE).unwrap();
         assert_eq!(decoded, msg);
     }

--- a/vendor/herdr-compat/src/protocol/wire.rs
+++ b/vendor/herdr-compat/src/protocol/wire.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Current protocol version. Bumped when wire format changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 17;
+pub const PROTOCOL_VERSION: u32 = 19;
 
 /// Maximum allowed frame payload size (2 MB). Frames larger than this are
 /// rejected to prevent denial-of-service via oversized length prefixes.
@@ -115,7 +115,11 @@ pub enum ClientInputEvent {
         code: ClientKeyCode,
         modifiers: u8,
         kind: ClientKeyKind,
+        repeat_count: u16,
+        generated_text: Option<String>,
+        source: ClientKeySource,
     },
+    TextCommit(String),
     Mouse {
         kind: ClientMouseKind,
         column: u16,
@@ -127,6 +131,17 @@ pub enum ClientInputEvent {
     },
     FocusGained,
     FocusLost,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClientKeySource {
+    Synthesized,
+    Vt {
+        bytes: Vec<u8>,
+    },
+    WindowsConsole {
+        record: crate::input::WindowsKeyRecord,
+    },
 }
 
 impl ClientKeyKind {
@@ -251,13 +266,16 @@ impl ClientMouseKind {
 }
 
 impl ClientInputEvent {
-    #[cfg(windows)]
+    #[cfg(any(windows, test))]
     pub(crate) fn from_crossterm(event: crossterm::event::Event) -> Option<Self> {
         match event {
             crossterm::event::Event::Key(key) => Some(Self::Key {
                 code: ClientKeyCode::from_crossterm(key.code)?,
                 modifiers: key.modifiers.bits(),
                 kind: ClientKeyKind::from_crossterm(key.kind),
+                repeat_count: 1,
+                generated_text: None,
+                source: ClientKeySource::Synthesized,
             }),
             crossterm::event::Event::Mouse(mouse) => Some(Self::Mouse {
                 kind: ClientMouseKind::from_crossterm(mouse.kind)?,
@@ -278,13 +296,28 @@ impl ClientInputEvent {
                 code,
                 modifiers,
                 kind,
-            } => crate::raw_input::RawInputEvent::Key(
-                crate::input::TerminalKey::new(
+                repeat_count,
+                generated_text,
+                source,
+            } => {
+                let mut key = crate::input::TerminalKey::new(
                     code.to_crossterm(),
                     crossterm::event::KeyModifiers::from_bits_truncate(*modifiers),
                 )
-                .with_kind(kind.to_crossterm()),
-            ),
+                .with_generated_text(generated_text.clone());
+                key = match source {
+                    ClientKeySource::Synthesized => key,
+                    ClientKeySource::Vt { bytes } => key.with_vt_bytes(bytes.clone()),
+                    ClientKeySource::WindowsConsole { record } => key.with_windows_record(*record),
+                };
+                key = key
+                    .with_repeat_count(*repeat_count)
+                    .with_kind(kind.to_crossterm());
+                crate::raw_input::RawInputEvent::Key(key)
+            }
+            Self::TextCommit(text) => {
+                crate::raw_input::RawInputEvent::Text(crate::input::TextCommit::new(text.clone()))
+            }
             Self::Mouse {
                 kind,
                 column,
@@ -434,6 +467,19 @@ pub struct CellData {
     pub hyperlink: Option<u32>,
 }
 
+impl CellData {
+    pub(crate) fn from_ratatui_cell(cell: &ratatui::buffer::Cell) -> Self {
+        Self {
+            symbol: cell.symbol().to_owned(),
+            fg: color_to_u32(cell.fg),
+            bg: color_to_u32(cell.bg),
+            modifier: modifier_to_u16(cell.modifier),
+            skip: cell.skip,
+            hyperlink: None,
+        }
+    }
+}
+
 /// Cursor shape encoded as a DECSCUSR parameter.
 ///
 /// 0 = terminal default, 1 = blinking block, 2 = steady block,
@@ -517,14 +563,9 @@ impl FrameData {
                             index
                         }))
                     });
-                cells.push(CellData {
-                    symbol: cell.symbol().to_owned(),
-                    fg: color_to_u32(cell.fg),
-                    bg: color_to_u32(cell.bg),
-                    modifier: modifier_to_u16(cell.modifier),
-                    skip: cell.skip,
-                    hyperlink,
-                });
+                let mut cell = CellData::from_ratatui_cell(cell);
+                cell.hyperlink = hyperlink;
+                cells.push(cell);
             }
         }
 
@@ -654,6 +695,12 @@ pub enum ServerMessage {
     /// Whether the client should currently capture host mouse input.
     MouseCapture {
         /// True when Herdr mouse UI is enabled or the focused pane app requests mouse reporting.
+        enabled: bool,
+    },
+
+    /// Whether the focused terminal requests Kitty report-all keyboard input.
+    KittyKeyboardReportAll {
+        /// True only while the focused pane requests `REPORT_ALL_KEYS_AS_ESCAPE_CODES`.
         enabled: bool,
     },
 
@@ -1053,12 +1100,39 @@ mod tests {
                     code: ClientKeyCode::Char('N'),
                     modifiers: crossterm::event::KeyModifiers::SHIFT.bits(),
                     kind: ClientKeyKind::Press,
+
+                    repeat_count: 1,
+                    generated_text: None,
+                    source: crate::protocol::ClientKeySource::Synthesized,
                 },
                 ClientInputEvent::Key {
                     code: ClientKeyCode::Backspace,
                     modifiers: 0,
                     kind: ClientKeyKind::Press,
+                    repeat_count: 3,
+                    generated_text: None,
+                    source: crate::protocol::ClientKeySource::Vt {
+                        bytes: b"\x1b[127;1u".to_vec(),
+                    },
                 },
+                ClientInputEvent::Key {
+                    code: ClientKeyCode::Esc,
+                    modifiers: 0,
+                    kind: ClientKeyKind::Release,
+                    repeat_count: 1,
+                    generated_text: None,
+                    source: crate::protocol::ClientKeySource::WindowsConsole {
+                        record: crate::input::WindowsKeyRecord {
+                            key_down: false,
+                            repeat_count: 1,
+                            virtual_key_code: 27,
+                            virtual_scan_code: 1,
+                            unicode: 27,
+                            control_key_state: 0,
+                        },
+                    },
+                },
+                ClientInputEvent::TextCommit("你🙂".to_owned()),
                 ClientInputEvent::Mouse {
                     kind: ClientMouseKind::Down(ClientMouseButton::Left),
                     column: 3,
@@ -1068,17 +1142,58 @@ mod tests {
             ],
         };
         let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
+        // Freeze the protocol 19 input envelope before it is published.
+        assert_eq!(
+            encoded,
+            vec![
+                7, 5, 0, 15, 78, 1, 0, 1, 0, 0, 0, 0, 0, 0, 3, 0, 1, 8, 27, 91, 49, 50, 55, 59, 49,
+                117, 0, 14, 0, 2, 1, 0, 2, 0, 1, 27, 1, 27, 0, 1, 7, 228, 189, 160, 240, 159, 153,
+                130, 2, 0, 0, 3, 4, 0,
+            ]
+        );
         let (decoded, _): (ClientMessage, _) =
             bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
         assert_eq!(msg, decoded);
     }
 
     #[test]
+    fn wire_release_cannot_restore_a_grouped_repeat_count() {
+        let event = ClientInputEvent::Key {
+            code: ClientKeyCode::Esc,
+            modifiers: 0,
+            kind: ClientKeyKind::Release,
+            repeat_count: 3,
+            generated_text: Some("ignored".to_owned()),
+            source: ClientKeySource::Synthesized,
+        };
+
+        match event.to_raw_input_event() {
+            crate::raw_input::RawInputEvent::Key(key) => {
+                assert_eq!(key.kind, crossterm::event::KeyEventKind::Release);
+                assert_eq!(key.repeat_count, 1);
+                assert_eq!(key.generated_text, None);
+            }
+            other => panic!("expected key event, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn client_input_events_convert_to_raw_keys() {
+        let record = crate::input::WindowsKeyRecord {
+            key_down: false,
+            repeat_count: 1,
+            virtual_key_code: 78,
+            virtual_scan_code: 49,
+            unicode: 78,
+            control_key_state: 16,
+        };
         let shifted = ClientInputEvent::Key {
             code: ClientKeyCode::Char('N'),
             modifiers: crossterm::event::KeyModifiers::SHIFT.bits(),
             kind: ClientKeyKind::Press,
+            repeat_count: 1,
+            generated_text: None,
+            source: ClientKeySource::WindowsConsole { record },
         }
         .to_raw_input_event();
         match shifted {
@@ -1086,6 +1201,10 @@ mod tests {
                 assert_eq!(key.code, crossterm::event::KeyCode::Char('N'));
                 assert_eq!(key.modifiers, crossterm::event::KeyModifiers::SHIFT);
                 assert_eq!(key.kind, crossterm::event::KeyEventKind::Press);
+                assert_eq!(
+                    key.windows_record().map(|record| record.key_down),
+                    Some(false)
+                );
             }
             other => panic!("expected shifted key event, got {other:?}"),
         }
@@ -1094,6 +1213,10 @@ mod tests {
             code: ClientKeyCode::Backspace,
             modifiers: 0,
             kind: ClientKeyKind::Press,
+
+            repeat_count: 1,
+            generated_text: None,
+            source: crate::protocol::ClientKeySource::Synthesized,
         }
         .to_raw_input_event();
         match backspace {
@@ -1406,6 +1529,15 @@ mod tests {
     #[test]
     fn server_mouse_capture_roundtrip() {
         let msg = ServerMessage::MouseCapture { enabled: true };
+        let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
+        let (decoded, _): (ServerMessage, _) =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn server_kitty_keyboard_report_all_roundtrip() {
+        let msg = ServerMessage::KittyKeyboardReportAll { enabled: true };
         let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
         let (decoded, _): (ServerMessage, _) =
             bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();

--- a/vendor/herdr-compat/src/raw_input.rs
+++ b/vendor/herdr-compat/src/raw_input.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RawInputEvent {
     Key(crate::input::TerminalKey),
+    Text(crate::input::TextCommit),
     Mouse(crossterm::event::MouseEvent),
     Paste(String),
     OuterFocusGained,

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -993,6 +993,19 @@ describe("App multi-bridge helpers", () => {
     expect(menuItems("tab", false, false, false, false, "pane", true)).toEqual([]);
   });
 
+  it("offers contextual workspace moving only when the bridge supports it", () => {
+    expect(menuItems("space", false, true, false, false, "pane", false, true)).toEqual([
+      { key: "rename", label: "Rename" },
+      { key: "newtab", label: "New tab" },
+      { key: "reorder", label: "Move space" },
+      { key: "close", label: "Close space", danger: true },
+    ]);
+    expect(menuItems("space", false, true)).not.toContainEqual({
+      key: "reorder",
+      label: "Move space",
+    });
+  });
+
   it("requires a current note-capable pane before showing add-note", () => {
     const eligible = {
       kind: "pane" as const,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -215,6 +215,7 @@ type ScopedWorkspaceRef = {
   workspaceId: string;
 };
 type SpaceReorderMode = ScopedWorkspaceRef;
+const SPACE_REORDER_INSTRUCTIONS_ID = "space-reorder-instructions";
 type SpaceDragState = {
   pointerId: number;
   startY: number;
@@ -1010,6 +1011,23 @@ export function App() {
   const [showDetail, setShowDetail] = useState(false);
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [spaceReorderMode, setSpaceReorderMode] = useState<SpaceReorderMode | null>(null);
+  const [spaceReorderAnnouncement, setSpaceReorderAnnouncement] = useState("");
+  const spaceReorderAnnouncementFrameRef = useRef<number | null>(null);
+  const announceSpaceReorder = useCallback((message: string) => {
+    if (spaceReorderAnnouncementFrameRef.current !== null) {
+      window.cancelAnimationFrame(spaceReorderAnnouncementFrameRef.current);
+    }
+    setSpaceReorderAnnouncement("");
+    spaceReorderAnnouncementFrameRef.current = window.requestAnimationFrame(() => {
+      setSpaceReorderAnnouncement(message);
+      spaceReorderAnnouncementFrameRef.current = null;
+    });
+  }, []);
+  const closeSpaceReorder = useCallback(() => setSpaceReorderMode(null), []);
+  const cancelSpaceReorder = useCallback(() => {
+    announceSpaceReorder("Canceled moving space.");
+    closeSpaceReorder();
+  }, [announceSpaceReorder, closeSpaceReorder]);
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [noteDeleteTarget, setNoteDeleteTarget] = useState<ScopedNoteEntry | null>(null);
   const [deletingNote, setDeletingNote] = useState(false);
@@ -1189,7 +1207,7 @@ export function App() {
         return true;
       }
       if (spaceReorderMode) {
-        setSpaceReorderMode(null);
+        cancelSpaceReorder();
         return true;
       }
       if (notesPanelOpen) {
@@ -1200,6 +1218,7 @@ export function App() {
     });
   }, [
     backendSettingsOpen,
+    cancelSpaceReorder,
     deletingNote,
     dialog,
     launchTarget,
@@ -1216,12 +1235,21 @@ export function App() {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        setSpaceReorderMode(null);
+        cancelSpaceReorder();
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [spaceReorderMode]);
+  }, [cancelSpaceReorder, spaceReorderMode]);
+
+  useEffect(
+    () => () => {
+      if (spaceReorderAnnouncementFrameRef.current !== null) {
+        window.cancelAnimationFrame(spaceReorderAnnouncementFrameRef.current);
+      }
+    },
+    [],
+  );
 
   const bridgeViews = useMemo<BridgeConnectionView[]>(
     () =>
@@ -3429,7 +3457,8 @@ export function App() {
     bridgeId: BridgeId,
     sourceWorkspaceId: string,
     beforeWorkspaceId: string | null,
-  ) {
+    keepMode = false,
+  ): Promise<boolean> {
     const runtime = bridge.getRuntime(bridgeId);
     const snapshot = connectionRefs.current[bridgeId]?.snapshot;
     const params = snapshot
@@ -3443,18 +3472,21 @@ export function App() {
       !runtime.capabilities?.commands.includes("workspace.move_block")
     ) {
       setError("Space ordering is unavailable");
-      setSpaceReorderMode(null);
-      return;
+      closeSpaceReorder();
+      return false;
     }
     if (!params) {
-      setSpaceReorderMode(null);
-      return;
+      closeSpaceReorder();
+      return false;
     }
     const commands = createCommands(runtime.httpUrl);
-    await exec(runtime, () =>
+    const moved = await exec(runtime, () =>
       commands.moveWorkspaceBlock(params.workspaceIds, params.beforeWorkspaceId),
     );
-    setSpaceReorderMode(null);
+    if (!keepMode || !moved) {
+      closeSpaceReorder();
+    }
+    return moved;
   }
 
   async function toggleAgentPin(bridgeId: BridgeId, paneId: string, pinned: boolean) {
@@ -3662,6 +3694,9 @@ export function App() {
       data-touch={isTouchInput ? "true" : "false"}
       data-detail={isCompactLayout && showDetail ? "true" : "false"}
     >
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {spaceReorderAnnouncement}
+      </span>
       {bridge.enabledRuntimes.map((runtime) => (
         <BridgeConnectionController
           key={runtime.id}
@@ -3765,9 +3800,10 @@ export function App() {
           onToggleCollapsedGroup={toggleCollapsedSidebarGroup}
           onSetCollapsedGroups={setVisibleSidebarGroupsCollapsed}
           onSpaceGroup={setSpaceGroup}
-          onCancelSpaceReorder={() => setSpaceReorderMode(null)}
-          onReorderSpace={(bridgeId, workspaceId, beforeWorkspaceId) =>
-            void reorderSpace(bridgeId, workspaceId, beforeWorkspaceId)
+          onCancelSpaceReorder={cancelSpaceReorder}
+          onAnnounceSpaceReorder={announceSpaceReorder}
+          onReorderSpace={(bridgeId, workspaceId, beforeWorkspaceId, keepMode) =>
+            reorderSpace(bridgeId, workspaceId, beforeWorkspaceId, keepMode)
           }
           onSelectBridge={setSelectedBridgeId}
           onSelectSpace={selectSpace}
@@ -5904,6 +5940,7 @@ function Switcher({
   onSetCollapsedGroups,
   onSpaceGroup,
   onCancelSpaceReorder,
+  onAnnounceSpaceReorder,
   onReorderSpace,
   onSelectBridge,
   onSelectSpace,
@@ -5961,11 +5998,13 @@ function Switcher({
   onSetCollapsedGroups: (keys: readonly string[], collapsed: boolean) => void;
   onSpaceGroup: (group: SpaceGroup) => void;
   onCancelSpaceReorder: () => void;
+  onAnnounceSpaceReorder: (message: string) => void;
   onReorderSpace: (
     bridgeId: BridgeId,
     workspaceId: string,
     beforeWorkspaceId: string | null,
-  ) => void;
+    keepMode?: boolean,
+  ) => Promise<boolean>;
   onSelectBridge: (bridgeId: BridgeId) => void;
   onSelectSpace: (bridgeId: BridgeId, workspaceId: string) => void;
   onSelectTab: (bridgeId: BridgeId, tabId: string) => void;
@@ -6048,6 +6087,11 @@ function Switcher({
     [reorderWorkspaces],
   );
   const reorderSourceRootId = spaceReorderMode?.workspaceId ?? null;
+  const reorderSourceLabel = spaceReorderMode
+    ? (reorderWorkspaces.find(
+        (workspace) => workspace.workspace_id === spaceReorderMode.workspaceId,
+      )?.label ?? "Space")
+    : "Space";
   const remainingReorderRootIds = useMemo(
     () => reorderRootIds.filter((workspaceId) => workspaceId !== reorderSourceRootId),
     [reorderRootIds, reorderSourceRootId],
@@ -6329,11 +6373,16 @@ function Switcher({
     }
     if (!reorderBridgeView?.snapshot || reorderBlockIds.length === 0) {
       onCancelSpaceReorder();
+    }
+  }, [onCancelSpaceReorder, reorderBlockIds.length, reorderBridgeView?.snapshot, spaceReorderMode]);
+
+  useEffect(() => {
+    if (!spaceReorderMode) {
       return;
     }
     const frame = window.requestAnimationFrame(() => spaceReorderCardRef.current?.focus());
     return () => window.cancelAnimationFrame(frame);
-  }, [onCancelSpaceReorder, reorderBlockIds.length, reorderBridgeView, spaceReorderMode]);
+  }, [spaceReorderMode?.bridgeId, spaceReorderMode?.workspaceId]);
 
   const rowRefKey = (bridgeId: BridgeId, workspaceId: string) =>
     `${bridgeId}:${workspaceId}`;
@@ -6399,11 +6448,15 @@ function Switcher({
     spaceDragRef.current = null;
     setSpaceDragTarget(undefined);
     if (commit && drag.moved) {
-      onReorderSpace(
+      void onReorderSpace(
         spaceReorderMode.bridgeId,
         spaceReorderMode.workspaceId,
         drag.beforeWorkspaceId,
-      );
+      ).then((moved) => {
+        if (moved) {
+          onAnnounceSpaceReorder(`Moved ${reorderSourceLabel}.`);
+        }
+      });
     }
   };
   const beginSpaceDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
@@ -6432,13 +6485,37 @@ function Switcher({
       spaceReorderMode.workspaceId,
       direction,
     );
-    if (destination !== undefined) {
-      onReorderSpace(
-        spaceReorderMode.bridgeId,
-        spaceReorderMode.workspaceId,
-        destination,
-      );
+    if (destination === undefined) {
+      const boundaryLabel: Record<WorkspaceReorderDirection, string> = {
+        up: "is already at the beginning",
+        down: "is already at the end",
+        top: "is already at the beginning",
+        bottom: "is already at the end",
+      };
+      onAnnounceSpaceReorder(`${reorderSourceLabel} ${boundaryLabel[direction]}.`);
+      return;
     }
+    void onReorderSpace(
+      spaceReorderMode.bridgeId,
+      spaceReorderMode.workspaceId,
+      destination,
+      true,
+    ).then((moved) => {
+      if (!moved) {
+        return;
+      }
+      const destinationLabel: Record<WorkspaceReorderDirection, string> = {
+        up: "up one position",
+        down: "down one position",
+        top: "to the beginning",
+        bottom: "to the end",
+      };
+      onAnnounceSpaceReorder(`Moved ${reorderSourceLabel} ${destinationLabel[direction]}.`);
+      window.requestAnimationFrame(() => spaceReorderCardRef.current?.focus());
+    });
+  };
+  const cancelSpaceReorder = () => {
+    onCancelSpaceReorder();
   };
 
   let agentPaneIndex = 0;
@@ -6957,16 +7034,22 @@ function Switcher({
           moveSpaceWithKeyboard(direction);
         } else if (event.key === "Escape") {
           event.preventDefault();
-          onCancelSpaceReorder();
+          cancelSpaceReorder();
         }
       }}
-      onCancelReorder={onCancelSpaceReorder}
+      onCancelReorder={cancelSpaceReorder}
     />
     );
   };
 
   return (
     <>
+      {spaceReorderMode ? (
+        <span id={SPACE_REORDER_INSTRUCTIONS_ID} className="sr-only">
+          Use the Up and Down arrow keys to move this space one position, Home and End to move it
+          to either end, and Escape to cancel.
+        </span>
+      ) : null}
       <header className="sb-head">
         <div className="brand">
           <span className="brand-mark">
@@ -8625,6 +8708,7 @@ function SpaceRow({
         data-reorder-drag={reorderSource ? "true" : undefined}
         disabled={reorderSource && reorderBusy}
         aria-label={reorderSource ? `Move ${workspace.label}` : undefined}
+        aria-describedby={reorderSource ? SPACE_REORDER_INSTRUCTIONS_ID : undefined}
         style={{ animationDelay: `${Math.min(index, 14) * 22}ms` }}
         {...(reorderSource
           ? {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,6 +39,7 @@ import type {
   FormEvent as ReactFormEvent,
   KeyboardEvent as ReactKeyboardEvent,
   MutableRefObject,
+  PointerEvent as ReactPointerEvent,
   ReactNode,
   SetStateAction,
 } from "react";
@@ -179,6 +180,13 @@ import type {
   TabInfo,
   WorkspaceInfo,
 } from "./types";
+import {
+  workspaceMoveBlockParams,
+  workspaceReorderBlockIds,
+  workspaceReorderDestination,
+  workspaceReorderRoots,
+} from "./workspaceReorder";
+import type { WorkspaceReorderDirection } from "./workspaceReorder";
 
 const NoteMarkdownPreview = lazy(() => import("./NoteMarkdownPreview"));
 
@@ -205,6 +213,13 @@ type MobileNotesScreen = "list" | "editor";
 type ScopedWorkspaceRef = {
   bridgeId: BridgeId;
   workspaceId: string;
+};
+type SpaceReorderMode = ScopedWorkspaceRef;
+type SpaceDragState = {
+  pointerId: number;
+  startY: number;
+  beforeWorkspaceId: string | null;
+  moved: boolean;
 };
 type ScopedLaunchTarget = LaunchTarget & {
   bridgeId: BridgeId;
@@ -994,6 +1009,7 @@ export function App() {
   const [sidebarOpen, setSidebarOpen] = useState(initialPrefs.sidebarOpen);
   const [showDetail, setShowDetail] = useState(false);
   const [menu, setMenu] = useState<MenuState | null>(null);
+  const [spaceReorderMode, setSpaceReorderMode] = useState<SpaceReorderMode | null>(null);
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [noteDeleteTarget, setNoteDeleteTarget] = useState<ScopedNoteEntry | null>(null);
   const [deletingNote, setDeletingNote] = useState(false);
@@ -1172,6 +1188,10 @@ export function App() {
         setBackendSettingsOpen(false);
         return true;
       }
+      if (spaceReorderMode) {
+        setSpaceReorderMode(null);
+        return true;
+      }
       if (notesPanelOpen) {
         setNotesPanelOpen(false);
         return true;
@@ -1186,7 +1206,22 @@ export function App() {
     menu,
     noteDeleteTarget,
     notesPanelOpen,
+    spaceReorderMode,
   ]);
+
+  useEffect(() => {
+    if (!spaceReorderMode) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setSpaceReorderMode(null);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [spaceReorderMode]);
 
   const bridgeViews = useMemo<BridgeConnectionView[]>(
     () =>
@@ -1358,6 +1393,19 @@ export function App() {
   );
   const menuSupportedCommands = menuCommandsReady ? (menuRuntime?.capabilities?.commands ?? []) : [];
   const menuPaneMoveSupported = menuSupportedCommands.includes("pane.move");
+  const menuWorkspace =
+    menu?.kind === "space"
+      ? menuConnectionState?.snapshot?.workspaces.find(
+          (workspace) => workspace.workspace_id === menu.id,
+        )
+      : undefined;
+  const menuWorkspaceReorderSupported = Boolean(
+    menuWorkspace &&
+      !menuWorkspace.worktree?.is_linked_worktree &&
+      menuConnectionState?.snapshot &&
+      workspaceReorderRoots(menuConnectionState.snapshot.workspaces).length > 1 &&
+      menuSupportedCommands.includes("workspace.move_block"),
+  );
   const menuAgentPinsSupported = Boolean(
     menu &&
       menu.kind === "pane" &&
@@ -1393,6 +1441,7 @@ export function App() {
         menuPanePinned,
         menuPinLabel,
         menuNotesSupported,
+        menuWorkspaceReorderSupported,
       )
     : [];
 
@@ -3376,6 +3425,38 @@ export function App() {
     }
   }
 
+  async function reorderSpace(
+    bridgeId: BridgeId,
+    sourceWorkspaceId: string,
+    beforeWorkspaceId: string | null,
+  ) {
+    const runtime = bridge.getRuntime(bridgeId);
+    const snapshot = connectionRefs.current[bridgeId]?.snapshot;
+    const params = snapshot
+      ? workspaceMoveBlockParams(snapshot.workspaces, sourceWorkspaceId, beforeWorkspaceId)
+      : null;
+    if (
+      !runtime ||
+      !snapshot ||
+      !runtime.canConnect ||
+      runtime.capabilityState !== "ready" ||
+      !runtime.capabilities?.commands.includes("workspace.move_block")
+    ) {
+      setError("Space ordering is unavailable");
+      setSpaceReorderMode(null);
+      return;
+    }
+    if (!params) {
+      setSpaceReorderMode(null);
+      return;
+    }
+    const commands = createCommands(runtime.httpUrl);
+    await exec(runtime, () =>
+      commands.moveWorkspaceBlock(params.workspaceIds, params.beforeWorkspaceId),
+    );
+    setSpaceReorderMode(null);
+  }
+
   async function toggleAgentPin(bridgeId: BridgeId, paneId: string, pinned: boolean) {
     const runtime = bridge.getRuntime(bridgeId);
     if (
@@ -3426,6 +3507,8 @@ export function App() {
         current[bridgeId] === id ? current : { ...current, [bridgeId]: id },
       );
       setLaunchTarget({ mode: "tab", workspaceId: id, bridgeId });
+    } else if (key === "reorder" && kind === "space") {
+      setSpaceReorderMode({ bridgeId, workspaceId: id });
     } else if (key === "pin" && kind === "pane") {
       void toggleAgentPin(bridgeId, id, false);
     } else if (key === "unpin" && kind === "pane") {
@@ -3592,7 +3675,51 @@ export function App() {
           onNotesChanged={refreshNotesForBridge}
         />
       ))}
-      <aside className="sidebar" aria-label="Switcher">
+      <aside
+        className="sidebar"
+        aria-label="Switcher"
+        data-space-reorder={spaceReorderMode ? "true" : undefined}
+        onClickCapture={(event) => {
+          if (
+            spaceReorderMode &&
+            event.target instanceof Element &&
+            !event.target.closest(".space-row-shell[data-reorder-source='true']")
+          ) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }}
+        onContextMenuCapture={(event) => {
+          if (spaceReorderMode) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }}
+        onKeyDownCapture={(event) => {
+          if (!spaceReorderMode || event.key !== "Tab") {
+            return;
+          }
+          const controls = Array.from(
+            event.currentTarget.querySelectorAll<HTMLButtonElement>(
+              ".space-row-shell[data-reorder-source='true'] > .space-row:not(:disabled), " +
+                ".space-reorder-controls button:not(:disabled)",
+            ),
+          );
+          if (controls.length === 0) {
+            return;
+          }
+          event.preventDefault();
+          const currentIndex = controls.indexOf(document.activeElement as HTMLButtonElement);
+          const nextIndex = event.shiftKey
+            ? currentIndex <= 0
+              ? controls.length - 1
+              : currentIndex - 1
+            : currentIndex < 0 || currentIndex === controls.length - 1
+              ? 0
+              : currentIndex + 1;
+          controls[nextIndex]?.focus();
+        }}
+      >
         <Switcher
           bridgeViews={bridgeViews}
           selectedBridgeId={selectedRuntime?.id ?? null}
@@ -3620,6 +3747,8 @@ export function App() {
           combineMatchingWorkspaceNames={combineMatchingWorkspaceNames}
           collapsedSidebarGroupKeys={collapsedSidebarGroupKeys}
           spaceGroup={spaceGroup}
+          spaceReorderMode={spaceReorderMode}
+          spaceReorderBusy={busy}
           multiHostSpaceSelection={multiHostSpaceSelection}
           activeSpace={activeSpace}
           activeWorkspacesByBridgeId={activeWorkspacesByBridgeId}
@@ -3636,6 +3765,10 @@ export function App() {
           onToggleCollapsedGroup={toggleCollapsedSidebarGroup}
           onSetCollapsedGroups={setVisibleSidebarGroupsCollapsed}
           onSpaceGroup={setSpaceGroup}
+          onCancelSpaceReorder={() => setSpaceReorderMode(null)}
+          onReorderSpace={(bridgeId, workspaceId, beforeWorkspaceId) =>
+            void reorderSpace(bridgeId, workspaceId, beforeWorkspaceId)
+          }
           onSelectBridge={setSelectedBridgeId}
           onSelectSpace={selectSpace}
           onSelectTab={selectTab}
@@ -5752,6 +5885,8 @@ function Switcher({
   combineMatchingWorkspaceNames,
   collapsedSidebarGroupKeys,
   spaceGroup,
+  spaceReorderMode,
+  spaceReorderBusy,
   multiHostSpaceSelection,
   activeSpace,
   activeWorkspacesByBridgeId,
@@ -5768,6 +5903,8 @@ function Switcher({
   onToggleCollapsedGroup,
   onSetCollapsedGroups,
   onSpaceGroup,
+  onCancelSpaceReorder,
+  onReorderSpace,
   onSelectBridge,
   onSelectSpace,
   onSelectTab,
@@ -5805,6 +5942,8 @@ function Switcher({
   combineMatchingWorkspaceNames: boolean;
   collapsedSidebarGroupKeys: ReadonlySet<string>;
   spaceGroup: SpaceGroup;
+  spaceReorderMode: SpaceReorderMode | null;
+  spaceReorderBusy: boolean;
   multiHostSpaceSelection: boolean;
   activeSpace: WorkspaceInfo | null;
   activeWorkspacesByBridgeId: Record<string, string>;
@@ -5821,6 +5960,12 @@ function Switcher({
   onToggleCollapsedGroup: (key: string) => void;
   onSetCollapsedGroups: (keys: readonly string[], collapsed: boolean) => void;
   onSpaceGroup: (group: SpaceGroup) => void;
+  onCancelSpaceReorder: () => void;
+  onReorderSpace: (
+    bridgeId: BridgeId,
+    workspaceId: string,
+    beforeWorkspaceId: string | null,
+  ) => void;
   onSelectBridge: (bridgeId: BridgeId) => void;
   onSelectSpace: (bridgeId: BridgeId, workspaceId: string) => void;
   onSelectTab: (bridgeId: BridgeId, tabId: string) => void;
@@ -5843,6 +5988,11 @@ function Switcher({
 }) {
   const [optionsMenu, setOptionsMenu] = useState<{ x: number; y: number } | null>(null);
   const [spaceOptionsMenu, setSpaceOptionsMenu] = useState<{ x: number; y: number } | null>(null);
+  const [spaceDragTarget, setSpaceDragTarget] = useState<string | null | undefined>(undefined);
+  const spaceDragRef = useRef<SpaceDragState | null>(null);
+  const spaceListRef = useRef<HTMLDivElement | null>(null);
+  const spaceRowRefs = useRef(new Map<string, HTMLDivElement>());
+  const spaceReorderCardRef = useRef<HTMLButtonElement | null>(null);
   const selectedBridgeView = selectedBridgeId
     ? (bridgeViews.find((view) => view.runtime.id === selectedBridgeId) ?? null)
     : null;
@@ -5881,6 +6031,34 @@ function Switcher({
       };
     });
   });
+  const reorderBridgeView = spaceReorderMode
+    ? (hostBridgeViews.find((view) => view.runtime.id === spaceReorderMode.bridgeId) ?? null)
+    : null;
+  const reorderWorkspaces = reorderBridgeView?.snapshot?.workspaces ?? [];
+  const reorderBlockIds = useMemo(
+    () =>
+      spaceReorderMode
+        ? workspaceReorderBlockIds(reorderWorkspaces, spaceReorderMode.workspaceId)
+        : [],
+    [reorderWorkspaces, spaceReorderMode],
+  );
+  const reorderBlockIdSet = useMemo(() => new Set(reorderBlockIds), [reorderBlockIds]);
+  const reorderRootIds = useMemo(
+    () => workspaceReorderRoots(reorderWorkspaces).map((workspace) => workspace.workspace_id),
+    [reorderWorkspaces],
+  );
+  const reorderSourceRootId = spaceReorderMode?.workspaceId ?? null;
+  const remainingReorderRootIds = useMemo(
+    () => reorderRootIds.filter((workspaceId) => workspaceId !== reorderSourceRootId),
+    [reorderRootIds, reorderSourceRootId],
+  );
+  const finalReorderWorkspaceId = useMemo(() => {
+    const finalRootId = remainingReorderRootIds.at(-1);
+    if (!finalRootId) {
+      return null;
+    }
+    return workspaceReorderBlockIds(reorderWorkspaces, finalRootId).at(-1) ?? finalRootId;
+  }, [remainingReorderRootIds, reorderWorkspaces]);
   const canGroupSpacesByHost = shouldOfferSpaceHostGrouping(hostScope, hostBridgeViews.length);
   const effectiveSpaceGroup = resolveEffectiveSpaceGroup(
     spaceGroup,
@@ -6142,6 +6320,126 @@ function Switcher({
       setSpaceOptionsMenu(null);
     }
   }, [canGroupSpacesByHost, spaceOptionsMenu]);
+
+  useEffect(() => {
+    if (!spaceReorderMode) {
+      spaceDragRef.current = null;
+      setSpaceDragTarget(undefined);
+      return;
+    }
+    if (!reorderBridgeView?.snapshot || reorderBlockIds.length === 0) {
+      onCancelSpaceReorder();
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => spaceReorderCardRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [onCancelSpaceReorder, reorderBlockIds.length, reorderBridgeView, spaceReorderMode]);
+
+  const rowRefKey = (bridgeId: BridgeId, workspaceId: string) =>
+    `${bridgeId}:${workspaceId}`;
+  const setSpaceRowRef = (
+    bridgeId: BridgeId,
+    workspaceId: string,
+    node: HTMLDivElement | null,
+  ) => {
+    const key = rowRefKey(bridgeId, workspaceId);
+    if (node) {
+      spaceRowRefs.current.set(key, node);
+    } else {
+      spaceRowRefs.current.delete(key);
+    }
+  };
+  const reorderTargetAtY = (clientY: number) => {
+    if (!spaceReorderMode) {
+      return null;
+    }
+    for (const rootId of remainingReorderRootIds) {
+      const blockIds = workspaceReorderBlockIds(reorderWorkspaces, rootId);
+      const firstRow = spaceRowRefs.current.get(rowRefKey(spaceReorderMode.bridgeId, rootId));
+      const lastRow = spaceRowRefs.current.get(
+        rowRefKey(spaceReorderMode.bridgeId, blockIds.at(-1) ?? rootId),
+      );
+      if (firstRow && lastRow) {
+        const firstRect = firstRow.getBoundingClientRect();
+        const lastRect = lastRow.getBoundingClientRect();
+        if (clientY < (firstRect.top + lastRect.bottom) / 2) {
+          return rootId;
+        }
+      }
+    }
+    return null;
+  };
+  const updateSpaceDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    const drag = spaceDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) {
+      return;
+    }
+    const listRect = spaceListRef.current?.getBoundingClientRect();
+    if (listRect) {
+      const edge = 42;
+      if (event.clientY < listRect.top + edge) {
+        spaceListRef.current?.scrollBy({ top: -12 });
+      } else if (event.clientY > listRect.bottom - edge) {
+        spaceListRef.current?.scrollBy({ top: 12 });
+      }
+    }
+    const beforeWorkspaceId = reorderTargetAtY(event.clientY);
+    const moved = drag.moved || Math.abs(event.clientY - drag.startY) > 5;
+    spaceDragRef.current = { ...drag, beforeWorkspaceId, moved };
+    setSpaceDragTarget(moved ? beforeWorkspaceId : undefined);
+  };
+  const finishSpaceDrag = (event: ReactPointerEvent<HTMLButtonElement>, commit: boolean) => {
+    const drag = spaceDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId || !spaceReorderMode) {
+      return;
+    }
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    spaceDragRef.current = null;
+    setSpaceDragTarget(undefined);
+    if (commit && drag.moved) {
+      onReorderSpace(
+        spaceReorderMode.bridgeId,
+        spaceReorderMode.workspaceId,
+        drag.beforeWorkspaceId,
+      );
+    }
+  };
+  const beginSpaceDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (
+      !spaceReorderMode ||
+      spaceReorderBusy ||
+      (event.button !== 0 && event.pointerType !== "touch")
+    ) {
+      return;
+    }
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    spaceDragRef.current = {
+      pointerId: event.pointerId,
+      startY: event.clientY,
+      beforeWorkspaceId: reorderTargetAtY(event.clientY),
+      moved: false,
+    };
+  };
+  const moveSpaceWithKeyboard = (direction: WorkspaceReorderDirection) => {
+    if (!spaceReorderMode || spaceReorderBusy) {
+      return;
+    }
+    const destination = workspaceReorderDestination(
+      reorderWorkspaces,
+      spaceReorderMode.workspaceId,
+      direction,
+    );
+    if (destination !== undefined) {
+      onReorderSpace(
+        spaceReorderMode.bridgeId,
+        spaceReorderMode.workspaceId,
+        destination,
+      );
+    }
+  };
 
   let agentPaneIndex = 0;
   let paneIndex = 0;
@@ -6596,8 +6894,20 @@ function Switcher({
     entry: (typeof spaceEntries)[number],
     index: number,
     showBridgeLabel: boolean,
-  ) => (
-    <SpaceRow
+  ) => {
+    const workspaceId = entry.workspace.workspace_id;
+    const bridgeId = entry.view.runtime.id;
+    const reorderMember =
+      spaceReorderMode?.bridgeId === bridgeId && reorderBlockIdSet.has(workspaceId);
+    const reorderSource = reorderMember && workspaceId === spaceReorderMode?.workspaceId;
+    const dropBefore =
+      spaceReorderMode?.bridgeId === bridgeId && spaceDragTarget === workspaceId;
+    const dropAfter =
+      spaceReorderMode?.bridgeId === bridgeId &&
+      spaceDragTarget === null &&
+      finalReorderWorkspaceId === workspaceId;
+    return (
+      <SpaceRow
       key={`${entry.view.runtime.id}:${entry.workspace.workspace_id}`}
       index={index}
       workspace={entry.workspace}
@@ -6605,20 +6915,55 @@ function Switcher({
       agentCount={entry.workspacePanes.filter(isAgentPane).length}
       active={entry.active}
       attention={countAttention(entry.workspacePanes)}
-      onSelect={() => onSelectSpace(entry.view.runtime.id, entry.workspace.workspace_id)}
+      reorderMember={reorderMember}
+      reorderSource={reorderSource}
+      reorderBusy={spaceReorderBusy}
+      dropBefore={dropBefore}
+      dropAfter={dropAfter}
+      rowRef={(node) => setSpaceRowRef(bridgeId, workspaceId, node)}
+      reorderCardRef={reorderSource ? spaceReorderCardRef : undefined}
+      onSelect={() => {
+        if (!spaceReorderMode) {
+          onSelectSpace(bridgeId, workspaceId);
+        }
+      }}
       onMenu={(x, y) =>
-        onScopedMenu(
-          "space",
-          entry.view.runtime.id,
-          entry.workspace.workspace_id,
-          entry.workspace.label,
-          x,
-          y,
-          canClearWorkspaceName(entry.workspace, entry.workspacePanes),
-        )
+        !spaceReorderMode
+          ? onScopedMenu(
+              "space",
+              bridgeId,
+              workspaceId,
+              entry.workspace.label,
+              x,
+              y,
+              canClearWorkspaceName(entry.workspace, entry.workspacePanes),
+            )
+          : undefined
       }
+      onReorderPointerDown={beginSpaceDrag}
+      onReorderPointerMove={updateSpaceDrag}
+      onReorderPointerUp={(event) => finishSpaceDrag(event, true)}
+      onReorderPointerCancel={(event) => finishSpaceDrag(event, false)}
+      onReorderKeyDown={(event) => {
+        const directions: Partial<Record<string, WorkspaceReorderDirection>> = {
+          ArrowUp: "up",
+          ArrowDown: "down",
+          Home: "top",
+          End: "bottom",
+        };
+        const direction = directions[event.key];
+        if (direction) {
+          event.preventDefault();
+          moveSpaceWithKeyboard(direction);
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          onCancelSpaceReorder();
+        }
+      }}
+      onCancelReorder={onCancelSpaceReorder}
     />
-  );
+    );
+  };
 
   return (
     <>
@@ -6739,7 +7084,7 @@ function Switcher({
         </button>
       </div>
 
-      <div className="list">
+      <div className="list" ref={spaceListRef}>
         {!hasListSnapshot ? (
           <div className="empty">
             <strong>
@@ -6770,7 +7115,7 @@ function Switcher({
           <>
             {/* SPACES ---------------------------------------------------- */}
             {scope === "space" && hostBridgeViews.some((view) => view.snapshot) ? (
-            <section className="sec">
+            <section className="sec" data-sidebar-section="spaces">
               <div className="sec-head">
                 <span className="sec-label">spaces</span>
                 <span className="sec-rule" />
@@ -6851,7 +7196,7 @@ function Switcher({
             {/* PANES ----------------------------------------------------- */}
             {notesViewActive ||
             (hostScope === "all" ? hasListSnapshot : snapshot && snapshot.workspaces.length > 0) ? (
-            <section className="sec">
+            <section className="sec" data-sidebar-section="content">
               <div className="sec-head">
                 <span className="sec-label">
                   {sidebarView === "agents"
@@ -8224,8 +8569,21 @@ function SpaceRow({
   active,
   attention,
   index,
+  reorderMember,
+  reorderSource,
+  reorderBusy,
+  dropBefore,
+  dropAfter,
+  rowRef,
+  reorderCardRef,
   onSelect,
   onMenu,
+  onReorderPointerDown,
+  onReorderPointerMove,
+  onReorderPointerUp,
+  onReorderPointerCancel,
+  onReorderKeyDown,
+  onCancelReorder,
 }: {
   workspace: WorkspaceInfo;
   bridgeLabel?: string;
@@ -8233,27 +8591,75 @@ function SpaceRow({
   active: boolean;
   attention: number;
   index: number;
+  reorderMember: boolean;
+  reorderSource: boolean;
+  reorderBusy: boolean;
+  dropBefore: boolean;
+  dropAfter: boolean;
+  rowRef: (node: HTMLDivElement | null) => void;
+  reorderCardRef?: MutableRefObject<HTMLButtonElement | null>;
   onSelect: () => void;
   onMenu: (x: number, y: number) => void;
+  onReorderPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+  onReorderPointerMove: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+  onReorderPointerUp: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+  onReorderPointerCancel: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+  onReorderKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
+  onCancelReorder: () => void;
 }) {
   const press = useLongPress(onMenu, onSelect);
   return (
-    <button
-      className="space-row"
-      type="button"
-      data-active={active}
-      style={{ animationDelay: `${Math.min(index, 14) * 22}ms` }}
-      {...press}
+    <div
+      ref={rowRef}
+      className="space-row-shell"
+      data-reorder-member={reorderMember ? "true" : undefined}
+      data-reorder-source={reorderSource ? "true" : undefined}
+      data-drop-before={dropBefore ? "true" : undefined}
+      data-drop-after={dropAfter ? "true" : undefined}
     >
-      <span className="dot" data-status={workspace.agent_status} />
-      <span className="space-body">
-        <span className="space-name">{workspace.label}</span>
-        <span className="space-sub mono">
-          {spaceSubtitle(workspace, bridgeLabel, agentCount)}
+      <button
+        ref={reorderCardRef}
+        className="space-row"
+        type="button"
+        data-active={active}
+        data-reorder-drag={reorderSource ? "true" : undefined}
+        disabled={reorderSource && reorderBusy}
+        aria-label={reorderSource ? `Move ${workspace.label}` : undefined}
+        style={{ animationDelay: `${Math.min(index, 14) * 22}ms` }}
+        {...(reorderSource
+          ? {
+              onPointerDown: onReorderPointerDown,
+              onPointerMove: onReorderPointerMove,
+              onPointerUp: onReorderPointerUp,
+              onPointerCancel: onReorderPointerCancel,
+              onKeyDown: onReorderKeyDown,
+            }
+          : press)}
+      >
+        <span className="dot" data-status={workspace.agent_status} />
+        <span className="space-body">
+          <span className="space-name">{workspace.label}</span>
+          <span className="space-sub mono">
+            {spaceSubtitle(workspace, bridgeLabel, agentCount)}
+          </span>
         </span>
-      </span>
-      {attention > 0 ? <span className="attn">{attention}</span> : null}
-    </button>
+        {attention > 0 ? <span className="attn">{attention}</span> : null}
+      </button>
+      {reorderSource ? (
+        <span className="space-reorder-controls">
+          <button
+            className="space-reorder-cancel"
+            type="button"
+            disabled={reorderBusy}
+            aria-label="Cancel moving space"
+            title="Cancel"
+            onClick={onCancelReorder}
+          >
+            <X size={15} aria-hidden="true" />
+          </button>
+        </span>
+      ) : null}
+    </div>
   );
 }
 
@@ -8789,16 +9195,21 @@ export function menuItems(
   panePinned = false,
   pinLabel: "agent" | "pane" = "pane",
   notesSupported = false,
+  workspaceReorderSupported = false,
 ): MenuItem[] {
   if (kind === "space") {
     if (!commandsReady) {
       return [];
     }
-    return [
+    const items: MenuItem[] = [
       { key: "rename", label: "Rename" },
       { key: "newtab", label: "New tab" },
-      { key: "close", label: "Close space", danger: true },
     ];
+    if (workspaceReorderSupported) {
+      items.push({ key: "reorder", label: "Move space" });
+    }
+    items.push({ key: "close", label: "Close space", danger: true });
+    return items;
   }
   if (kind === "tab") {
     if (!commandsReady) {

--- a/web/src/commands.test.ts
+++ b/web/src/commands.test.ts
@@ -52,6 +52,26 @@ describe("command helpers", () => {
     ]);
   });
 
+  it("moves workspace blocks through the atomic Herdr command", async () => {
+    const requests: unknown[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(JSON.stringify({ type: "ok" }), { status: 200 });
+    });
+
+    await commands.moveWorkspaceBlock(["space-root", "space-child"], "space-before");
+
+    expect(requests).toEqual([
+      {
+        method: "workspace.move_block",
+        params: {
+          workspace_ids: ["space-root", "space-child"],
+          before_workspace_id: "space-before",
+        },
+      },
+    ]);
+  });
+
   it("launches presets through the bridge-owned launch endpoint", async () => {
     const requests: unknown[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {

--- a/web/src/commands.ts
+++ b/web/src/commands.ts
@@ -98,6 +98,11 @@ export function createCommands(httpUrl: BridgeHttpUrl = sameOriginHttpUrl) {
       runCommand(httpUrl, "workspace.close", { workspace_id: workspaceId }),
     focusWorkspace: (workspaceId: string) =>
       runCommand(httpUrl, "workspace.focus", { workspace_id: workspaceId }),
+    moveWorkspaceBlock: (workspaceIds: string[], beforeWorkspaceId: string | null) =>
+      runCommand(httpUrl, "workspace.move_block", {
+        workspace_ids: workspaceIds,
+        before_workspace_id: beforeWorkspaceId,
+      }),
 
     createTab: (workspaceId: string, label?: string) =>
       runCommand(httpUrl, "tab.create", { workspace_id: workspaceId, focus: true, label }),

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -492,6 +492,11 @@ button {
 
 /* ------------------------------------------------------------- space row */
 
+.space-row-shell {
+  position: relative;
+  transition: opacity 140ms ease;
+}
+
 .space-row {
   display: grid;
   grid-template-columns: 14px minmax(0, 1fr) auto;
@@ -525,6 +530,104 @@ button {
   border-color: var(--line);
   background: var(--row-active);
   box-shadow: 0 0 0 1px var(--accent-soft);
+}
+
+.space-row-shell[data-reorder-member="true"] .space-row {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
+  background: color-mix(in srgb, var(--accent-soft) 44%, transparent);
+}
+
+.space-row-shell[data-reorder-source="true"] .space-row {
+  padding-right: 50px;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.sidebar[data-space-reorder="true"] button {
+  pointer-events: none;
+}
+
+.sidebar[data-space-reorder="true"]
+  .space-row-shell[data-reorder-source="true"]
+  > .space-row,
+.sidebar[data-space-reorder="true"] .space-reorder-cancel {
+  pointer-events: auto;
+}
+
+.space-row-shell[data-reorder-source="true"] > .space-row {
+  cursor: grab;
+  touch-action: none;
+}
+
+.space-row-shell[data-reorder-source="true"] > .space-row:active {
+  cursor: grabbing;
+}
+
+.sidebar[data-space-reorder="true"] .sb-head,
+.sidebar[data-space-reorder="true"] .host-scope,
+.sidebar[data-space-reorder="true"] .sidebar-mode,
+.sidebar[data-space-reorder="true"] .sidebar-scope,
+.sidebar[data-space-reorder="true"] [data-sidebar-section="spaces"] .sec-head,
+.sidebar[data-space-reorder="true"] [data-sidebar-section="spaces"] .grp-space,
+.sidebar[data-space-reorder="true"] [data-sidebar-section="content"],
+.sidebar[data-space-reorder="true"]
+  .space-row-shell:not([data-reorder-member="true"]) {
+  opacity: 0.38;
+}
+
+.space-reorder-controls {
+  position: absolute;
+  top: 50%;
+  right: 7px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  transform: translateY(-50%);
+}
+
+.space-reorder-cancel {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  color: var(--subtext0);
+  background: transparent;
+}
+
+.space-reorder-cancel:hover {
+  border-color: var(--line);
+  color: var(--text);
+  background: var(--row-hover);
+}
+
+.space-reorder-cancel:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.space-row-shell[data-drop-before="true"]::before,
+.space-row-shell[data-drop-after="true"]::after {
+  position: absolute;
+  right: 7px;
+  left: 7px;
+  z-index: 2;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 1px var(--mantle);
+  content: "";
+  pointer-events: none;
+}
+
+.space-row-shell[data-drop-before="true"]::before {
+  top: -2px;
+}
+
+.space-row-shell[data-drop-after="true"]::after {
+  bottom: -2px;
 }
 
 .space-body {
@@ -3172,6 +3275,15 @@ button {
 .app[data-touch="true"] .space-row,
 .app[data-touch="true"] .pane-row {
   padding: 11px 12px;
+}
+
+.app[data-touch="true"] .space-row-shell[data-reorder-source="true"] .space-row {
+  padding-right: 62px;
+}
+
+.app[data-touch="true"] .space-reorder-cancel {
+  width: 42px;
+  height: 42px;
 }
 
 .app[data-touch="true"] .sb-head,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -79,6 +79,18 @@
   box-sizing: border-box;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 html,
 body,
 #root {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -10,6 +10,13 @@ export type WorkspaceInfo = {
   active_tab_id: string;
   agent_status: AgentStatus;
   can_clear_name?: boolean;
+  worktree?: {
+    repo_key: string;
+    repo_name: string;
+    repo_root: string;
+    checkout_path: string;
+    is_linked_worktree: boolean;
+  };
 };
 
 export type TabInfo = {

--- a/web/src/workspaceReorder.test.ts
+++ b/web/src/workspaceReorder.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceInfo } from "./types";
+import {
+  workspaceMoveBlockParams,
+  workspaceReorderBlockIds,
+  workspaceReorderDestination,
+  workspaceReorderRoots,
+} from "./workspaceReorder";
+
+describe("workspace reordering", () => {
+  it("moves ordinary workspaces as single-item blocks", () => {
+    const workspaces = [workspace("a", 1), workspace("b", 2), workspace("c", 3)];
+
+    expect(workspaceMoveBlockParams(workspaces, "b", "a")).toEqual({
+      workspaceIds: ["b"],
+      beforeWorkspaceId: "a",
+    });
+    expect(workspaceMoveBlockParams(workspaces, "b", "c")).toBeNull();
+    expect(workspaceMoveBlockParams(workspaces, "b", null)).toEqual({
+      workspaceIds: ["b"],
+      beforeWorkspaceId: null,
+    });
+  });
+
+  it("moves a worktree root and its linked workspaces atomically", () => {
+    const workspaces = [
+      worktree("root", 1, "repo", false),
+      worktree("child-a", 2, "repo", true),
+      worktree("child-b", 3, "repo", true),
+      workspace("other", 4),
+    ];
+
+    expect(workspaceReorderRoots(workspaces).map((entry) => entry.workspace_id)).toEqual([
+      "root",
+      "other",
+    ]);
+    expect(workspaceReorderBlockIds(workspaces, "root")).toEqual([
+      "root",
+      "child-a",
+      "child-b",
+    ]);
+    expect(workspaceMoveBlockParams(workspaces, "root", null)).toEqual({
+      workspaceIds: ["root", "child-a", "child-b"],
+      beforeWorkspaceId: null,
+    });
+    expect(workspaceMoveBlockParams(workspaces, "child-a", null)).toBeNull();
+  });
+
+  it("maps keyboard movement to stable before-workspace anchors", () => {
+    const workspaces = [workspace("a", 1), workspace("b", 2), workspace("c", 3)];
+
+    expect(workspaceReorderDestination(workspaces, "b", "up")).toBe("a");
+    expect(workspaceReorderDestination(workspaces, "b", "down")).toBeNull();
+    expect(workspaceReorderDestination(workspaces, "c", "top")).toBe("a");
+    expect(workspaceReorderDestination(workspaces, "a", "bottom")).toBeNull();
+    expect(workspaceReorderDestination(workspaces, "a", "up")).toBeUndefined();
+  });
+});
+
+function workspace(workspaceId: string, number: number): WorkspaceInfo {
+  return {
+    workspace_id: workspaceId,
+    number,
+    label: workspaceId,
+    focused: false,
+    pane_count: 1,
+    tab_count: 1,
+    active_tab_id: `tab-${workspaceId}`,
+    agent_status: "unknown",
+  };
+}
+
+function worktree(
+  workspaceId: string,
+  number: number,
+  repoKey: string,
+  linked: boolean,
+): WorkspaceInfo {
+  return {
+    ...workspace(workspaceId, number),
+    worktree: {
+      repo_key: repoKey,
+      repo_name: "repo",
+      repo_root: "/repo",
+      checkout_path: `/repo/${workspaceId}`,
+      is_linked_worktree: linked,
+    },
+  };
+}

--- a/web/src/workspaceReorder.ts
+++ b/web/src/workspaceReorder.ts
@@ -1,0 +1,104 @@
+import type { WorkspaceInfo } from "./types";
+
+export type WorkspaceMoveBlockParams = {
+  workspaceIds: string[];
+  beforeWorkspaceId: string | null;
+};
+
+export type WorkspaceReorderDirection = "up" | "down" | "top" | "bottom";
+
+export function workspaceReorderRoots(workspaces: readonly WorkspaceInfo[]) {
+  return workspaces.filter((workspace) => !workspace.worktree?.is_linked_worktree);
+}
+
+export function workspaceReorderBlockIds(
+  workspaces: readonly WorkspaceInfo[],
+  sourceWorkspaceId: string,
+) {
+  const source = workspaces.find((workspace) => workspace.workspace_id === sourceWorkspaceId);
+  if (!source || source.worktree?.is_linked_worktree) {
+    return [];
+  }
+  if (!source.worktree) {
+    return [source.workspace_id];
+  }
+  return workspaces
+    .filter((workspace) => workspace.worktree?.repo_key === source.worktree?.repo_key)
+    .map((workspace) => workspace.workspace_id);
+}
+
+export function workspaceReorderRootId(
+  workspaces: readonly WorkspaceInfo[],
+  workspaceId: string,
+) {
+  const workspace = workspaces.find((candidate) => candidate.workspace_id === workspaceId);
+  if (!workspace) {
+    return null;
+  }
+  if (!workspace.worktree?.is_linked_worktree) {
+    return workspace.workspace_id;
+  }
+  return (
+    workspaces.find(
+      (candidate) =>
+        !candidate.worktree?.is_linked_worktree &&
+        candidate.worktree?.repo_key === workspace.worktree?.repo_key,
+    )?.workspace_id ?? null
+  );
+}
+
+export function workspaceMoveBlockParams(
+  workspaces: readonly WorkspaceInfo[],
+  sourceWorkspaceId: string,
+  requestedBeforeWorkspaceId: string | null,
+): WorkspaceMoveBlockParams | null {
+  const workspaceIds = workspaceReorderBlockIds(workspaces, sourceWorkspaceId);
+  if (workspaceIds.length === 0) {
+    return null;
+  }
+  const sourceRootId = workspaceReorderRootId(workspaces, sourceWorkspaceId);
+  const beforeWorkspaceId = requestedBeforeWorkspaceId
+    ? workspaceReorderRootId(workspaces, requestedBeforeWorkspaceId)
+    : null;
+  if (!sourceRootId || (requestedBeforeWorkspaceId && !beforeWorkspaceId)) {
+    return null;
+  }
+  if (beforeWorkspaceId && workspaceIds.includes(beforeWorkspaceId)) {
+    return null;
+  }
+
+  const rootIds = workspaceReorderRoots(workspaces).map((workspace) => workspace.workspace_id);
+  const sourcePosition = rootIds.indexOf(sourceRootId);
+  const remainingRootIds = rootIds.filter((workspaceId) => workspaceId !== sourceRootId);
+  const insertPosition = beforeWorkspaceId
+    ? remainingRootIds.indexOf(beforeWorkspaceId)
+    : remainingRootIds.length;
+  if (sourcePosition < 0 || insertPosition < 0 || insertPosition === sourcePosition) {
+    return null;
+  }
+
+  return { workspaceIds, beforeWorkspaceId };
+}
+
+export function workspaceReorderDestination(
+  workspaces: readonly WorkspaceInfo[],
+  sourceWorkspaceId: string,
+  direction: WorkspaceReorderDirection,
+) {
+  const sourceRootId = workspaceReorderRootId(workspaces, sourceWorkspaceId);
+  const rootIds = workspaceReorderRoots(workspaces).map((workspace) => workspace.workspace_id);
+  const sourcePosition = sourceRootId ? rootIds.indexOf(sourceRootId) : -1;
+  if (sourcePosition < 0) {
+    return undefined;
+  }
+  if (direction === "up") {
+    return sourcePosition > 0 ? rootIds[sourcePosition - 1] : undefined;
+  }
+  if (direction === "down") {
+    return sourcePosition < rootIds.length - 1 ? (rootIds[sourcePosition + 2] ?? null) : undefined;
+  }
+  if (direction === "top") {
+    return sourcePosition > 0 ? rootIds[0] : undefined;
+  }
+  return sourcePosition < rootIds.length - 1 ? null : undefined;
+}


### PR DESCRIPTION
## Breaking change

- Herdr v0.8.0 or newer with terminal protocol exactly 19 is now required. The bridge rejects the previous protocol 17 baseline and other unreviewed protocol versions instead of providing a wire fallback.

## Summary

- refresh the minimal compatibility crate and bridge integration for Herdr v0.8.0 / protocol 19, including workspace reorder events and commands
- respect Herdr's canonical workspace order and add contextual, atomic workspace/worktree-group reordering within each host
- support full-card pointer dragging on desktop and mobile (mouse, touch, and pen), persistent Move mode, keyboard controls, focus management, and screen-reader feedback
- handle the Herdr v0.8 newly-created-shell race with a bounded settling delay and selective `agent_pane_busy` backoff

## Validation

- `npm run check`
- live deployment smoke tests on `srv` and `pc`, including successful built-in Claude launches with temporary tabs removed afterward
- Keel `iterative-review` with `claude-default`, completed clean after three follow-up rounds
