### PR TITLE
Add browser desktop notifications for agent attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- Added browser desktop notifications for agent attention states. Enable under Settings → Features;
+  optional per-status toggles cover blocked and done, notifications deep-link to the pane on click,
+  and an optional tab-title badge shows the count of agents needing attention.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added browser desktop notifications for agent attention states. Enable under Settings → Features;
   optional per-status toggles cover blocked and done, notifications deep-link to the pane on click,
   and an optional tab-title badge shows the count of agents needing attention.
+  [PR #52](https://github.com/kcosr/herdr-web/pull/52)
 
 ### Changed
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,6 +65,19 @@ import type { AgentPinsListResponse } from "./agentPins";
 import { applyActivityMessage, parseActivityEventData, replayActivityMessages } from "./activity";
 import type { ActivityLogEntry } from "./activity";
 import { BackendSettingsDialog } from "./BackendSettingsDialog";
+import {
+  countAttentionPanes,
+  DEFAULT_BROWSER_NOTIFICATION_PREFS,
+  DEFAULT_DOCUMENT_TITLE,
+  documentTitleWithBadge,
+  parseBrowserDocumentBadge,
+  parseBrowserNotificationEnabled,
+  parseBrowserNotifyOnBlocked,
+  parseBrowserNotifyOnDone,
+  requestBrowserNotificationPermission,
+  showAgentStatusNotification,
+} from "./browserNotifications";
+import type { BrowserNotificationTarget } from "./browserNotifications";
 import { useBridge } from "./bridge";
 import type { BridgeId, BridgeRuntime } from "./bridge";
 import { createCommands, createdPaneId } from "./commands";
@@ -179,6 +192,7 @@ import type {
   Snapshot,
   TabInfo,
   WorkspaceInfo,
+  PaneAgentStatusChangedMessage,
 } from "./types";
 import {
   workspaceMoveBlockParams,
@@ -414,6 +428,10 @@ type DisplayPrefs = {
   mobileKeyboardHideRefit: boolean;
   mobileCommandExpandingInput: boolean;
   mobileCommandEnterNewline: boolean;
+  browserNotificationsEnabled: boolean;
+  browserNotifyOnBlocked: boolean;
+  browserNotifyOnDone: boolean;
+  browserDocumentBadge: boolean;
 };
 type SharedNavigationPrefs = {
   selectedBridgeId: BridgeId | null;
@@ -477,6 +495,10 @@ function readDisplayPrefs(): DisplayPrefs {
     mobileKeyboardHideRefit: DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
     mobileCommandExpandingInput: DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT,
     mobileCommandEnterNewline: DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
+    browserNotificationsEnabled: DEFAULT_BROWSER_NOTIFICATION_PREFS.enabled,
+    browserNotifyOnBlocked: DEFAULT_BROWSER_NOTIFICATION_PREFS.notifyOnBlocked,
+    browserNotifyOnDone: DEFAULT_BROWSER_NOTIFICATION_PREFS.notifyOnDone,
+    browserDocumentBadge: DEFAULT_BROWSER_NOTIFICATION_PREFS.documentBadge,
   };
   try {
     const raw = window.localStorage.getItem(DISPLAY_PREFS_KEY);
@@ -681,6 +703,22 @@ function parseDisplayPrefsValue(
     ),
     mobileCommandEnterNewline: parseMobileCommandEnterNewline(
       parsed.mobileCommandEnterNewline,
+    ),
+    browserNotificationsEnabled: parseBrowserNotificationEnabled(
+      parsed.browserNotificationsEnabled,
+      fallback.browserNotificationsEnabled,
+    ),
+    browserNotifyOnBlocked: parseBrowserNotifyOnBlocked(
+      parsed.browserNotifyOnBlocked,
+      fallback.browserNotifyOnBlocked,
+    ),
+    browserNotifyOnDone: parseBrowserNotifyOnDone(
+      parsed.browserNotifyOnDone,
+      fallback.browserNotifyOnDone,
+    ),
+    browserDocumentBadge: parseBrowserDocumentBadge(
+      parsed.browserDocumentBadge,
+      fallback.browserDocumentBadge,
     ),
   };
 }
@@ -1070,6 +1108,27 @@ export function App() {
   const [mobileCommandEnterNewline, setMobileCommandEnterNewline] = useState(
     initialPrefs.mobileCommandEnterNewline,
   );
+  const [browserNotificationsEnabled, setBrowserNotificationsEnabled] = useState(
+    initialPrefs.browserNotificationsEnabled,
+  );
+  const [browserNotifyOnBlocked, setBrowserNotifyOnBlocked] = useState(
+    initialPrefs.browserNotifyOnBlocked,
+  );
+  const [browserNotifyOnDone, setBrowserNotifyOnDone] = useState(
+    initialPrefs.browserNotifyOnDone,
+  );
+  const [browserDocumentBadge, setBrowserDocumentBadge] = useState(
+    initialPrefs.browserDocumentBadge,
+  );
+  const browserNotificationPrefsRef = useRef({
+    enabled: initialPrefs.browserNotificationsEnabled,
+    notifyOnBlocked: initialPrefs.browserNotifyOnBlocked,
+    notifyOnDone: initialPrefs.browserNotifyOnDone,
+    documentBadge: initialPrefs.browserDocumentBadge,
+  });
+  const openPaneFromNotificationRef = useRef<(target: BrowserNotificationTarget) => void>(
+    () => undefined,
+  );
   const [launchTarget, setLaunchTarget] = useState<ScopedLaunchTarget | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -1174,6 +1233,10 @@ export function App() {
       setMobileKeyboardHideRefit(prefs.mobileKeyboardHideRefit);
       setMobileCommandExpandingInput(prefs.mobileCommandExpandingInput);
       setMobileCommandEnterNewline(prefs.mobileCommandEnterNewline);
+      setBrowserNotificationsEnabled(prefs.browserNotificationsEnabled);
+      setBrowserNotifyOnBlocked(prefs.browserNotifyOnBlocked);
+      setBrowserNotifyOnDone(prefs.browserNotifyOnDone);
+      setBrowserDocumentBadge(prefs.browserDocumentBadge);
       setDisplayPrefsLoaded(true);
       },
     );
@@ -1716,6 +1779,10 @@ export function App() {
       mobileKeyboardHideRefit,
       mobileCommandExpandingInput,
       mobileCommandEnterNewline,
+      browserNotificationsEnabled,
+      browserNotifyOnBlocked,
+      browserNotifyOnDone,
+      browserDocumentBadge,
     });
   }, [
     displayPrefsLoaded,
@@ -1751,6 +1818,24 @@ export function App() {
     mobileKeyboardHideRefit,
     mobileCommandExpandingInput,
     mobileCommandEnterNewline,
+    browserNotificationsEnabled,
+    browserNotifyOnBlocked,
+    browserNotifyOnDone,
+    browserDocumentBadge,
+  ]);
+
+  useEffect(() => {
+    browserNotificationPrefsRef.current = {
+      enabled: browserNotificationsEnabled,
+      notifyOnBlocked: browserNotifyOnBlocked,
+      notifyOnDone: browserNotifyOnDone,
+      documentBadge: browserDocumentBadge,
+    };
+  }, [
+    browserNotificationsEnabled,
+    browserNotifyOnBlocked,
+    browserNotifyOnDone,
+    browserDocumentBadge,
   ]);
 
   useEffect(() => {
@@ -2325,6 +2410,71 @@ export function App() {
       openMobileDetail();
     }
   };
+
+  openPaneFromNotificationRef.current = (target) => {
+    const snapshot = snapshotForBridge(target.bridgeId);
+    const pane = snapshot?.panes.find((candidate) => candidate.pane_id === target.paneId);
+    if (pane) {
+      openPane(target.bridgeId, pane);
+      return;
+    }
+    setSelectedBridgeId(target.bridgeId);
+    rememberPaneSelection(target.bridgeId, target.paneId, target.workspaceId);
+  };
+
+  const handleAgentStatusActivity = useCallback(
+    (bridgeId: BridgeId, message: PaneAgentStatusChangedMessage) => {
+      const runtime = bridge.getRuntime(bridgeId);
+      showAgentStatusNotification({
+        bridgeId,
+        message,
+        prefs: browserNotificationPrefsRef.current,
+        bridgeLabel: runtime?.label ?? bridgeId,
+        onClick: (target) => openPaneFromNotificationRef.current(target),
+      });
+    },
+    [bridge],
+  );
+
+  const attentionCount = useMemo(() => {
+    return Object.values(connectionStates).reduce((total, state) => {
+      if (!state.snapshot) {
+        return total;
+      }
+      return total + countAttentionPanes(state.snapshot.panes);
+    }, 0);
+  }, [connectionStates]);
+
+  useEffect(() => {
+    document.title = documentTitleWithBadge(
+      DEFAULT_DOCUMENT_TITLE,
+      attentionCount,
+      browserDocumentBadge,
+    );
+    return () => {
+      document.title = DEFAULT_DOCUMENT_TITLE;
+    };
+  }, [attentionCount, browserDocumentBadge]);
+
+  const setBrowserNotificationsEnabledWithPermission = useCallback(async (enabled: boolean) => {
+    if (!enabled) {
+      setBrowserNotificationsEnabled(false);
+      return;
+    }
+    const permission = await requestBrowserNotificationPermission();
+    if (permission === "granted") {
+      setBrowserNotificationsEnabled(true);
+      return;
+    }
+    setBrowserNotificationsEnabled(false);
+    if (permission === "denied") {
+      setError("Browser notifications are blocked. Enable them in the browser site settings.");
+      return;
+    }
+    if (permission === "unsupported") {
+      setError("This browser does not support desktop notifications.");
+    }
+  }, []);
 
   const requestTerminalFocus = () => setTerminalFocusToken((token) => token + 1);
   const requestNoteTitleFocus = (bridgeId: BridgeId, noteId: string) => {
@@ -3706,6 +3856,7 @@ export function App() {
           setConnectionStates={setConnectionStates}
           onPaneSelection={applySharedPaneSelection}
           onAgentActivityChanged={refreshAgentActivityForBridge}
+          onAgentStatusActivity={handleAgentStatusActivity}
           onAgentPinsChanged={refreshAgentPinsForBridge}
           onNotesChanged={refreshNotesForBridge}
         />
@@ -4273,6 +4424,16 @@ export function App() {
           showMobileTerminalSettings={isTouchInput}
           notesEnabled={notesEnabled}
           onNotesEnabled={setNotesEnabled}
+          browserNotificationsEnabled={browserNotificationsEnabled}
+          onBrowserNotificationsEnabled={(enabled) => {
+            void setBrowserNotificationsEnabledWithPermission(enabled);
+          }}
+          browserNotifyOnBlocked={browserNotifyOnBlocked}
+          onBrowserNotifyOnBlocked={setBrowserNotifyOnBlocked}
+          browserNotifyOnDone={browserNotifyOnDone}
+          onBrowserNotifyOnDone={setBrowserNotifyOnDone}
+          browserDocumentBadge={browserDocumentBadge}
+          onBrowserDocumentBadge={setBrowserDocumentBadge}
           navigationSyncMode={navigationSyncMode}
           onNavigationSyncMode={changeNavigationSyncMode}
           agentFeaturesInTabs={agentFeaturesInTabs}
@@ -4359,6 +4520,7 @@ export function BridgeConnectionController({
   setConnectionStates,
   onPaneSelection,
   onAgentActivityChanged,
+  onAgentStatusActivity,
   onAgentPinsChanged,
   onNotesChanged,
 }: {
@@ -4368,12 +4530,14 @@ export function BridgeConnectionController({
   setConnectionStates: Dispatch<SetStateAction<Record<string, BridgeConnectionState>>>;
   onPaneSelection: (bridgeId: BridgeId, paneId: string, workspaceId?: string) => void;
   onAgentActivityChanged: (bridgeId: BridgeId) => void;
+  onAgentStatusActivity: (bridgeId: BridgeId, message: PaneAgentStatusChangedMessage) => void;
   onAgentPinsChanged: (bridgeId: BridgeId) => void;
   onNotesChanged: (bridgeId: BridgeId) => void;
 }) {
   const httpUrlRef = useRef(runtime.httpUrl);
   const wsUrlRef = useRef(runtime.wsUrl);
   const onAgentActivityChangedRef = useRef(onAgentActivityChanged);
+  const onAgentStatusActivityRef = useRef(onAgentStatusActivity);
   const onAgentPinsChangedRef = useRef(onAgentPinsChanged);
   const onNotesChangedRef = useRef(onNotesChanged);
   const followSharedSelectionRef = useRef(followSharedSelection);
@@ -4387,11 +4551,13 @@ export function BridgeConnectionController({
   useEffect(() => {
     followSharedSelectionRef.current = followSharedSelection;
     onAgentActivityChangedRef.current = onAgentActivityChanged;
+    onAgentStatusActivityRef.current = onAgentStatusActivity;
     onAgentPinsChangedRef.current = onAgentPinsChanged;
     onNotesChangedRef.current = onNotesChanged;
   }, [
     followSharedSelection,
     onAgentActivityChanged,
+    onAgentStatusActivity,
     onAgentPinsChanged,
     onNotesChanged,
   ]);
@@ -4528,6 +4694,9 @@ export function BridgeConnectionController({
               loadState: "ready",
             },
           }));
+          if (parsed.message.type === "pane.agent_status_changed") {
+            onAgentStatusActivityRef.current(runtime.id, parsed.message);
+          }
         } else if (result.status === "resync") {
           requestActivityResync();
         }

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -61,6 +61,14 @@ type Props = {
   showMobileTerminalSettings: boolean;
   notesEnabled: boolean;
   onNotesEnabled: (enabled: boolean) => void;
+  browserNotificationsEnabled: boolean;
+  onBrowserNotificationsEnabled: (enabled: boolean) => void;
+  browserNotifyOnBlocked: boolean;
+  onBrowserNotifyOnBlocked: (enabled: boolean) => void;
+  browserNotifyOnDone: boolean;
+  onBrowserNotifyOnDone: (enabled: boolean) => void;
+  browserDocumentBadge: boolean;
+  onBrowserDocumentBadge: (enabled: boolean) => void;
   navigationSyncMode: NavigationSyncMode;
   onNavigationSyncMode: (mode: NavigationSyncMode) => void;
   agentFeaturesInTabs: boolean;
@@ -115,6 +123,14 @@ export function BackendSettingsDialog({
   showMobileTerminalSettings,
   notesEnabled,
   onNotesEnabled,
+  browserNotificationsEnabled,
+  onBrowserNotificationsEnabled,
+  browserNotifyOnBlocked,
+  onBrowserNotifyOnBlocked,
+  browserNotifyOnDone,
+  onBrowserNotifyOnDone,
+  browserDocumentBadge,
+  onBrowserDocumentBadge,
   navigationSyncMode,
   onNavigationSyncMode,
   agentFeaturesInTabs,
@@ -490,30 +506,135 @@ export function BackendSettingsDialog({
             ) : null}
 
             {activeArea === "features" ? (
-              <div className="settings-section settings-section-flat">
-                <div className="settings-label">Client features</div>
-                <div className="settings-row">
-                  <span>Notes</span>
-                  <div className="segmented-control" role="group" aria-label="Notes feature">
-                    <button
-                      type="button"
-                      data-on={!notesEnabled}
-                      aria-pressed={!notesEnabled}
-                      onClick={() => onNotesEnabled(false)}
-                    >
-                      Off
-                    </button>
-                    <button
-                      type="button"
-                      data-on={notesEnabled}
-                      aria-pressed={notesEnabled}
-                      onClick={() => onNotesEnabled(true)}
-                    >
-                      On
-                    </button>
+              <>
+                <div className="settings-section settings-section-flat">
+                  <div className="settings-label">Client features</div>
+                  <div className="settings-row">
+                    <span>Notes</span>
+                    <div className="segmented-control" role="group" aria-label="Notes feature">
+                      <button
+                        type="button"
+                        data-on={!notesEnabled}
+                        aria-pressed={!notesEnabled}
+                        onClick={() => onNotesEnabled(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={notesEnabled}
+                        aria-pressed={notesEnabled}
+                        onClick={() => onNotesEnabled(true)}
+                      >
+                        On
+                      </button>
+                    </div>
                   </div>
                 </div>
-              </div>
+                <div className="settings-section settings-section-flat">
+                  <div className="settings-label">Browser notifications</div>
+                  <div className="settings-row">
+                    <span title="Show a desktop notification when an agent becomes blocked or done">
+                      Desktop alerts
+                    </span>
+                    <div
+                      className="segmented-control"
+                      role="group"
+                      aria-label="Browser notifications"
+                    >
+                      <button
+                        type="button"
+                        data-on={!browserNotificationsEnabled}
+                        aria-pressed={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotificationsEnabled(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={browserNotificationsEnabled}
+                        aria-pressed={browserNotificationsEnabled}
+                        onClick={() => onBrowserNotificationsEnabled(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                  <div className="settings-row">
+                    <span>Notify when blocked</span>
+                    <div
+                      className="segmented-control"
+                      role="group"
+                      aria-label="Notify when blocked"
+                    >
+                      <button
+                        type="button"
+                        data-on={!browserNotifyOnBlocked}
+                        aria-pressed={!browserNotifyOnBlocked}
+                        disabled={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotifyOnBlocked(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={browserNotifyOnBlocked}
+                        aria-pressed={browserNotifyOnBlocked}
+                        disabled={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotifyOnBlocked(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                  <div className="settings-row">
+                    <span>Notify when done</span>
+                    <div className="segmented-control" role="group" aria-label="Notify when done">
+                      <button
+                        type="button"
+                        data-on={!browserNotifyOnDone}
+                        aria-pressed={!browserNotifyOnDone}
+                        disabled={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotifyOnDone(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={browserNotifyOnDone}
+                        aria-pressed={browserNotifyOnDone}
+                        disabled={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotifyOnDone(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                  <div className="settings-row">
+                    <span title="Prefix the tab title with the number of blocked or done agents">
+                      Tab badge
+                    </span>
+                    <div className="segmented-control" role="group" aria-label="Document title badge">
+                      <button
+                        type="button"
+                        data-on={!browserDocumentBadge}
+                        aria-pressed={!browserDocumentBadge}
+                        onClick={() => onBrowserDocumentBadge(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={browserDocumentBadge}
+                        aria-pressed={browserDocumentBadge}
+                        onClick={() => onBrowserDocumentBadge(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </>
             ) : null}
 
             {activeArea === "display" ? (

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -681,6 +681,7 @@ function createConnectionHarness({
           setConnectionStates={setConnectionStates}
           onPaneSelection={onPaneSelection}
           onAgentActivityChanged={() => undefined}
+          onAgentStatusActivity={() => undefined}
           onAgentPinsChanged={() => undefined}
           onNotesChanged={onNotesChanged}
         />,

--- a/web/src/browserNotifications.test.ts
+++ b/web/src/browserNotifications.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  browserNotificationBody,
+  browserNotificationTag,
+  browserNotificationTitle,
+  browserNotificationTarget,
+  countAttentionPanes,
+  DEFAULT_BROWSER_NOTIFICATION_PREFS,
+  documentTitleWithBadge,
+  parseBrowserNotificationPrefs,
+  parseBrowserNotificationTarget,
+  requestBrowserNotificationPermission,
+  shouldNotifyAgentStatus,
+  showAgentStatusNotification,
+} from "./browserNotifications";
+import type { PaneAgentStatusChangedMessage, PaneInfo } from "./types";
+
+function message(
+  overrides: Partial<PaneAgentStatusChangedMessage> = {},
+): PaneAgentStatusChangedMessage {
+  return {
+    type: "pane.agent_status_changed",
+    pane_id: "w1:p1",
+    workspace_id: "w1",
+    agent_status: "blocked",
+    agent: "claude",
+    title: "fix auth",
+    display_agent: "Claude",
+    state_labels: {},
+    ...overrides,
+  };
+}
+
+describe("browser notification prefs", () => {
+  it("parses known booleans and falls back otherwise", () => {
+    expect(
+      parseBrowserNotificationPrefs({
+        enabled: true,
+        notifyOnBlocked: false,
+        notifyOnDone: true,
+        documentBadge: false,
+      }),
+    ).toEqual({
+      enabled: true,
+      notifyOnBlocked: false,
+      notifyOnDone: true,
+      documentBadge: false,
+    });
+    expect(parseBrowserNotificationPrefs({})).toEqual(DEFAULT_BROWSER_NOTIFICATION_PREFS);
+    expect(parseBrowserNotificationPrefs(null)).toEqual(DEFAULT_BROWSER_NOTIFICATION_PREFS);
+  });
+});
+
+describe("shouldNotifyAgentStatus", () => {
+  it("respects the master switch and per-status toggles", () => {
+    expect(
+      shouldNotifyAgentStatus("blocked", {
+        enabled: false,
+        notifyOnBlocked: true,
+        notifyOnDone: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldNotifyAgentStatus("blocked", {
+        enabled: true,
+        notifyOnBlocked: true,
+        notifyOnDone: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldNotifyAgentStatus("done", {
+        enabled: true,
+        notifyOnBlocked: true,
+        notifyOnDone: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldNotifyAgentStatus("working", {
+        enabled: true,
+        notifyOnBlocked: true,
+        notifyOnDone: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("notification copy and tags", () => {
+  it("builds attention-oriented titles and bodies", () => {
+    expect(browserNotificationTitle(message())).toBe("Claude needs you");
+    expect(browserNotificationTitle(message({ agent_status: "done" }))).toBe("Claude is done");
+    expect(browserNotificationBody(message(), "laptop")).toBe("laptop · fix auth · w1:p1");
+    expect(browserNotificationTag("bridge-a", "w1:p1")).toBe("herdr-web:agent:bridge-a:w1:p1");
+  });
+
+  it("round-trips notification click targets", () => {
+    const target = browserNotificationTarget("b1", message());
+    expect(target).toEqual({ bridgeId: "b1", paneId: "w1:p1", workspaceId: "w1" });
+    expect(parseBrowserNotificationTarget(target)).toEqual(target);
+    expect(parseBrowserNotificationTarget({ bridgeId: "b1" })).toBeNull();
+  });
+});
+
+describe("document title badge", () => {
+  it("prefixes attention counts when enabled", () => {
+    expect(documentTitleWithBadge("herdr-web", 0, true)).toBe("herdr-web");
+    expect(documentTitleWithBadge("herdr-web", 3, true)).toBe("(3) herdr-web");
+    expect(documentTitleWithBadge("herdr-web", 3, false)).toBe("herdr-web");
+  });
+
+  it("counts blocked and done panes", () => {
+    const panes = [
+      { agent_status: "blocked" },
+      { agent_status: "done" },
+      { agent_status: "working" },
+      { agent_status: "idle" },
+    ] as PaneInfo[];
+    expect(countAttentionPanes(panes)).toBe(2);
+  });
+});
+
+describe("showAgentStatusNotification", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a notification when enabled and permission is granted", () => {
+    function MockNotification(this: { close: () => void; onclick: null }, title: string, options?: NotificationOptions) {
+      void title;
+      void options;
+      this.close = vi.fn();
+      this.onclick = null;
+    }
+    MockNotification.permission = "granted" as NotificationPermission;
+    MockNotification.requestPermission = async () => "granted" as NotificationPermission;
+    const NotificationCtor = vi.fn(MockNotification) as unknown as typeof Notification;
+    Object.defineProperty(NotificationCtor, "permission", { value: "granted" });
+
+    const shown = showAgentStatusNotification({
+      bridgeId: "b1",
+      message: message(),
+      prefs: { ...DEFAULT_BROWSER_NOTIFICATION_PREFS, enabled: true },
+      bridgeLabel: "dev",
+      NotificationCtor,
+      onClick: vi.fn(),
+    });
+
+    expect(shown).toBe(true);
+    expect(NotificationCtor).toHaveBeenCalledWith(
+      "Claude needs you",
+      expect.objectContaining({
+        body: "dev · fix auth · w1:p1",
+        tag: "herdr-web:agent:b1:w1:p1",
+        renotify: true,
+        data: { bridgeId: "b1", paneId: "w1:p1", workspaceId: "w1" },
+      }),
+    );
+  });
+
+  it("skips when permission is not granted", () => {
+    function MockNotification() {
+      return undefined;
+    }
+    const NotificationCtor = vi.fn(MockNotification) as unknown as typeof Notification;
+    Object.defineProperty(NotificationCtor, "permission", { value: "denied" });
+    expect(
+      showAgentStatusNotification({
+        bridgeId: "b1",
+        message: message(),
+        prefs: { ...DEFAULT_BROWSER_NOTIFICATION_PREFS, enabled: true },
+        NotificationCtor,
+      }),
+    ).toBe(false);
+    expect(NotificationCtor).not.toHaveBeenCalled();
+  });
+});
+
+describe("requestBrowserNotificationPermission", () => {
+  it("returns unsupported when Notification is missing", async () => {
+    await expect(requestBrowserNotificationPermission(undefined)).resolves.toBe("unsupported");
+  });
+
+  it("requests permission when still default", async () => {
+    const requestPermission = vi.fn(async () => "granted" as NotificationPermission);
+    function MockNotification() {
+      return undefined;
+    }
+    MockNotification.permission = "default" as NotificationPermission;
+    MockNotification.requestPermission = requestPermission;
+    await expect(
+      requestBrowserNotificationPermission(
+        MockNotification as unknown as typeof Notification,
+      ),
+    ).resolves.toBe("granted");
+    expect(requestPermission).toHaveBeenCalled();
+  });
+});

--- a/web/src/browserNotifications.ts
+++ b/web/src/browserNotifications.ts
@@ -1,0 +1,277 @@
+import { isAttention } from "./state";
+import type { AgentStatus, PaneAgentStatusChangedMessage, PaneInfo } from "./types";
+
+export type BrowserNotificationPrefs = {
+  enabled: boolean;
+  notifyOnBlocked: boolean;
+  notifyOnDone: boolean;
+  documentBadge: boolean;
+};
+
+export type BrowserNotificationTarget = {
+  bridgeId: string;
+  paneId: string;
+  workspaceId: string;
+};
+
+export const DEFAULT_BROWSER_NOTIFICATION_PREFS: BrowserNotificationPrefs = {
+  enabled: false,
+  notifyOnBlocked: true,
+  notifyOnDone: true,
+  documentBadge: true,
+};
+
+export const DEFAULT_DOCUMENT_TITLE = "herdr-web";
+
+export function parseBrowserNotificationEnabled(
+  value: unknown,
+  fallback = DEFAULT_BROWSER_NOTIFICATION_PREFS.enabled,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseBrowserNotifyOnBlocked(
+  value: unknown,
+  fallback = DEFAULT_BROWSER_NOTIFICATION_PREFS.notifyOnBlocked,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseBrowserNotifyOnDone(
+  value: unknown,
+  fallback = DEFAULT_BROWSER_NOTIFICATION_PREFS.notifyOnDone,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseBrowserDocumentBadge(
+  value: unknown,
+  fallback = DEFAULT_BROWSER_NOTIFICATION_PREFS.documentBadge,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseBrowserNotificationPrefs(
+  value: Partial<BrowserNotificationPrefs> | null | undefined,
+  fallback: BrowserNotificationPrefs = DEFAULT_BROWSER_NOTIFICATION_PREFS,
+): BrowserNotificationPrefs {
+  return {
+    enabled: parseBrowserNotificationEnabled(value?.enabled, fallback.enabled),
+    notifyOnBlocked: parseBrowserNotifyOnBlocked(value?.notifyOnBlocked, fallback.notifyOnBlocked),
+    notifyOnDone: parseBrowserNotifyOnDone(value?.notifyOnDone, fallback.notifyOnDone),
+    documentBadge: parseBrowserDocumentBadge(value?.documentBadge, fallback.documentBadge),
+  };
+}
+
+/** Statuses that can raise a browser notification when prefs allow. */
+export function shouldNotifyAgentStatus(
+  status: AgentStatus,
+  prefs: Pick<BrowserNotificationPrefs, "enabled" | "notifyOnBlocked" | "notifyOnDone">,
+): boolean {
+  if (!prefs.enabled) {
+    return false;
+  }
+  if (status === "blocked") {
+    return prefs.notifyOnBlocked;
+  }
+  if (status === "done") {
+    return prefs.notifyOnDone;
+  }
+  return false;
+}
+
+export function browserNotificationTag(bridgeId: string, paneId: string) {
+  return `herdr-web:agent:${bridgeId}:${paneId}`;
+}
+
+export function browserNotificationTitle(message: PaneAgentStatusChangedMessage): string {
+  const agent =
+    message.display_agent?.trim() ||
+    message.agent?.trim() ||
+    message.title?.trim() ||
+    "Agent";
+  if (message.agent_status === "blocked") {
+    return `${agent} needs you`;
+  }
+  if (message.agent_status === "done") {
+    return `${agent} is done`;
+  }
+  return agent;
+}
+
+export function browserNotificationBody(
+  message: PaneAgentStatusChangedMessage,
+  bridgeLabel?: string | null,
+): string {
+  const parts: string[] = [];
+  if (bridgeLabel?.trim()) {
+    parts.push(bridgeLabel.trim());
+  }
+  const title = message.title?.trim();
+  if (title && title !== message.display_agent?.trim() && title !== message.agent?.trim()) {
+    parts.push(title);
+  }
+  parts.push(message.pane_id);
+  return parts.join(" · ");
+}
+
+export function browserNotificationTarget(
+  bridgeId: string,
+  message: Pick<PaneAgentStatusChangedMessage, "pane_id" | "workspace_id">,
+): BrowserNotificationTarget {
+  return {
+    bridgeId,
+    paneId: message.pane_id,
+    workspaceId: message.workspace_id,
+  };
+}
+
+export function parseBrowserNotificationTarget(value: unknown): BrowserNotificationTarget | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (
+    typeof value.bridgeId !== "string" ||
+    typeof value.paneId !== "string" ||
+    typeof value.workspaceId !== "string"
+  ) {
+    return null;
+  }
+  return {
+    bridgeId: value.bridgeId,
+    paneId: value.paneId,
+    workspaceId: value.workspaceId,
+  };
+}
+
+export function countAttentionPanes(panes: readonly PaneInfo[]) {
+  return panes.reduce((total, pane) => (isAttention(pane.agent_status) ? total + 1 : total), 0);
+}
+
+export function documentTitleWithBadge(
+  baseTitle: string,
+  attentionCount: number,
+  badgeEnabled: boolean,
+): string {
+  if (!badgeEnabled || attentionCount <= 0) {
+    return baseTitle;
+  }
+  return `(${attentionCount}) ${baseTitle}`;
+}
+
+type NotificationApi = {
+  permission: NotificationPermission;
+  requestPermission: () => Promise<NotificationPermission>;
+  new (title: string, options?: NotificationOptions): Notification;
+};
+
+export function isBrowserNotificationApiSupported(
+  notificationCtor: NotificationApi | typeof Notification | undefined = globalNotification(),
+): boolean {
+  return (
+    typeof notificationCtor === "function" &&
+    typeof (notificationCtor as NotificationApi).permission === "string"
+  );
+}
+
+export function browserNotificationPermission(
+  notificationCtor: NotificationApi | typeof Notification | undefined = globalNotification(),
+): NotificationPermission | "unsupported" {
+  if (!isBrowserNotificationApiSupported(notificationCtor)) {
+    return "unsupported";
+  }
+  return (notificationCtor as NotificationApi).permission;
+}
+
+/**
+ * Request browser permission when enabling notifications.
+ * Returns the resulting permission; does not change prefs.
+ */
+export async function requestBrowserNotificationPermission(
+  notificationCtor: NotificationApi | typeof Notification | undefined = globalNotification(),
+): Promise<NotificationPermission | "unsupported"> {
+  if (!isBrowserNotificationApiSupported(notificationCtor)) {
+    return "unsupported";
+  }
+  const api = notificationCtor as NotificationApi;
+  if (api.permission === "granted" || api.permission === "denied") {
+    return api.permission;
+  }
+  try {
+    return await api.requestPermission();
+  } catch {
+    return "denied";
+  }
+}
+
+export type ShowAgentStatusNotificationOptions = {
+  bridgeId: string;
+  message: PaneAgentStatusChangedMessage;
+  prefs: BrowserNotificationPrefs;
+  bridgeLabel?: string | null;
+  permission?: NotificationPermission | "unsupported";
+  NotificationCtor?: typeof Notification | undefined;
+  onClick?: (target: BrowserNotificationTarget) => void;
+};
+
+/**
+ * Show a desktop Notification for an agent status transition when prefs/permission allow.
+ * Returns true when a notification was created.
+ */
+export function showAgentStatusNotification(options: ShowAgentStatusNotificationOptions): boolean {
+  const {
+    bridgeId,
+    message,
+    prefs,
+    bridgeLabel,
+    onClick,
+  } = options;
+  if (!shouldNotifyAgentStatus(message.agent_status, prefs)) {
+    return false;
+  }
+  const NotificationCtor = options.NotificationCtor ?? globalNotification();
+  if (!isBrowserNotificationApiSupported(NotificationCtor)) {
+    return false;
+  }
+  const permission = options.permission ?? NotificationCtor!.permission;
+  if (permission !== "granted") {
+    return false;
+  }
+
+  const target = browserNotificationTarget(bridgeId, message);
+  const notificationOptions: NotificationOptions & { renotify?: boolean } = {
+    body: browserNotificationBody(message, bridgeLabel),
+    tag: browserNotificationTag(bridgeId, message.pane_id),
+    // Re-alert when the same pane transitions again (same tag).
+    renotify: true,
+    data: target,
+  };
+  const notification = new NotificationCtor!(
+    browserNotificationTitle(message),
+    notificationOptions,
+  );
+
+  if (onClick) {
+    notification.onclick = () => {
+      try {
+        window.focus();
+      } catch {
+        // Some environments restrict focus from notification handlers.
+      }
+      onClick(target);
+      notification.close();
+    };
+  }
+  return true;
+}
+
+function globalNotification(): typeof Notification | undefined {
+  if (typeof Notification === "undefined") {
+    return undefined;
+  }
+  return Notification;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
## Summary

- When enabled under Settings → Features, agent status transitions to `blocked` / `done` raise browser Notification API alerts.
- Optional per-status toggles, click deep-link to the pane, and an optional tab-title badge for the current attention count.
- Pure frontend change; no bridge protocol changes.

## Validation

- `npm run test --prefix web -- src/browserNotifications.test.ts` (10 passed)
- `npm run lint:web`

## Notes

- Independent of PR #51 (IME/HMR). Safe to review/merge in either order.
- Web Push (background alerts when the tab is closed) is intentionally split into a follow-up PR stacked on this branch.
- Changelog under `## [Unreleased]` will get this PR number after open, per repo convention.