### PR TITLE
Improve CJK terminal IME and local hot-reload workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,24 @@
 
 ### Added
 
+- Added `scripts/dev.sh` / `npm run dev` to run the bridge and Vite HMR frontend together for local
+  iteration (proxied `/api` and `/ws`, hot-reloading UI without rebuilding `web/dist` each change).
+
 ### Changed
 
+- Static responses now set cache headers: HTML entrypoints use `Cache-Control: no-cache`, while
+  hashed `/assets/*` files are long-cached as immutable to make production static refreshes more
+  predictable after rebuilds.
+
 ### Fixed
+
+- Fixed CJK / IME terminal typing so intermediate composition preedit (for example pinyin) is no
+  longer streamed into the PTY. Committed text is sent only after `compositionend`, the hidden
+  ghostty textarea is anchored near the terminal caret so the OS candidate window is usable, and
+  desktop focus is routed to that textarea (ghostty's host element is not editable after
+  contenteditable is removed, so IMEs previously had nothing reliable to attach to).
+- Show in-progress IME preedit (pinyin / partial CJK) as an underlined overlay at the terminal
+  caret while composing, so composition is visible before commit.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@
 
 - Added `scripts/dev.sh` / `npm run dev` to run the bridge and Vite HMR frontend together for local
   iteration (proxied `/api` and `/ws`, hot-reloading UI without rebuilding `web/dist` each change).
+  [PR #51](https://github.com/kcosr/herdr-web/pull/51)
 
 ### Changed
 
 - Static responses now set cache headers: HTML entrypoints use `Cache-Control: no-cache`, while
   hashed `/assets/*` files are long-cached as immutable to make production static refreshes more
   predictable after rebuilds.
+  [PR #51](https://github.com/kcosr/herdr-web/pull/51)
 
 ### Fixed
 
@@ -22,8 +24,10 @@
   ghostty textarea is anchored near the terminal caret so the OS candidate window is usable, and
   desktop focus is routed to that textarea (ghostty's host element is not editable after
   contenteditable is removed, so IMEs previously had nothing reliable to attach to).
+  [PR #51](https://github.com/kcosr/herdr-web/pull/51)
 - Show in-progress IME preedit (pinyin / partial CJK) as an underlined overlay at the terminal
   caret while composing, so composition is visible before commit.
+  [PR #51](https://github.com/kcosr/herdr-web/pull/51)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ npm install
 npm install --prefix web
 ```
 
+## Development Server (HMR)
+
+For day-to-day UI work, run the bridge and Vite together:
+
+```bash
+# Optional: point at a non-default Herdr socket (for example herdr-dev / protocol 19)
+HERDR_SOCKET_PATH=$HOME/.config/herdr-dev/herdr.sock npm run dev
+```
+
+Then open the Vite URL:
+
+```text
+http://127.0.0.1:5173
+```
+
+Vite proxies `/api` and `/ws` to the bridge (default `http://127.0.0.1:8787`). Frontend edits hot-reload;
+Rust bridge changes still need `npm run bridge:build` and a process restart. Production-style static
+serving continues to use `npm run build` plus `scripts/run-bridge.sh` and
+`http://127.0.0.1:8787`.
+
 ## Development Build And Test
 
 ```bash
@@ -128,6 +148,7 @@ npm run build
 Useful narrower commands:
 
 ```bash
+npm run dev
 npm run lint:web
 npm run test:web
 npm run build:web

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -14,7 +14,7 @@ use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{DefaultBodyLimit, Path as AxumPath, Query, State};
 use axum::http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
-    ACCESS_CONTROL_MAX_AGE, ACCESS_CONTROL_REQUEST_HEADERS, HOST, ORIGIN, VARY,
+    ACCESS_CONTROL_MAX_AGE, ACCESS_CONTROL_REQUEST_HEADERS, CACHE_CONTROL, HOST, ORIGIN, VARY,
 };
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
@@ -1081,6 +1081,7 @@ async fn add_security_headers(
     next: Next,
 ) -> Response {
     let cors_origin = cors_origin_header(request.headers(), &policy);
+    let request_path = request.uri().path().to_string();
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
     headers.insert(
@@ -1091,10 +1092,28 @@ async fn add_security_headers(
         HeaderName::from_static("content-security-policy"),
         content_security_policy(&policy),
     );
+    insert_static_cache_headers(headers, &request_path);
     if let Some(origin) = cors_origin {
         insert_cors_headers(headers, origin);
     }
     response
+}
+
+/// Cache policy for the static SPA: never sticky-cache HTML entrypoints; long-cache hashed assets.
+fn insert_static_cache_headers(headers: &mut HeaderMap, path: &str) {
+    if headers.contains_key(CACHE_CONTROL) {
+        return;
+    }
+    if path == "/" || path.ends_with(".html") {
+        headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+        return;
+    }
+    if path.starts_with("/assets/") {
+        headers.insert(
+            CACHE_CONTROL,
+            HeaderValue::from_static("public, max-age=31536000, immutable"),
+        );
+    }
 }
 
 async fn preflight_handler(

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "dev": "scripts/dev.sh",
     "dev:web": "npm run dev --prefix web",
     "build:web": "npm run build --prefix web",
     "test:web": "npm run test --prefix web",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Local development: bridge (API/WS) + Vite HMR frontend.
+# Frontend: http://127.0.0.1:5173  (proxies /api and /ws to the bridge)
+# Bridge:   http://127.0.0.1:8787  (also serves last web/dist build)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8787}"
+VITE_PORT="${VITE_PORT:-5173}"
+BRIDGE_BIN="${BRIDGE_BIN:-$ROOT/bridge/target/debug/herdr-web-bridge}"
+STATIC_DIR="${STATIC_DIR:-$ROOT/web/dist}"
+
+if [[ -z "${HERDR_SOCKET_PATH:-}" ]]; then
+  if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+    export HERDR_SOCKET_PATH="$XDG_CONFIG_HOME/herdr/herdr.sock"
+  elif [[ -n "${HOME:-}" ]]; then
+    export HERDR_SOCKET_PATH="$HOME/.config/herdr/herdr.sock"
+  fi
+fi
+
+if [[ ! -d "$ROOT/web/node_modules" ]]; then
+  echo "web dependencies missing; run: npm install --prefix web" >&2
+  exit 1
+fi
+
+if [[ ! -x "$BRIDGE_BIN" ]]; then
+  echo "bridge binary not found; building..."
+  npm run bridge:build --prefix "$ROOT"
+fi
+
+if [[ ! -d "$STATIC_DIR" ]]; then
+  mkdir -p "$STATIC_DIR"
+  # Minimal placeholder so ServeDir has a root; Vite serves the live UI.
+  printf '%s\n' '<!doctype html><title>herdr-web bridge</title><p>Use the Vite dev server.</p>' \
+    >"$STATIC_DIR/index.html"
+fi
+
+if [[ -n "${HERDR_SOCKET_PATH:-}" && ! -S "$HERDR_SOCKET_PATH" ]]; then
+  echo "warning: Herdr socket not found at HERDR_SOCKET_PATH=$HERDR_SOCKET_PATH" >&2
+  echo "start Herdr first, or set HERDR_SOCKET_PATH (e.g. \$HOME/.config/herdr-dev/herdr.sock)" >&2
+fi
+
+bridge_pid=""
+cleanup() {
+  if [[ -n "$bridge_pid" ]] && kill -0 "$bridge_pid" 2>/dev/null; then
+    kill "$bridge_pid" 2>/dev/null || true
+    wait "$bridge_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+echo "starting bridge on http://${HOST}:${PORT}"
+echo "  HERDR_SOCKET_PATH=${HERDR_SOCKET_PATH:-<unset>}"
+"$BRIDGE_BIN" --host "$HOST" --port "$PORT" --static-dir "$STATIC_DIR" "$@" &
+bridge_pid=$!
+
+# Give the bridge a moment to bind (or fail loudly).
+sleep 0.4
+if ! kill -0 "$bridge_pid" 2>/dev/null; then
+  wait "$bridge_pid" || true
+  exit 1
+fi
+
+export HERDR_WEB_BRIDGE="${HERDR_WEB_BRIDGE:-http://${HOST}:${PORT}}"
+echo "starting Vite HMR on http://127.0.0.1:${VITE_PORT} (proxy → $HERDR_WEB_BRIDGE)"
+echo "open the Vite URL for hot reload; rebuild web/dist only for production static serving."
+cd "$ROOT/web"
+exec npm run dev -- --port "$VITE_PORT"

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,24 @@ import "./styles.css";
 
 startNativeControls();
 
+/** Runtime marker so you can confirm the loaded bundle in DevTools: `__HERDR_WEB__`. */
+declare global {
+  interface Window {
+    __HERDR_WEB__?: {
+      features: string[];
+    };
+  }
+}
+
+window.__HERDR_WEB__ = {
+  features: [
+    "ime-composition-gate",
+    "ime-caret-anchor",
+    "focus-textarea-for-ime",
+    "ime-preedit-overlay",
+  ],
+};
+
 const root = document.getElementById("root");
 
 if (!root) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1739,23 +1739,53 @@ button {
 
 .terminal-host .ghostty-hidden-input {
   position: fixed !important;
-  left: -10000px !important;
-  top: 0 !important;
-  width: 1px !important;
-  height: 1px !important;
+  left: var(--ghostty-ime-left, -10000px) !important;
+  top: var(--ghostty-ime-top, 0px) !important;
+  width: var(--ghostty-ime-width, 1px) !important;
+  height: var(--ghostty-ime-height, 1px) !important;
   opacity: 0 !important;
   color: transparent !important;
   background: transparent !important;
   caret-color: transparent !important;
   overflow: hidden !important;
   resize: none !important;
-}
-
-.terminal-host .ghostty-hidden-input.ghostty-keyboard-input {
-  left: 1px !important;
-  top: 1px !important;
+  border: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
   pointer-events: none !important;
   z-index: 0 !important;
+}
+
+/* Keep the OS IME candidate window near the terminal caret while typing or composing. */
+.terminal-host .ghostty-hidden-input.ghostty-keyboard-input,
+.terminal-host .ghostty-hidden-input.ghostty-ime-composing {
+  left: var(--ghostty-ime-left, 1px) !important;
+  top: var(--ghostty-ime-top, 1px) !important;
+  width: var(--ghostty-ime-width, 2px) !important;
+  height: var(--ghostty-ime-height, 16px) !important;
+  z-index: 5 !important;
+}
+
+/* Visible preedit (pinyin / partial CJK) painted over the terminal caret while composing. */
+.terminal-host .ghostty-ime-preedit {
+  position: fixed;
+  z-index: 6;
+  box-sizing: border-box;
+  max-width: min(80vw, 36rem);
+  padding: 0 2px;
+  margin: 0;
+  border: 0;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--surface0) 88%, transparent);
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+  text-decoration-color: var(--blue);
+  white-space: pre;
+  pointer-events: none;
+  overflow: hidden;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--blue) 35%, transparent);
 }
 
 .terminal-file-input {

--- a/web/src/terminalImeInput.test.ts
+++ b/web/src/terminalImeInput.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  beforeInputOutput,
+  compositionCommittedOutput,
+  compositionPreeditText,
+  imeTextareaAnchor,
+  imeTextareaSizeForPreedit,
+  isImeComposingInputEvent,
+  isImeComposingKeyEvent,
+  isImeCompositionInputType,
+  keyboardEventOutput,
+  shouldHandleBeforeInputForTerminal,
+  shouldSendTextareaDeltaOnInput,
+  textareaDelta,
+} from "./terminalImeInput";
+
+describe("IME composition guards", () => {
+  it("detects composing key events including keyCode 229", () => {
+    expect(isImeComposingKeyEvent({ isComposing: true, keyCode: 65 })).toBe(true);
+    expect(isImeComposingKeyEvent({ isComposing: false, keyCode: 229 })).toBe(true);
+    expect(isImeComposingKeyEvent({ isComposing: false, keyCode: 65 })).toBe(false);
+  });
+
+  it("detects composition input types and isComposing", () => {
+    expect(isImeCompositionInputType("insertCompositionText")).toBe(true);
+    expect(isImeCompositionInputType("insertFromComposition")).toBe(true);
+    expect(isImeCompositionInputType("insertText")).toBe(false);
+    expect(
+      isImeComposingInputEvent({ isComposing: true, inputType: "insertText" }),
+    ).toBe(true);
+    expect(
+      isImeComposingInputEvent({ isComposing: false, inputType: "insertCompositionText" }),
+    ).toBe(true);
+  });
+
+  it("blocks terminal beforeinput handling during composition preedit", () => {
+    expect(
+      shouldHandleBeforeInputForTerminal({
+        isComposing: true,
+        inputType: "insertCompositionText",
+        data: "ni",
+      }),
+    ).toBe(false);
+    expect(
+      shouldHandleBeforeInputForTerminal({
+        isComposing: false,
+        inputType: "insertCompositionText",
+        data: "ni",
+      }),
+    ).toBe(false);
+    expect(
+      shouldHandleBeforeInputForTerminal({
+        isComposing: false,
+        inputType: "insertText",
+        data: "a",
+      }),
+    ).toBe(true);
+    expect(
+      shouldHandleBeforeInputForTerminal({
+        isComposing: false,
+        inputType: "insertText",
+        data: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks textarea delta flush while composing", () => {
+    expect(shouldSendTextareaDeltaOnInput(true)).toBe(false);
+    expect(shouldSendTextareaDeltaOnInput(false)).toBe(true);
+  });
+});
+
+describe("composition commit and deltas", () => {
+  it("prefers CompositionEvent.data when present", () => {
+    expect(compositionCommittedOutput("", "nihao", "你好")).toBe("你好");
+  });
+
+  it("falls back to textarea delta from the pre-composition baseline", () => {
+    expect(compositionCommittedOutput("", "你好", "")).toBe("你好");
+    expect(compositionCommittedOutput("ab", "ab你好", null)).toBe("你好");
+  });
+
+  it("returns null when composition commits nothing", () => {
+    expect(compositionCommittedOutput("", "", "")).toBe(null);
+    expect(compositionCommittedOutput("ab", "ab", null)).toBe(null);
+  });
+
+  it("extracts in-progress preedit for the caret overlay", () => {
+    expect(compositionPreeditText("", "ni", "ni")).toBe("ni");
+    expect(compositionPreeditText("", "nihao", undefined)).toBe("nihao");
+    expect(compositionPreeditText("ab", "abni", null)).toBe("ni");
+    // Empty composition data falls back to the textarea suffix.
+    expect(compositionPreeditText("", "ni", "")).toBe("ni");
+    expect(compositionPreeditText("", "", null)).toBe("");
+  });
+
+  it("grows the IME hit target with preedit length", () => {
+    expect(imeTextareaSizeForPreedit(9, 16, 0)).toEqual({ width: 9, height: 16 });
+    expect(imeTextareaSizeForPreedit(9, 16, 4)).toEqual({ width: 36, height: 16 });
+  });
+
+  it("computes simple and mid-string textarea deltas", () => {
+    expect(textareaDelta("", "hi")).toBe("hi");
+    expect(textareaDelta("hi", "hi!")).toBe("!");
+    expect(textareaDelta("abc", "adc")).toBe("\x7F\x7Fdc");
+  });
+
+  it("maps beforeinput types used by non-IME typing", () => {
+    expect(beforeInputOutput({ inputType: "insertText", data: "a" })).toBe("a");
+    expect(beforeInputOutput({ inputType: "insertLineBreak", data: null })).toBe("\r");
+    expect(beforeInputOutput({ inputType: "deleteContentBackward", data: null })).toBe("\x7F");
+    expect(beforeInputOutput({ inputType: "insertCompositionText", data: "ni" })).toBe(null);
+  });
+
+  it("maps simple keyboard keys outside composition", () => {
+    expect(
+      keyboardEventOutput({
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        key: "a",
+      }),
+    ).toBe("a");
+    expect(
+      keyboardEventOutput({
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        key: "Enter",
+      }),
+    ).toBe("\r");
+  });
+});
+
+describe("IME caret anchor", () => {
+  it("places the textarea over the cursor cell inside the viewport", () => {
+    expect(
+      imeTextareaAnchor({
+        viewportLeft: 100,
+        viewportTop: 50,
+        viewportWidth: 180,
+        viewportHeight: 64,
+        cellWidth: 9,
+        cellHeight: 16,
+        cursorCol: 2,
+        cursorRow: 1,
+        fontSizePx: 14,
+      }),
+    ).toEqual({
+      left: 118,
+      top: 66,
+      width: 9,
+      height: 16,
+      fontSizePx: 14,
+    });
+  });
+
+  it("clamps the cursor to the visible grid", () => {
+    const anchor = imeTextareaAnchor({
+      viewportLeft: 0,
+      viewportTop: 0,
+      viewportWidth: 90,
+      viewportHeight: 32,
+      cellWidth: 9,
+      cellHeight: 16,
+      cursorCol: 99,
+      cursorRow: 99,
+      fontSizePx: 12,
+    });
+    expect(anchor.left).toBe(81);
+    expect(anchor.top).toBe(16);
+  });
+});

--- a/web/src/terminalImeInput.ts
+++ b/web/src/terminalImeInput.ts
@@ -1,0 +1,208 @@
+/**
+ * Helpers for browser IME (especially CJK) on the ghostty terminal textarea.
+ *
+ * Composition must not stream intermediate preedit (pinyin, etc.) into the PTY.
+ * Only the final committed text after compositionend (or non-composition insertText)
+ * should become terminal input.
+ */
+
+export type ImeTextareaAnchor = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  fontSizePx: number;
+};
+
+/** True while an IME composition is active (keydown / input paths). */
+export function isImeComposingKeyEvent(
+  event: Pick<KeyboardEvent, "isComposing" | "keyCode">,
+): boolean {
+  return event.isComposing || event.keyCode === 229;
+}
+
+/** True for InputEvent / beforeinput while composition is in progress. */
+export function isImeComposingInputEvent(
+  event: Pick<InputEvent, "isComposing" | "inputType">,
+): boolean {
+  if (event.isComposing) {
+    return true;
+  }
+  return isImeCompositionInputType(event.inputType);
+}
+
+/** Input types that belong to IME preedit, not final terminal bytes. */
+export function isImeCompositionInputType(inputType: string): boolean {
+  return (
+    inputType === "insertCompositionText" ||
+    inputType === "deleteCompositionText" ||
+    inputType === "insertFromComposition" ||
+    inputType === "deleteByComposition"
+  );
+}
+
+/**
+ * Whether beforeinput should send bytes to the terminal immediately.
+ * Composition preedit must pass through the textarea so the OS IME can work.
+ */
+export function shouldHandleBeforeInputForTerminal(
+  event: Pick<InputEvent, "isComposing" | "inputType" | "data">,
+): boolean {
+  if (isImeComposingInputEvent(event)) {
+    return false;
+  }
+  return beforeInputOutput(event) !== null;
+}
+
+/**
+ * Whether a generic input event may flush textarea deltas to the terminal.
+ * While composing, intermediate values stay local until compositionend.
+ */
+export function shouldSendTextareaDeltaOnInput(isComposing: boolean): boolean {
+  return !isComposing;
+}
+
+/**
+ * Final committed text for a completed composition.
+ * Prefer CompositionEvent.data when present; otherwise diff against the pre-composition baseline.
+ */
+export function compositionCommittedOutput(
+  baseline: string,
+  textareaValue: string,
+  compositionData: string | null | undefined,
+): string | null {
+  if (typeof compositionData === "string" && compositionData.length > 0) {
+    return compositionData.replace(/\n/g, "\r");
+  }
+  const delta = textareaDelta(baseline, textareaValue);
+  return delta.length > 0 ? delta : null;
+}
+
+/**
+ * In-progress IME preedit (pinyin / partial CJK) for on-screen preview.
+ * Prefer CompositionEvent.data; fall back to the textarea suffix after the baseline.
+ */
+export function compositionPreeditText(
+  baseline: string,
+  textareaValue: string,
+  compositionData: string | null | undefined,
+): string {
+  // Empty string from CompositionEvent means "no data this event", not "clear preedit".
+  if (typeof compositionData === "string" && compositionData.length > 0) {
+    return compositionData;
+  }
+  if (textareaValue.startsWith(baseline)) {
+    return textareaValue.slice(baseline.length);
+  }
+  return textareaValue;
+}
+
+/** Grow the invisible IME hit target with preedit length so candidate windows stay near the caret. */
+export function imeTextareaSizeForPreedit(
+  cellWidth: number,
+  cellHeight: number,
+  preeditLength: number,
+): { width: number; height: number } {
+  const cells = Math.max(1, preeditLength > 0 ? preeditLength : 1);
+  return {
+    width: Math.max(2, Math.ceil(cellWidth) * cells),
+    height: Math.max(2, Math.ceil(cellHeight)),
+  };
+}
+
+export function beforeInputOutput(event: Pick<InputEvent, "inputType" | "data">): string | null {
+  switch (event.inputType) {
+    case "insertText":
+    case "insertReplacementText":
+    case "insertFromPaste":
+      return event.data ? event.data.replace(/\n/g, "\r") : null;
+    case "insertLineBreak":
+    case "insertParagraph":
+      return "\r";
+    case "deleteContentBackward":
+      return "\x7F";
+    case "deleteContentForward":
+      return "\x1B[3~";
+    default:
+      return null;
+  }
+}
+
+export function textareaDelta(previousValue: string, nextValue: string): string {
+  if (nextValue.startsWith(previousValue)) {
+    return nextValue.slice(previousValue.length).replace(/\n/g, "\r");
+  }
+
+  const previousChars = Array.from(previousValue);
+  const nextChars = Array.from(nextValue);
+  let commonPrefixLength = 0;
+  while (
+    commonPrefixLength < previousChars.length &&
+    commonPrefixLength < nextChars.length &&
+    previousChars[commonPrefixLength] === nextChars[commonPrefixLength]
+  ) {
+    commonPrefixLength += 1;
+  }
+
+  const deletes = "\x7F".repeat(previousChars.length - commonPrefixLength);
+  const inserts = nextChars.slice(commonPrefixLength).join("").replace(/\n/g, "\r");
+  return `${deletes}${inserts}`;
+}
+
+export function keyboardEventOutput(
+  event: Pick<KeyboardEvent, "ctrlKey" | "altKey" | "metaKey" | "key">,
+): string | null {
+  if (event.ctrlKey || event.altKey || event.metaKey) {
+    return null;
+  }
+  if (event.key.length === 1) {
+    return event.key;
+  }
+  switch (event.key) {
+    case "Enter":
+      return "\r";
+    case "Backspace":
+      return "\x7F";
+    case "Delete":
+      return "\x1B[3~";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Compute a fixed-position rect for the hidden textarea so the OS IME candidate
+ * window anchors near the terminal caret instead of off-screen.
+ */
+export function imeTextareaAnchor(options: {
+  viewportLeft: number;
+  viewportTop: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  cellWidth: number;
+  cellHeight: number;
+  cursorCol: number;
+  cursorRow: number;
+  fontSizePx: number;
+}): ImeTextareaAnchor {
+  const cellWidth = Math.max(1, options.cellWidth);
+  const cellHeight = Math.max(1, options.cellHeight);
+  const maxCol = Math.max(0, Math.floor(options.viewportWidth / cellWidth) - 1);
+  const maxRow = Math.max(0, Math.floor(options.viewportHeight / cellHeight) - 1);
+  const col = clampInteger(options.cursorCol, 0, maxCol);
+  const row = clampInteger(options.cursorRow, 0, maxRow);
+  return {
+    left: options.viewportLeft + col * cellWidth,
+    top: options.viewportTop + row * cellHeight,
+    width: cellWidth,
+    height: cellHeight,
+    fontSizePx: Math.max(1, options.fontSizePx),
+  };
+}
+
+function clampInteger(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(max, Math.max(min, Math.trunc(value)));
+}

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -27,6 +27,18 @@ import type {
   MobileTouchSelectionEndpointTimeoutMs,
 } from "./mobileTerminalPrefs";
 import { DEFAULT_TERMINAL_FONT_SIZE_PX } from "./terminalPrefs";
+import {
+  beforeInputOutput,
+  compositionCommittedOutput,
+  compositionPreeditText,
+  imeTextareaAnchor,
+  imeTextareaSizeForPreedit,
+  isImeComposingKeyEvent,
+  keyboardEventOutput,
+  shouldHandleBeforeInputForTerminal,
+  shouldSendTextareaDeltaOnInput,
+  textareaDelta,
+} from "./terminalImeInput";
 
 const TERMINAL_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace';
@@ -188,6 +200,9 @@ export class GhosttyRenderer implements TerminalRenderer {
     terminal.loadAddon(fitAddon);
     terminal.open(container);
     terminal.attachCustomKeyEventHandler((event) => {
+      if (isImeComposingKeyEvent(event)) {
+        return false;
+      }
       const output = customKeyboardEventOutput(event);
       if (!output) {
         return false;
@@ -201,6 +216,8 @@ export class GhosttyRenderer implements TerminalRenderer {
     });
     terminal.textarea?.blur();
     container.blur();
+    // Ghostty marks the host contenteditable for a11y/focus; that fights IME and
+    // injects text nodes. Keep input on the dedicated textarea instead.
     container.removeAttribute("contenteditable");
     terminal.renderer?.getCanvas().style.setProperty("background-color", "#11111b");
     terminal.renderer?.getCanvas().style.setProperty("image-rendering", "auto");
@@ -208,6 +225,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     this.#fitAddon = fitAddon;
     this.#installScrollHandlers();
     this.#installMobileInputBridge();
+    this.#installTerminalFocusRedirect();
     return this.fit();
   }
 
@@ -273,21 +291,31 @@ export class GhosttyRenderer implements TerminalRenderer {
   }
 
   focus() {
-    this.#terminal?.focus();
+    // Ghostty's Terminal.focus() targets the host element. That is fine for Latin
+    // keydown, but CJK IMEs need a real editable control — use the hidden textarea.
+    this.focusTextInput();
   }
 
   focusTextInput() {
-    const textarea = this.#terminal?.textarea;
-    if (!textarea) {
+    const terminal = this.#terminal;
+    const textarea = terminal?.textarea;
+    if (!textarea || !terminal) {
       this.#terminal?.focus();
       return;
     }
     this.#textInputTapGraceUntil = performance.now() + TERMINAL_TEXT_INPUT_TAP_GRACE_MS;
+    positionGhosttyTextareaForInput(textarea, terminal);
     textarea.classList.add("ghostty-keyboard-input");
+    // Prefer the textarea over the host element so composition events land where our
+    // IME bridge listens (and where the OS can attach a candidate window).
     textarea.focus({ preventScroll: true });
     window.setTimeout(() => {
-      if (textarea.isConnected) {
-        textarea.classList.add("ghostty-keyboard-input");
+      if (!textarea.isConnected) {
+        return;
+      }
+      positionGhosttyTextareaForInput(textarea, this.#terminal);
+      textarea.classList.add("ghostty-keyboard-input");
+      if (document.activeElement !== textarea) {
         textarea.focus({ preventScroll: true });
       }
     }, 0);
@@ -1085,19 +1113,119 @@ export class GhosttyRenderer implements TerminalRenderer {
     };
   }
 
+  /**
+   * If focus lands on the terminal host/canvas (ghostty default), pull it onto the
+   * hidden textarea so OS IMEs have an editable target.
+   */
+  #installTerminalFocusRedirect() {
+    const terminal = this.#requireTerminal();
+    const container = this.#container;
+    const textarea = terminal.textarea;
+    if (!container || !textarea) {
+      return;
+    }
+    const onFocusIn = (event: FocusEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node) || !container.contains(target)) {
+        return;
+      }
+      if (target === textarea) {
+        positionGhosttyTextareaForInput(textarea, terminal);
+        textarea.classList.add("ghostty-keyboard-input");
+        return;
+      }
+      // Mobile keeps a separate command box; don't steal focus from it when the
+      // host receives incidental focus. Desktop has no tap-focus handler.
+      if (this.#tapFocusHandler) {
+        return;
+      }
+      // Host element, canvas, or other non-textarea focus inside the terminal.
+      this.focusTextInput();
+    };
+    const onPointerDown = () => {
+      if (this.#tapFocusHandler) {
+        return;
+      }
+      // Clicking the canvas does not always move DOM focus; ensure the next key
+      // and IME composition hit the textarea.
+      if (document.activeElement !== textarea) {
+        this.focusTextInput();
+      } else {
+        positionGhosttyTextareaForInput(textarea, terminal);
+      }
+    };
+    container.addEventListener("focusin", onFocusIn);
+    container.addEventListener("pointerdown", onPointerDown);
+    const previousCleanup = this.#mobileInputCleanup;
+    this.#mobileInputCleanup = () => {
+      container.removeEventListener("focusin", onFocusIn);
+      container.removeEventListener("pointerdown", onPointerDown);
+      previousCleanup?.();
+    };
+  }
+
   #installMobileInputBridge() {
     const terminal = this.#requireTerminal();
     const textarea = terminal.textarea;
-    if (!textarea) {
+    const host = this.#container;
+    if (!textarea || !host) {
       return;
     }
     textarea.classList.add("ghostty-hidden-input");
     hideGhosttyTextarea(textarea);
-    cleanupEditableArtifacts(this.#container);
+    cleanupEditableArtifacts(host);
+
+    const preeditOverlay = document.createElement("div");
+    preeditOverlay.className = "ghostty-ime-preedit";
+    preeditOverlay.setAttribute("aria-hidden", "true");
+    preeditOverlay.hidden = true;
+    host.appendChild(preeditOverlay);
 
     let lastKeydown: { data: string; time: number } | null = null;
     let processedTextareaValue = "";
+    let compositionBaseline: string | null = null;
+    const isComposing = () => compositionBaseline !== null;
+
+    const sendTerminalText = (output: string) => {
+      if (!output) {
+        return;
+      }
+      terminal.input(output, true);
+      cleanupEditableArtifacts(host);
+    };
+
+    const clearTextareaState = () => {
+      textarea.value = "";
+      processedTextareaValue = "";
+      lastKeydown = null;
+    };
+
+    const hidePreedit = () => {
+      preeditOverlay.hidden = true;
+      preeditOverlay.textContent = "";
+    };
+
+    const refreshCompositionUi = (compositionData?: string | null) => {
+      if (!isComposing()) {
+        hidePreedit();
+        positionGhosttyTextareaForInput(textarea, terminal);
+        return;
+      }
+      const baseline = compositionBaseline ?? "";
+      const preedit = compositionPreeditText(baseline, textarea.value, compositionData);
+      const metrics = terminal.renderer?.getMetrics();
+      const cellWidth = metrics?.width ?? 9;
+      const cellHeight = metrics?.height ?? 16;
+      const size = imeTextareaSizeForPreedit(cellWidth, cellHeight, Array.from(preedit).length);
+      // Anchor at the terminal caret; grow width with preedit so the OS IME stays nearby.
+      positionGhosttyTextareaForInput(textarea, terminal, size);
+      updateImePreeditOverlay(preeditOverlay, preedit, textarea, terminal);
+    };
+
     const onKeydown = (event: KeyboardEvent) => {
+      if (isImeComposingKeyEvent(event) || isComposing()) {
+        return;
+      }
       const customOutput = textareaKeyboardEventOutput(event);
       if (customOutput) {
         event.preventDefault();
@@ -1105,10 +1233,8 @@ export class GhosttyRenderer implements TerminalRenderer {
         if (typeof event.stopImmediatePropagation === "function") {
           event.stopImmediatePropagation();
         }
-        textarea.value = "";
-        processedTextareaValue = "";
-        terminal.input(customOutput, true);
-        cleanupEditableArtifacts(this.#container);
+        clearTextareaState();
+        sendTerminalText(customOutput);
         return;
       }
       const output = keyboardEventOutput(event);
@@ -1117,6 +1243,9 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
     };
     const onBeforeInput = (event: InputEvent) => {
+      if (!shouldHandleBeforeInputForTerminal(event) || isComposing()) {
+        return;
+      }
       const output = beforeInputOutput(event);
       if (!output) {
         return;
@@ -1130,18 +1259,18 @@ export class GhosttyRenderer implements TerminalRenderer {
 
       const now = performance.now();
       if (lastKeydown && lastKeydown.data === output && now - lastKeydown.time < 100) {
-        textarea.value = "";
-        processedTextareaValue = "";
-        cleanupEditableArtifacts(this.#container);
+        clearTextareaState();
+        cleanupEditableArtifacts(host);
         return;
       }
 
-      textarea.value = "";
-      processedTextareaValue = "";
-      terminal.input(output, true);
-      cleanupEditableArtifacts(this.#container);
+      clearTextareaState();
+      sendTerminalText(output);
     };
     const sendTextareaDelta = () => {
+      if (!shouldSendTextareaDeltaOnInput(isComposing())) {
+        return;
+      }
       const value = textarea.value;
       if (value === processedTextareaValue) {
         return;
@@ -1150,22 +1279,33 @@ export class GhosttyRenderer implements TerminalRenderer {
       const output = textareaDelta(processedTextareaValue, value);
       processedTextareaValue = value;
       if (output) {
-        terminal.input(output, true);
+        sendTerminalText(output);
+      } else {
+        cleanupEditableArtifacts(host);
       }
-      cleanupEditableArtifacts(this.#container);
     };
     const onInput = () => {
+      if (isComposing()) {
+        // Keep preedit local; only refresh the on-screen preview.
+        refreshCompositionUi(null);
+        return;
+      }
       sendTextareaDelta();
     };
     const onCompositionStart = (event: CompositionEvent) => {
-      processedTextareaValue = textarea.value;
+      compositionBaseline = textarea.value;
+      processedTextareaValue = compositionBaseline;
+      lastKeydown = null;
+      textarea.classList.add("ghostty-ime-composing");
+      refreshCompositionUi(event.data);
       event.stopPropagation();
       if (typeof event.stopImmediatePropagation === "function") {
         event.stopImmediatePropagation();
       }
-      cleanupEditableArtifacts(this.#container);
+      cleanupEditableArtifacts(host);
     };
     const onCompositionUpdate = (event: CompositionEvent) => {
+      refreshCompositionUi(event.data);
       event.stopPropagation();
       if (typeof event.stopImmediatePropagation === "function") {
         event.stopImmediatePropagation();
@@ -1176,14 +1316,31 @@ export class GhosttyRenderer implements TerminalRenderer {
       if (typeof event.stopImmediatePropagation === "function") {
         event.stopImmediatePropagation();
       }
-      sendTextareaDelta();
-      textarea.value = "";
-      processedTextareaValue = "";
-      cleanupEditableArtifacts(this.#container);
+      const baseline = compositionBaseline ?? "";
+      compositionBaseline = null;
+      textarea.classList.remove("ghostty-ime-composing");
+      hidePreedit();
+      const output = compositionCommittedOutput(baseline, textarea.value, event.data);
+      clearTextareaState();
+      if (output) {
+        sendTerminalText(output);
+      } else {
+        cleanupEditableArtifacts(host);
+      }
+      // Keep the caret near the terminal cursor for the next keystroke / mobile keyboard.
+      if (document.activeElement === textarea) {
+        positionGhosttyTextareaForInput(textarea, terminal);
+      } else {
+        hideGhosttyTextarea(textarea);
+      }
     };
     const onBlur = () => {
       textarea.classList.remove("ghostty-keyboard-input");
+      textarea.classList.remove("ghostty-ime-composing");
+      compositionBaseline = null;
       this.#textInputTapGraceUntil = 0;
+      hidePreedit();
+      hideGhosttyTextarea(textarea);
     };
 
     textarea.addEventListener("keydown", onKeydown, { capture: true });
@@ -1193,6 +1350,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     textarea.addEventListener("compositionupdate", onCompositionUpdate, { capture: true });
     textarea.addEventListener("compositionend", onCompositionEnd, { capture: true });
     textarea.addEventListener("blur", onBlur);
+    const previousCleanup = this.#mobileInputCleanup;
     this.#mobileInputCleanup = () => {
       textarea.removeEventListener("keydown", onKeydown, { capture: true });
       textarea.removeEventListener("beforeinput", onBeforeInput, { capture: true });
@@ -1201,6 +1359,8 @@ export class GhosttyRenderer implements TerminalRenderer {
       textarea.removeEventListener("compositionupdate", onCompositionUpdate, { capture: true });
       textarea.removeEventListener("compositionend", onCompositionEnd, { capture: true });
       textarea.removeEventListener("blur", onBlur);
+      preeditOverlay.remove();
+      previousCleanup?.();
     };
   }
 }
@@ -1216,6 +1376,110 @@ function hideGhosttyTextarea(textarea: HTMLTextAreaElement) {
   textarea.style.background = "transparent";
   textarea.style.caretColor = "transparent";
   textarea.style.overflow = "hidden";
+  textarea.style.fontSize = "";
+  textarea.style.lineHeight = "";
+  textarea.style.zIndex = "";
+  textarea.style.setProperty("--ghostty-ime-left", "-10000px");
+  textarea.style.setProperty("--ghostty-ime-top", "0px");
+  textarea.style.setProperty("--ghostty-ime-width", "1px");
+  textarea.style.setProperty("--ghostty-ime-height", "1px");
+}
+
+function positionGhosttyTextareaForInput(
+  textarea: HTMLTextAreaElement,
+  terminal: Terminal | null | undefined,
+  sizeOverride?: { width: number; height: number },
+) {
+  if (!terminal) {
+    hideGhosttyTextarea(textarea);
+    return;
+  }
+  const canvas = terminal.renderer?.getCanvas();
+  const host = canvas ?? terminal.element;
+  const rect = host?.getBoundingClientRect();
+  const metrics = terminal.renderer?.getMetrics();
+  if (!rect || rect.width <= 0 || rect.height <= 0) {
+    // Keep the IME on-screen near the terminal even if metrics are not ready yet.
+    const width = sizeOverride?.width ?? 2;
+    const height = sizeOverride?.height ?? 16;
+    textarea.style.position = "fixed";
+    textarea.style.left = `${Math.max(1, rect?.left ?? 1)}px`;
+    textarea.style.top = `${Math.max(1, rect?.top ?? 1)}px`;
+    textarea.style.width = `${width}px`;
+    textarea.style.height = `${height}px`;
+    textarea.style.opacity = "0";
+    textarea.style.color = "transparent";
+    textarea.style.background = "transparent";
+    textarea.style.caretColor = "transparent";
+    textarea.style.overflow = "hidden";
+    textarea.style.zIndex = "5";
+    textarea.style.setProperty("--ghostty-ime-left", textarea.style.left);
+    textarea.style.setProperty("--ghostty-ime-top", textarea.style.top);
+    textarea.style.setProperty("--ghostty-ime-width", `${width}px`);
+    textarea.style.setProperty("--ghostty-ime-height", `${height}px`);
+    return;
+  }
+
+  const cursor = terminal.buffer?.active;
+  const anchor = imeTextareaAnchor({
+    viewportLeft: rect.left,
+    viewportTop: rect.top,
+    viewportWidth: rect.width,
+    viewportHeight: rect.height,
+    cellWidth: metrics?.width ?? 9,
+    cellHeight: metrics?.height ?? 16,
+    cursorCol: cursor?.cursorX ?? 0,
+    cursorRow: cursor?.cursorY ?? 0,
+    fontSizePx: terminal.options.fontSize ?? DEFAULT_TERMINAL_FONT_SIZE_PX,
+  });
+  const width = sizeOverride?.width ?? anchor.width;
+  const height = sizeOverride?.height ?? anchor.height;
+
+  textarea.style.position = "fixed";
+  textarea.style.left = `${anchor.left}px`;
+  textarea.style.top = `${anchor.top}px`;
+  textarea.style.width = `${width}px`;
+  textarea.style.height = `${height}px`;
+  textarea.style.opacity = "0";
+  textarea.style.color = "transparent";
+  textarea.style.background = "transparent";
+  textarea.style.caretColor = "transparent";
+  textarea.style.overflow = "hidden";
+  textarea.style.fontSize = `${anchor.fontSizePx}px`;
+  textarea.style.lineHeight = `${height}px`;
+  textarea.style.zIndex = "5";
+  textarea.style.setProperty("--ghostty-ime-left", `${anchor.left}px`);
+  textarea.style.setProperty("--ghostty-ime-top", `${anchor.top}px`);
+  textarea.style.setProperty("--ghostty-ime-width", `${width}px`);
+  textarea.style.setProperty("--ghostty-ime-height", `${height}px`);
+}
+
+function updateImePreeditOverlay(
+  overlay: HTMLDivElement,
+  preedit: string,
+  textarea: HTMLTextAreaElement,
+  terminal: Terminal,
+) {
+  if (!preedit) {
+    overlay.hidden = true;
+    overlay.textContent = "";
+    return;
+  }
+  const parsedFontSize = Number.parseFloat(textarea.style.fontSize || "");
+  const fontSize =
+    terminal.options.fontSize ??
+    (Number.isFinite(parsedFontSize) && parsedFontSize > 0
+      ? parsedFontSize
+      : DEFAULT_TERMINAL_FONT_SIZE_PX);
+  const lineHeight = textarea.style.height || `${Math.ceil(fontSize * 1.2)}px`;
+  overlay.hidden = false;
+  overlay.textContent = preedit;
+  overlay.style.left = textarea.style.left || "0px";
+  overlay.style.top = textarea.style.top || "0px";
+  overlay.style.fontSize = `${fontSize}px`;
+  overlay.style.lineHeight = lineHeight;
+  overlay.style.minHeight = lineHeight;
+  overlay.style.fontFamily = TERMINAL_FONT_FAMILY;
 }
 
 function isGhosttyDisposedError(error: unknown) {
@@ -1230,63 +1494,6 @@ function cleanupEditableArtifacts(container: HTMLElement | null) {
     if (node.nodeType === Node.TEXT_NODE) {
       node.remove();
     }
-  }
-}
-
-function beforeInputOutput(event: InputEvent) {
-  switch (event.inputType) {
-    case "insertText":
-    case "insertReplacementText":
-      return event.data ? event.data.replace(/\n/g, "\r") : null;
-    case "insertLineBreak":
-    case "insertParagraph":
-      return "\r";
-    case "deleteContentBackward":
-      return "\x7F";
-    case "deleteContentForward":
-      return "\x1B[3~";
-    default:
-      return null;
-  }
-}
-
-function textareaDelta(previousValue: string, nextValue: string) {
-  if (nextValue.startsWith(previousValue)) {
-    return nextValue.slice(previousValue.length).replace(/\n/g, "\r");
-  }
-
-  const previousChars = Array.from(previousValue);
-  const nextChars = Array.from(nextValue);
-  let commonPrefixLength = 0;
-  while (
-    commonPrefixLength < previousChars.length &&
-    commonPrefixLength < nextChars.length &&
-    previousChars[commonPrefixLength] === nextChars[commonPrefixLength]
-  ) {
-    commonPrefixLength += 1;
-  }
-
-  const deletes = "\x7F".repeat(previousChars.length - commonPrefixLength);
-  const inserts = nextChars.slice(commonPrefixLength).join("").replace(/\n/g, "\r");
-  return `${deletes}${inserts}`;
-}
-
-function keyboardEventOutput(event: KeyboardEvent) {
-  if (event.ctrlKey || event.altKey || event.metaKey) {
-    return null;
-  }
-  if (event.key.length === 1) {
-    return event.key;
-  }
-  switch (event.key) {
-    case "Enter":
-      return "\r";
-    case "Backspace":
-      return "\x7F";
-    case "Delete":
-      return "\x1B[3~";
-    default:
-      return null;
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix CJK / IME terminal typing so composition preedit (pinyin, etc.) stays local until commit instead of streaming into the PTY.
- Route desktop focus to the ghostty textarea (host is not editable after contenteditable is removed) and anchor it near the caret for OS candidate windows.
- Show in-progress IME preedit as an underlined overlay at the terminal caret while composing.
- Add `scripts/dev.sh` / `npm run dev` for bridge + Vite HMR, and set static cache headers (`no-cache` for HTML, long-cache for hashed `/assets/*`).

## Validation

- `npm run check` (vendor, lint, web + bridge tests, web + bridge build)
- Live smoke against Herdr `v0.8.0` / protocol `19` (`herdr-dev` socket): Chinese composition commits correctly and preedit overlay is visible

## Notes

- Changelog entries under `## [Unreleased]` will be updated with this PR number after open, per repo convention.