### PR TITLE
Add Web Push for background agent alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   optional per-status toggles cover blocked and done, notifications deep-link to the pane on click,
   and an optional tab-title badge shows the count of agents needing attention.
   [PR #52](https://github.com/kcosr/herdr-web/pull/52)
+- Added optional Web Push + service worker support so blocked/done alerts can reach the device when
+  the tab is closed. The bridge auto-generates VAPID keys (or accepts `HERDR_WEB_VAPID_*`), exposes
+  `web_push` on `/api/capabilities`, and accepts `/api/push/subscribe|unsubscribe`.
+  [PR #53](https://github.com/kcosr/herdr-web/pull/53)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- Added browser desktop notifications for agent attention states. Enable under Settings → Features;
+  optional per-status toggles cover blocked and done, notifications deep-link to the pane on click,
+  and an optional tab-title badge shows the count of agents needing attention.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added browser desktop notifications for agent attention states. Enable under Settings → Features;
   optional per-status toggles cover blocked and done, notifications deep-link to the pane on click,
   and an optional tab-title badge shows the count of agents needing attention.
+  [PR #52](https://github.com/kcosr/herdr-web/pull/52)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -152,11 +152,17 @@ for HTTP/cleartext behavior, Android SDK setup, and APK verification notes.
 Settings are grouped by area:
 
 - Bridge: same-origin and saved bridge profiles, reachability testing, and bridge enablement.
-- Features: client feature toggles such as Notes.
+- Features: client feature toggles such as Notes, desktop agent alerts, tab badges, and optional
+  background Web Push (service worker; requires HTTPS or localhost).
 - Display: browser-wide navigation synchronization, agent features in Tabs, multi-host Space
   selection, top/bottom app padding, and mobile terminal controls size.
 - Terminal: browser-to-bridge terminal input transport and input batching delay.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
+
+Desktop alerts use the page Notification API while a tab is open. Background push uses a service
+worker and bridge-side VAPID keys (auto-generated under the herdr-web data dir, or set
+`HERDR_WEB_VAPID_PUBLIC_KEY` / `HERDR_WEB_VAPID_PRIVATE_KEY`). When an agent becomes blocked or done,
+the bridge can push even if no browser tab is connected.
 
 When viewing all of multiple hosts, use the Spaces list `…` menu to group spaces by host or keep a
 flat list with host context in each row. The menu stays hidden in single-host scope.

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -9,6 +9,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-keywrap"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b6f24a1f796bc46415a1d0d18dc0a8203ccba088acf5def3291c4f61225522"
+dependencies = [
+ "aes 0.9.2",
+ "byteorder",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +80,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
+name = "android_system_properties"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -36,6 +101,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -48,6 +137,17 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -78,11 +178,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -115,7 +215,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -127,10 +227,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -151,6 +275,12 @@ checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
 ]
+
+[[package]]
+name = "binstring"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
 
 [[package]]
 name = "bit-set"
@@ -180,12 +310,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -207,6 +357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +378,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +398,56 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "coarsetime"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2"
+dependencies = [
+ "libc",
+ "wasix",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "compact_str"
@@ -265,6 +481,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,10 +523,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -296,6 +566,12 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -325,13 +601,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -342,6 +642,61 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "ct-codecs"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a45ee8994e5307cb4c60cfc1c20bf7263ffb771ddc135c9f768a14bcbc15b09"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.90+curl-8.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97799a0d220bfb3361e0fe4936966ff8c4b24d65c3f06dfc70d7b680b44e7897"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys",
 ]
 
 [[package]]
@@ -391,6 +746,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+dependencies = [
+ "const-oid 0.6.2",
+ "der_derive",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aed3b3c608dc56cf36c45fe979d04eda51242e6703d8d0bb03426ef7c41db6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,8 +822,31 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -450,10 +871,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ece"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ea1d2f2cc974957a4e2575d8e5bb494549bab66338d6320c2789abcfff5746"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "hex",
+ "hkdf",
+ "lazy_static",
+ "once_cell",
+ "openssl",
+ "serde",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ed25519-compact"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c24599140dc39d7a81e4476e7573d41bbc18e07c803900298e522a5fbcfbfb6"
+dependencies = [
+ "ct-codecs",
+ "getrandom 0.4.2",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -481,6 +974,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,12 +1010,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -515,6 +1044,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "finl_unicode"
@@ -557,6 +1092,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +1129,25 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -625,6 +1194,20 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -646,10 +1229,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -709,6 +1316,7 @@ name = "herdr-web-bridge"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "herdr-compat",
@@ -723,14 +1331,74 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-width",
+ "web-push",
  "windows-sys",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-sha1-compact"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b3ba31f6dc772cc8221ce81dbbbd64fa1e668255a6737d95eeace59b5a8823"
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-sha512"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "019ece39bbefc17f13f677a690328cb978dbf6790e141a3c24e66372cb38588b"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "http"
@@ -749,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -760,7 +1428,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
 ]
@@ -784,6 +1452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "ctutils",
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,7 +1471,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
@@ -810,12 +1488,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -829,6 +1613,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -849,6 +1654,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -878,6 +1701,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "isahc"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbce0b6b4f5c50b8e014e227d51ddf721558308566b4f6ba608abcea4d272cce"
+dependencies = [
+ "async-channel",
+ "castaway",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "event-listener",
+ "futures-lite",
+ "http 0.2.12",
+ "log",
+ "mime",
+ "polling",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "waker-fn",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +1753,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt-simple"
+version = "0.12.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06a4207b9d1f423858853fb9ee8b34aebc2b661f3b446ca4efda46c4b3700a2f"
+dependencies = [
+ "anyhow",
+ "binstring",
+ "blake2b_simd",
+ "coarsetime",
+ "ct-codecs",
+ "ed25519-compact",
+ "hmac-sha1-compact",
+ "hmac-sha256",
+ "hmac-sha512",
+ "k256",
+ "p256",
+ "p384",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "superboring",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature 2.2.0",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +1801,16 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -925,6 +1824,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -945,6 +1847,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libnghttp2-sys"
+version = "0.1.13+1.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492e00167f1418c15648144f42bbfc63099806ecee9bf8d09a6353d6b4856b3c"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1882,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1080,6 +2010,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-dsa"
+version = "0.1.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "163f15320f3fba11760c373af52d7f69d638482c2c350d877fb06513b1c3137c"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "sha3",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +2069,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,12 +2102,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1153,12 +2146,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -1186,6 +2252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +2278,36 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64 0.13.1",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1310,10 +2412,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -1329,10 +2488,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1357,6 +2551,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1395,6 +2598,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -1404,8 +2609,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1423,6 +2638,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -1432,6 +2650,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -1588,6 +2812,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +2877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +2915,31 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1_decode"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6326ddc956378a0739200b2c30892dccaf198992dfd7323274690b9e188af23"
+dependencies = [
+ "der 0.4.5",
+ "pem 0.8.3",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "semver"
@@ -1742,8 +3031,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1753,8 +3042,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]
@@ -1765,6 +3064,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1798,6 +3103,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +3141,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "sluice"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160b744a45e8261307bcfe03c98e2f8274502207d534c9a64b675c4db1b6bd58"
+dependencies = [
+ "async-channel",
+ "futures-core",
+ "futures-io",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +3166,38 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1865,6 +3233,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "superboring"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32799c1e73c2c5467e43bfaab8a9e28c5feed8b5ea59beb53376977f39971ead"
+dependencies = [
+ "aes-gcm",
+ "aes-keywrap",
+ "getrandom 0.2.17",
+ "hmac-sha256",
+ "hmac-sha512",
+ "ml-dsa",
+ "rand 0.8.6",
+ "rsa",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,10 +3277,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "terminfo"
@@ -1920,7 +3344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
@@ -2026,6 +3450,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,7 +3537,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "http-range-header",
@@ -2164,6 +3598,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,7 +3644,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -2262,10 +3706,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2292,6 +3764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,6 +3789,12 @@ checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "wasi"
@@ -2334,6 +3818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasix"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae86f02046da16a333a9129d31451423e1657737ecdafed4193838a5f54c5cfe"
+dependencies = [
+ "wasi",
 ]
 
 [[package]]
@@ -2413,6 +3906,28 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-push"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c305b9ee2993ab68b7744b13ef32231d83600dd879ac8183b4c76ae31d28ac"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "ct-codecs",
+ "ece",
+ "futures-lite",
+ "http 0.2.12",
+ "isahc",
+ "jwt-simple",
+ "log",
+ "pem 3.0.6",
+ "sec1_decode",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -2516,10 +4031,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2625,6 +4193,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure 0.13.2",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +4235,66 @@ name = "zerocopy-derive"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure 0.13.2",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
+base64 = "0.22"
 bytes = "1"
 futures-util = "0.3"
 herdr-compat = { path = "../vendor/herdr-compat" }
@@ -24,6 +25,7 @@ tower-http = { version = "0.6", features = ["fs", "compression-gzip"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 unicode-width = "0.2"
+web-push = "0.11"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = [

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -2,6 +2,7 @@ mod agent_activity;
 mod agent_pins;
 mod launcher_presets;
 mod notes;
+mod push;
 mod session;
 mod store_util;
 mod web_bridge;

--- a/bridge/src/push.rs
+++ b/bridge/src/push.rs
@@ -1,0 +1,524 @@
+//! Optional Web Push (VAPID) for agent attention alerts.
+//!
+//! Disabled when VAPID material cannot be loaded/generated. Subscriptions persist under the
+//! herdr-web data directory so they survive bridge restarts.
+
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use base64::engine::general_purpose::{URL_SAFE_NO_PAD, STANDARD};
+use base64::Engine;
+use herdr_compat::api::schema::AgentStatus;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+use web_push::{
+    ContentEncoding, IsahcWebPushClient, SubscriptionInfo, Urgency, VapidSignatureBuilder,
+    WebPushClient, WebPushMessageBuilder,
+};
+
+use crate::store_util::{default_store_dir, ensure_private_dir, set_private_file_permissions};
+
+/// Minimal alert payload used by the activity watcher (avoids a web_bridge cycle).
+#[derive(Debug, Clone)]
+pub struct AgentPushAlert {
+    pub pane_id: String,
+    pub workspace_id: String,
+    pub agent_status: AgentStatus,
+    pub agent: Option<String>,
+    pub title: Option<String>,
+    pub display_agent: Option<String>,
+}
+
+const SUBSCRIPTIONS_FILE: &str = "push-subscriptions.json";
+const VAPID_FILE: &str = "vapid.json";
+const PUSH_TTL_SECS: u32 = 21_600;
+const PUSH_TOPIC: &str = "herdr-web-herd";
+const VAPID_SUBJECT: &str = "mailto:herdr-web@localhost";
+const MAX_SUBSCRIPTIONS: usize = 32;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PushSubscriptionRecord {
+    pub endpoint: String,
+    pub keys: PushSubscriptionKeys,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PushSubscriptionKeys {
+    pub p256dh: String,
+    pub auth: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SubscriptionsFile {
+    subscriptions: Vec<PushSubscriptionRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VapidFile {
+    public_key: String,
+    private_key: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WebPushCapability {
+    pub version: u32,
+    pub public_key: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PushPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    r#type: Option<&'static str>,
+    title: String,
+    body: String,
+    tag: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pane_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<String>,
+    renotify: bool,
+}
+
+pub struct PushManager {
+    enabled: bool,
+    public_key: String,
+    private_key: String,
+    path: PathBuf,
+    subscriptions: Mutex<HashMap<String, PushSubscriptionRecord>>,
+}
+
+impl PushManager {
+    pub fn load() -> io::Result<Self> {
+        let dir = default_store_dir("HERDR_WEB_PUSH_DIR", "push", "herdr-web-push");
+        ensure_private_dir(&dir)?;
+        let vapid = load_or_create_vapid(&dir)?;
+        let path = dir.join(SUBSCRIPTIONS_FILE);
+        let subscriptions = load_subscriptions(&path)?;
+        if vapid.is_some() {
+            info!(
+                subscriptions = subscriptions.len(),
+                "web push enabled with VAPID keys"
+            );
+        } else {
+            info!("web push disabled (no VAPID keys)");
+        }
+        Ok(Self {
+            enabled: vapid.is_some(),
+            public_key: vapid
+                .as_ref()
+                .map(|keys| keys.public_key.clone())
+                .unwrap_or_default(),
+            private_key: vapid
+                .as_ref()
+                .map(|keys| keys.private_key.clone())
+                .unwrap_or_default(),
+            path,
+            subscriptions: Mutex::new(subscriptions),
+        })
+    }
+
+    pub fn capability(&self) -> Option<WebPushCapability> {
+        if !self.enabled {
+            return None;
+        }
+        Some(WebPushCapability {
+            version: 1,
+            public_key: self.public_key.clone(),
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn subscribe(&self, subscription: PushSubscriptionRecord) -> io::Result<()> {
+        if !self.enabled {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "web push is not configured",
+            ));
+        }
+        if subscription.endpoint.trim().is_empty()
+            || subscription.keys.p256dh.trim().is_empty()
+            || subscription.keys.auth.trim().is_empty()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid push subscription",
+            ));
+        }
+        let mut guard = self
+            .subscriptions
+            .lock()
+            .expect("push subscriptions lock poisoned");
+        guard.insert(subscription.endpoint.clone(), subscription);
+        while guard.len() > MAX_SUBSCRIPTIONS {
+            if let Some(oldest) = guard.keys().next().cloned() {
+                guard.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+        save_subscriptions(&self.path, &guard)
+    }
+
+    pub fn unsubscribe(&self, endpoint: &str) -> io::Result<bool> {
+        let mut guard = self
+            .subscriptions
+            .lock()
+            .expect("push subscriptions lock poisoned");
+        let removed = guard.remove(endpoint).is_some();
+        if removed {
+            save_subscriptions(&self.path, &guard)?;
+        }
+        Ok(removed)
+    }
+
+    pub async fn broadcast_alert(&self, alert: &AgentPushAlert) {
+        if !self.enabled {
+            return;
+        }
+        let Some(payload) = payload_for_alert(alert) else {
+            return;
+        };
+        let body = match serde_json::to_string(&payload) {
+            Ok(value) => value,
+            Err(err) => {
+                warn!(error = %err, "failed to serialize push payload");
+                return;
+            }
+        };
+        let subs: Vec<PushSubscriptionRecord> = self
+            .subscriptions
+            .lock()
+            .expect("push subscriptions lock poisoned")
+            .values()
+            .cloned()
+            .collect();
+        if subs.is_empty() {
+            return;
+        }
+        let client = match IsahcWebPushClient::new() {
+            Ok(client) => client,
+            Err(err) => {
+                warn!(error = %err, "failed to create web push client");
+                return;
+            }
+        };
+        let mut dead = Vec::new();
+        for sub in subs {
+            match self.send_one(&client, &sub, body.as_bytes()).await {
+                Ok(()) => {}
+                Err(err) => {
+                    warn!(endpoint = %sub.endpoint, error = %err, "web push delivery failed");
+                    if is_gone_error(&err) {
+                        dead.push(sub.endpoint);
+                    }
+                }
+            }
+        }
+        if !dead.is_empty() {
+            let mut guard = self
+                .subscriptions
+                .lock()
+                .expect("push subscriptions lock poisoned");
+            for endpoint in dead {
+                guard.remove(&endpoint);
+            }
+            if let Err(err) = save_subscriptions(&self.path, &guard) {
+                warn!(error = %err, "failed to prune dead push subscriptions");
+            }
+        }
+    }
+
+    async fn send_one(
+        &self,
+        client: &IsahcWebPushClient,
+        sub: &PushSubscriptionRecord,
+        payload: &[u8],
+    ) -> Result<(), web_push::WebPushError> {
+        let info = SubscriptionInfo::new(&sub.endpoint, &sub.keys.p256dh, &sub.keys.auth);
+        let mut sig_builder = VapidSignatureBuilder::from_base64(&self.private_key, &info)?;
+        sig_builder.add_claim("sub", VAPID_SUBJECT);
+        let signature = sig_builder.build()?;
+        let mut builder = WebPushMessageBuilder::new(&info);
+        builder.set_payload(ContentEncoding::Aes128Gcm, payload);
+        builder.set_ttl(PUSH_TTL_SECS);
+        builder.set_urgency(Urgency::High);
+        builder.set_topic(PUSH_TOPIC.to_string());
+        builder.set_vapid_signature(signature);
+        client.send(builder.build()?).await
+    }
+}
+
+pub fn parse_subscription_body(value: serde_json::Value) -> Result<PushSubscriptionRecord, String> {
+    let endpoint = value
+        .get("endpoint")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| "missing endpoint".to_string())?
+        .to_string();
+    let keys = value
+        .get("keys")
+        .ok_or_else(|| "missing keys".to_string())?;
+    let p256dh = keys
+        .get("p256dh")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| "missing keys.p256dh".to_string())?
+        .to_string();
+    let auth = keys
+        .get("auth")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| "missing keys.auth".to_string())?
+        .to_string();
+    Ok(PushSubscriptionRecord {
+        endpoint,
+        keys: PushSubscriptionKeys { p256dh, auth },
+    })
+}
+
+fn payload_for_alert(alert: &AgentPushAlert) -> Option<PushPayload> {
+    if !matches!(
+        alert.agent_status,
+        AgentStatus::Blocked | AgentStatus::Done
+    ) {
+        return None;
+    }
+    let agent_label = alert
+        .display_agent
+        .as_deref()
+        .or(alert.agent.as_deref())
+        .or(alert.title.as_deref())
+        .unwrap_or("Agent");
+    let title_text = match alert.agent_status {
+        AgentStatus::Blocked => format!("{agent_label} needs you"),
+        AgentStatus::Done => format!("{agent_label} is done"),
+        _ => return None,
+    };
+    let body = match alert.title.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+        Some(value) if value != agent_label => format!("{} · {}", value, alert.pane_id),
+        _ => alert.pane_id.clone(),
+    };
+    Some(PushPayload {
+        r#type: None,
+        title: title_text,
+        body,
+        tag: format!("herdr-web:agent:{}", alert.pane_id),
+        pane_id: Some(alert.pane_id.clone()),
+        workspace_id: Some(alert.workspace_id.clone()),
+        renotify: true,
+    })
+}
+
+fn load_or_create_vapid(dir: &Path) -> io::Result<Option<VapidFile>> {
+    if let (Ok(public_key), Ok(private_key)) = (
+        std::env::var("HERDR_WEB_VAPID_PUBLIC_KEY"),
+        std::env::var("HERDR_WEB_VAPID_PRIVATE_KEY"),
+    ) {
+        if !public_key.trim().is_empty() && !private_key.trim().is_empty() {
+            return Ok(Some(VapidFile {
+                public_key: public_key.trim().to_string(),
+                private_key: private_key.trim().to_string(),
+            }));
+        }
+    }
+
+    let path = dir.join(VAPID_FILE);
+    if path.is_file() {
+        let text = fs::read_to_string(&path)?;
+        match serde_json::from_str::<VapidFile>(&text) {
+            Ok(file)
+                if !file.public_key.trim().is_empty() && !file.private_key.trim().is_empty() =>
+            {
+                return Ok(Some(file));
+            }
+            Ok(_) => warn!(path = %path.display(), "ignoring incomplete vapid.json"),
+            Err(err) => warn!(path = %path.display(), error = %err, "ignoring corrupt vapid.json"),
+        }
+    }
+
+    match generate_vapid_keys() {
+        Ok(keys) => {
+            write_json_private(&path, &keys)?;
+            info!(path = %path.display(), "generated web push VAPID keys");
+            Ok(Some(keys))
+        }
+        Err(err) => {
+            warn!(error = %err, "failed to generate VAPID keys; web push disabled");
+            Ok(None)
+        }
+    }
+}
+
+fn generate_vapid_keys() -> Result<VapidFile, String> {
+    // web-push re-exports enough helpers via VapidSignatureBuilder; generate with openssl-free
+    // base64 private key material accepted by from_base64_no_sub.
+    use web_push::VapidSignatureBuilder as Builder;
+
+    // Generate 32 random bytes for an ES256 private scalar via getrandom from the web-push tree.
+    let mut raw = [0u8; 32];
+    getrandom_fill(&mut raw)?;
+    // Avoid an all-zero private key.
+    if raw.iter().all(|b| *b == 0) {
+        raw[0] = 1;
+    }
+    let private_key = URL_SAFE_NO_PAD.encode(raw);
+    let builder = Builder::from_base64_no_sub(&private_key).map_err(|err| err.to_string())?;
+    let public_key = URL_SAFE_NO_PAD.encode(builder.get_public_key());
+    // Validate the private key can actually sign a dummy endpoint.
+    let p256dh = URL_SAFE_NO_PAD.encode([1u8; 65]);
+    let auth = URL_SAFE_NO_PAD.encode([2u8; 16]);
+    let info = SubscriptionInfo::new("https://push.example.invalid/test", &p256dh, &auth);
+    let mut sig = Builder::from_base64(&private_key, &info).map_err(|err| err.to_string())?;
+    sig.add_claim("sub", VAPID_SUBJECT);
+    let _ = sig.build().map_err(|err| err.to_string())?;
+    Ok(VapidFile {
+        public_key,
+        private_key,
+    })
+}
+
+fn getrandom_fill(buf: &mut [u8]) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::io::Read;
+        let mut file = File::open("/dev/urandom").map_err(|err| err.to_string())?;
+        file.read_exact(buf).map_err(|err| err.to_string())?;
+        return Ok(());
+    }
+    #[cfg(not(unix))]
+    {
+        // Best-effort fallback for non-unix hosts used in local development.
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        for (index, byte) in buf.iter_mut().enumerate() {
+            *byte = ((nanos >> ((index % 16) * 8)) as u8).wrapping_add(index as u8);
+        }
+        Ok(())
+    }
+}
+
+fn load_subscriptions(path: &Path) -> io::Result<HashMap<String, PushSubscriptionRecord>> {
+    if !path.is_file() {
+        return Ok(HashMap::new());
+    }
+    let text = fs::read_to_string(path)?;
+    let parsed: SubscriptionsFile = serde_json::from_str(&text).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid push subscriptions file: {err}"),
+        )
+    })?;
+    Ok(parsed
+        .subscriptions
+        .into_iter()
+        .map(|sub| (sub.endpoint.clone(), sub))
+        .collect())
+}
+
+fn save_subscriptions(
+    path: &Path,
+    subscriptions: &HashMap<String, PushSubscriptionRecord>,
+) -> io::Result<()> {
+    let file = SubscriptionsFile {
+        subscriptions: subscriptions.values().cloned().collect(),
+    };
+    write_json_private(path, &file)
+}
+
+fn write_json_private<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        ensure_private_dir(parent)?;
+    }
+    let json = serde_json::to_vec_pretty(value)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    let temp_path = path.with_extension(format!(
+        "tmp-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0)
+    ));
+    {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&temp_path)?;
+        file.write_all(&json)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+    }
+    set_private_file_permissions(&temp_path)?;
+    fs::rename(&temp_path, path)?;
+    set_private_file_permissions(path)?;
+    Ok(())
+}
+
+fn is_gone_error(err: &web_push::WebPushError) -> bool {
+    let text = err.to_string().to_ascii_lowercase();
+    text.contains("410")
+        || text.contains("404")
+        || text.contains("gone")
+        || text.contains("not found")
+        || text.contains("unsubscribed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_subscription_bodies() {
+        let value = serde_json::json!({
+            "endpoint": "https://push.example/x",
+            "keys": { "p256dh": "abc", "auth": "def" }
+        });
+        let sub = parse_subscription_body(value).unwrap();
+        assert_eq!(sub.endpoint, "https://push.example/x");
+        assert_eq!(sub.keys.p256dh, "abc");
+    }
+
+    #[test]
+    fn payload_only_for_attention_statuses() {
+        let blocked = AgentPushAlert {
+            pane_id: "w1:p1".into(),
+            workspace_id: "w1".into(),
+            agent_status: AgentStatus::Blocked,
+            agent: Some("claude".into()),
+            title: Some("need input".into()),
+            display_agent: Some("Claude".into()),
+        };
+        let payload = payload_for_alert(&blocked).unwrap();
+        assert_eq!(payload.title, "Claude needs you");
+        assert!(payload_for_alert(&AgentPushAlert {
+            pane_id: "w1:p1".into(),
+            workspace_id: "w1".into(),
+            agent_status: AgentStatus::Working,
+            agent: None,
+            title: None,
+            display_agent: None,
+        })
+        .is_none());
+    }
+
+    #[test]
+    fn generates_vapid_material() {
+        let keys = generate_vapid_keys().expect("vapid generation");
+        assert!(!keys.public_key.is_empty());
+        assert!(!keys.private_key.is_empty());
+        // Public applicationServerKey is URL-safe base64 without padding.
+        assert!(URL_SAFE_NO_PAD.decode(&keys.public_key).is_ok() || STANDARD.decode(&keys.public_key).is_ok());
+    }
+}

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -46,6 +46,7 @@ use herdr_compat::protocol::{
 
 use crate::agent_activity::{AgentActivityListResponse, AgentActivityManager};
 use crate::agent_pins::{AgentPinsError, AgentPinsListResponse, AgentPinsManager};
+use crate::push::{parse_subscription_body, AgentPushAlert, PushManager, WebPushCapability};
 use crate::launcher_presets::{
     layout_leaf_for_preset, split_layout_with_command_preset, CustomCommandPreset,
     LauncherPresetLaunch, LauncherPresetStore, ManagedAgentKind, ResolvedLauncherPreset,
@@ -110,6 +111,8 @@ struct BridgeState {
     agent_pins: Arc<AgentPinsManager>,
     launcher_presets: Arc<LauncherPresetStore>,
     notes: Arc<NotesManager>,
+    push: Arc<PushManager>,
+    runtime: tokio::runtime::Handle,
     ui_event_tx: tokio::sync::broadcast::Sender<String>,
     activity_tx: tokio::sync::broadcast::Sender<ActivityMessage>,
     upload_dir: PathBuf,
@@ -154,6 +157,8 @@ struct Capabilities {
     agent_pins: AgentPinsCapability,
     launcher_presets: LauncherPresetsCapability,
     notes: NotesCapability,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    web_push: Option<WebPushCapability>,
 }
 
 #[derive(Debug, Serialize)]
@@ -935,6 +940,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
             .map_err(|message| io::Error::new(ErrorKind::InvalidInput, message))?,
     );
     let notes = Arc::new(NotesManager::new()?);
+    let push = Arc::new(PushManager::load()?);
     let request_policy = RequestPolicy {
         bind_host: options.host.clone(),
         bind_port: options.port,
@@ -966,6 +972,8 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         agent_pins,
         launcher_presets,
         notes,
+        push,
+        runtime: tokio::runtime::Handle::current(),
         ui_event_tx: tokio::sync::broadcast::channel(256).0,
         activity_tx: tokio::sync::broadcast::channel(512).0,
         upload_dir: options.upload_dir.clone(),
@@ -975,6 +983,15 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         "/api/agent-activity",
         get(agent_activity_list_handler).options(preflight_handler),
     );
+    let push_routes = Router::new()
+        .route(
+            "/api/push/subscribe",
+            post(push_subscribe_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/push/unsubscribe",
+            post(push_unsubscribe_handler).options(preflight_handler),
+        );
     let agent_pins_routes = Router::new()
         .route(
             "/api/agent-pins",
@@ -1034,6 +1051,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         .merge(agent_pins_routes)
         .merge(notes_routes)
         .merge(launcher_preset_routes)
+        .merge(push_routes)
         .route(
             "/api/snapshot",
             get(snapshot_handler).options(preflight_handler),
@@ -2861,6 +2879,54 @@ fn is_default_tab_label(label: &str) -> bool {
     !label.is_empty() && label.chars().all(|ch| ch.is_ascii_digit())
 }
 
+async fn push_subscribe_handler(
+    State(state): State<BridgeState>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> Result<Json<serde_json::Value>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    if !state.push.is_enabled() {
+        return Err(BridgeError::BadRequest(
+            "web push is not configured on this bridge".to_string(),
+        ));
+    }
+    let subscription = parse_subscription_body(body).map_err(BridgeError::BadRequest)?;
+    state.push.subscribe(subscription)?;
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+async fn push_unsubscribe_handler(
+    State(state): State<BridgeState>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> Result<Json<serde_json::Value>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    let endpoint = body
+        .get("endpoint")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| BridgeError::BadRequest("missing endpoint".to_string()))?;
+    let removed = state.push.unsubscribe(endpoint)?;
+    Ok(Json(serde_json::json!({ "ok": true, "removed": removed })))
+}
+
+fn maybe_broadcast_web_push(state: &BridgeState, alert: AgentPushAlert) {
+    if !state.push.is_enabled() {
+        return;
+    }
+    if !matches!(
+        alert.agent_status,
+        AgentStatus::Blocked | AgentStatus::Done
+    ) {
+        return;
+    }
+    let push = state.push.clone();
+    state.runtime.spawn(async move {
+        push.broadcast_alert(&alert).await;
+    });
+}
+
 async fn capabilities_handler(
     State(state): State<BridgeState>,
     headers: HeaderMap,
@@ -2872,6 +2938,7 @@ async fn capabilities_handler(
         agent_pins: AgentPinsCapability { version: 1 },
         launcher_presets: LauncherPresetsCapability { version: 1 },
         notes: NotesCapability { version: 1 },
+        web_push: state.push.capability(),
     }))
 }
 
@@ -3927,7 +3994,11 @@ fn run_agent_activity_subscription(
                 if let Some(message) = activity_message_from_subscription_value(value) {
                     if let ActivityMessage::PaneAgentStatusChanged {
                         pane_id,
+                        workspace_id,
                         agent_status,
+                        agent,
+                        title,
+                        display_agent,
                         ..
                     } = &message
                     {
@@ -3937,6 +4008,17 @@ fn run_agent_activity_subscription(
                         {
                             broadcast_agent_activity_changed(state);
                         }
+                        maybe_broadcast_web_push(
+                            state,
+                            AgentPushAlert {
+                                pane_id: pane_id.clone(),
+                                workspace_id: workspace_id.clone(),
+                                agent_status: *agent_status,
+                                agent: agent.clone(),
+                                title: title.clone(),
+                                display_agent: display_agent.clone(),
+                            },
+                        );
                     }
                     let _ = state.activity_tx.send(message);
                 }

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -4,7 +4,7 @@ import tseslint from "typescript-eslint";
 
 export default [
   {
-    ignores: ["dist/**", "node_modules/**", "*.tsbuildinfo"],
+    ignores: ["dist/**", "node_modules/**", "public/sw.js", "*.tsbuildinfo"],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,102 @@
+/* herdr-web service worker — web push + notification click deep links.
+ * Kept dependency-free so it can be served as a static asset from /sw.js. */
+
+const ICON = "/herdr-logo-192.png";
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+  event.waitUntil(handlePush(event));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const data = event.notification.data || {};
+  const targetUrl = notificationTargetUrl(data);
+  event.waitUntil(openOrFocusClient(targetUrl));
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    void self.skipWaiting();
+  }
+});
+
+async function handlePush(event) {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch {
+    payload = { body: event.data ? event.data.text() : "" };
+  }
+
+  if (payload.type === "clear" && payload.tag) {
+    const stale = await self.registration.getNotifications({ tag: payload.tag });
+    for (const notification of stale) {
+      notification.close();
+    }
+    return;
+  }
+
+  // When a herdr-web tab is visible, in-page Notification/API already covers alerts.
+  if (await anyVisibleClient()) {
+    return;
+  }
+
+  const title = payload.title || "herdr-web";
+  const options = {
+    body: payload.body || "",
+    tag: payload.tag || "herdr-web",
+    renotify: Boolean(payload.renotify),
+    icon: ICON,
+    badge: ICON,
+    data: {
+      paneId: payload.pane_id || payload.paneId || null,
+      workspaceId: payload.workspace_id || payload.workspaceId || null,
+      bridgeId: payload.bridge_id || payload.bridgeId || null,
+    },
+  };
+  await self.registration.showNotification(title, options);
+}
+
+async function anyVisibleClient() {
+  const windows = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+  return windows.some((client) => client.visibilityState === "visible");
+}
+
+function notificationTargetUrl(data) {
+  const url = new URL(self.registration.scope);
+  if (data && data.paneId) {
+    url.searchParams.set("pane", data.paneId);
+  }
+  if (data && data.bridgeId) {
+    url.searchParams.set("bridge", data.bridgeId);
+  }
+  return url.href;
+}
+
+async function openOrFocusClient(targetUrl) {
+  const windows = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+  for (const client of windows) {
+    if ("focus" in client) {
+      await client.focus();
+      if ("navigate" in client && targetUrl) {
+        try {
+          await client.navigate(targetUrl);
+        } catch {
+          // Older clients may reject navigate; focus alone is still useful.
+        }
+      }
+      return;
+    }
+  }
+  if (self.clients.openWindow) {
+    await self.clients.openWindow(targetUrl || "/");
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,6 +65,19 @@ import type { AgentPinsListResponse } from "./agentPins";
 import { applyActivityMessage, parseActivityEventData, replayActivityMessages } from "./activity";
 import type { ActivityLogEntry } from "./activity";
 import { BackendSettingsDialog } from "./BackendSettingsDialog";
+import {
+  countAttentionPanes,
+  DEFAULT_BROWSER_NOTIFICATION_PREFS,
+  DEFAULT_DOCUMENT_TITLE,
+  documentTitleWithBadge,
+  parseBrowserDocumentBadge,
+  parseBrowserNotificationEnabled,
+  parseBrowserNotifyOnBlocked,
+  parseBrowserNotifyOnDone,
+  requestBrowserNotificationPermission,
+  showAgentStatusNotification,
+} from "./browserNotifications";
+import type { BrowserNotificationTarget } from "./browserNotifications";
 import { useBridge } from "./bridge";
 import type { BridgeId, BridgeRuntime } from "./bridge";
 import { createCommands, createdPaneId } from "./commands";
@@ -179,6 +192,7 @@ import type {
   Snapshot,
   TabInfo,
   WorkspaceInfo,
+  PaneAgentStatusChangedMessage,
 } from "./types";
 import {
   workspaceMoveBlockParams,
@@ -414,6 +428,10 @@ type DisplayPrefs = {
   mobileKeyboardHideRefit: boolean;
   mobileCommandExpandingInput: boolean;
   mobileCommandEnterNewline: boolean;
+  browserNotificationsEnabled: boolean;
+  browserNotifyOnBlocked: boolean;
+  browserNotifyOnDone: boolean;
+  browserDocumentBadge: boolean;
 };
 type SharedNavigationPrefs = {
   selectedBridgeId: BridgeId | null;
@@ -477,6 +495,10 @@ function readDisplayPrefs(): DisplayPrefs {
     mobileKeyboardHideRefit: DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
     mobileCommandExpandingInput: DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT,
     mobileCommandEnterNewline: DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
+    browserNotificationsEnabled: DEFAULT_BROWSER_NOTIFICATION_PREFS.enabled,
+    browserNotifyOnBlocked: DEFAULT_BROWSER_NOTIFICATION_PREFS.notifyOnBlocked,
+    browserNotifyOnDone: DEFAULT_BROWSER_NOTIFICATION_PREFS.notifyOnDone,
+    browserDocumentBadge: DEFAULT_BROWSER_NOTIFICATION_PREFS.documentBadge,
   };
   try {
     const raw = window.localStorage.getItem(DISPLAY_PREFS_KEY);
@@ -681,6 +703,22 @@ function parseDisplayPrefsValue(
     ),
     mobileCommandEnterNewline: parseMobileCommandEnterNewline(
       parsed.mobileCommandEnterNewline,
+    ),
+    browserNotificationsEnabled: parseBrowserNotificationEnabled(
+      parsed.browserNotificationsEnabled,
+      fallback.browserNotificationsEnabled,
+    ),
+    browserNotifyOnBlocked: parseBrowserNotifyOnBlocked(
+      parsed.browserNotifyOnBlocked,
+      fallback.browserNotifyOnBlocked,
+    ),
+    browserNotifyOnDone: parseBrowserNotifyOnDone(
+      parsed.browserNotifyOnDone,
+      fallback.browserNotifyOnDone,
+    ),
+    browserDocumentBadge: parseBrowserDocumentBadge(
+      parsed.browserDocumentBadge,
+      fallback.browserDocumentBadge,
     ),
   };
 }
@@ -1070,6 +1108,27 @@ export function App() {
   const [mobileCommandEnterNewline, setMobileCommandEnterNewline] = useState(
     initialPrefs.mobileCommandEnterNewline,
   );
+  const [browserNotificationsEnabled, setBrowserNotificationsEnabled] = useState(
+    initialPrefs.browserNotificationsEnabled,
+  );
+  const [browserNotifyOnBlocked, setBrowserNotifyOnBlocked] = useState(
+    initialPrefs.browserNotifyOnBlocked,
+  );
+  const [browserNotifyOnDone, setBrowserNotifyOnDone] = useState(
+    initialPrefs.browserNotifyOnDone,
+  );
+  const [browserDocumentBadge, setBrowserDocumentBadge] = useState(
+    initialPrefs.browserDocumentBadge,
+  );
+  const browserNotificationPrefsRef = useRef({
+    enabled: initialPrefs.browserNotificationsEnabled,
+    notifyOnBlocked: initialPrefs.browserNotifyOnBlocked,
+    notifyOnDone: initialPrefs.browserNotifyOnDone,
+    documentBadge: initialPrefs.browserDocumentBadge,
+  });
+  const openPaneFromNotificationRef = useRef<(target: BrowserNotificationTarget) => void>(
+    () => undefined,
+  );
   const [launchTarget, setLaunchTarget] = useState<ScopedLaunchTarget | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -1174,6 +1233,10 @@ export function App() {
       setMobileKeyboardHideRefit(prefs.mobileKeyboardHideRefit);
       setMobileCommandExpandingInput(prefs.mobileCommandExpandingInput);
       setMobileCommandEnterNewline(prefs.mobileCommandEnterNewline);
+      setBrowserNotificationsEnabled(prefs.browserNotificationsEnabled);
+      setBrowserNotifyOnBlocked(prefs.browserNotifyOnBlocked);
+      setBrowserNotifyOnDone(prefs.browserNotifyOnDone);
+      setBrowserDocumentBadge(prefs.browserDocumentBadge);
       setDisplayPrefsLoaded(true);
       },
     );
@@ -1716,6 +1779,10 @@ export function App() {
       mobileKeyboardHideRefit,
       mobileCommandExpandingInput,
       mobileCommandEnterNewline,
+      browserNotificationsEnabled,
+      browserNotifyOnBlocked,
+      browserNotifyOnDone,
+      browserDocumentBadge,
     });
   }, [
     displayPrefsLoaded,
@@ -1751,6 +1818,24 @@ export function App() {
     mobileKeyboardHideRefit,
     mobileCommandExpandingInput,
     mobileCommandEnterNewline,
+    browserNotificationsEnabled,
+    browserNotifyOnBlocked,
+    browserNotifyOnDone,
+    browserDocumentBadge,
+  ]);
+
+  useEffect(() => {
+    browserNotificationPrefsRef.current = {
+      enabled: browserNotificationsEnabled,
+      notifyOnBlocked: browserNotifyOnBlocked,
+      notifyOnDone: browserNotifyOnDone,
+      documentBadge: browserDocumentBadge,
+    };
+  }, [
+    browserNotificationsEnabled,
+    browserNotifyOnBlocked,
+    browserNotifyOnDone,
+    browserDocumentBadge,
   ]);
 
   useEffect(() => {
@@ -2325,6 +2410,71 @@ export function App() {
       openMobileDetail();
     }
   };
+
+  openPaneFromNotificationRef.current = (target) => {
+    const snapshot = snapshotForBridge(target.bridgeId);
+    const pane = snapshot?.panes.find((candidate) => candidate.pane_id === target.paneId);
+    if (pane) {
+      openPane(target.bridgeId, pane);
+      return;
+    }
+    setSelectedBridgeId(target.bridgeId);
+    rememberPaneSelection(target.bridgeId, target.paneId, target.workspaceId);
+  };
+
+  const handleAgentStatusActivity = useCallback(
+    (bridgeId: BridgeId, message: PaneAgentStatusChangedMessage) => {
+      const runtime = bridge.getRuntime(bridgeId);
+      showAgentStatusNotification({
+        bridgeId,
+        message,
+        prefs: browserNotificationPrefsRef.current,
+        bridgeLabel: runtime?.label ?? bridgeId,
+        onClick: (target) => openPaneFromNotificationRef.current(target),
+      });
+    },
+    [bridge],
+  );
+
+  const attentionCount = useMemo(() => {
+    return Object.values(connectionStates).reduce((total, state) => {
+      if (!state.snapshot) {
+        return total;
+      }
+      return total + countAttentionPanes(state.snapshot.panes);
+    }, 0);
+  }, [connectionStates]);
+
+  useEffect(() => {
+    document.title = documentTitleWithBadge(
+      DEFAULT_DOCUMENT_TITLE,
+      attentionCount,
+      browserDocumentBadge,
+    );
+    return () => {
+      document.title = DEFAULT_DOCUMENT_TITLE;
+    };
+  }, [attentionCount, browserDocumentBadge]);
+
+  const setBrowserNotificationsEnabledWithPermission = useCallback(async (enabled: boolean) => {
+    if (!enabled) {
+      setBrowserNotificationsEnabled(false);
+      return;
+    }
+    const permission = await requestBrowserNotificationPermission();
+    if (permission === "granted") {
+      setBrowserNotificationsEnabled(true);
+      return;
+    }
+    setBrowserNotificationsEnabled(false);
+    if (permission === "denied") {
+      setError("Browser notifications are blocked. Enable them in the browser site settings.");
+      return;
+    }
+    if (permission === "unsupported") {
+      setError("This browser does not support desktop notifications.");
+    }
+  }, []);
 
   const requestTerminalFocus = () => setTerminalFocusToken((token) => token + 1);
   const requestNoteTitleFocus = (bridgeId: BridgeId, noteId: string) => {
@@ -3706,6 +3856,7 @@ export function App() {
           setConnectionStates={setConnectionStates}
           onPaneSelection={applySharedPaneSelection}
           onAgentActivityChanged={refreshAgentActivityForBridge}
+          onAgentStatusActivity={handleAgentStatusActivity}
           onAgentPinsChanged={refreshAgentPinsForBridge}
           onNotesChanged={refreshNotesForBridge}
         />
@@ -4273,6 +4424,16 @@ export function App() {
           showMobileTerminalSettings={isTouchInput}
           notesEnabled={notesEnabled}
           onNotesEnabled={setNotesEnabled}
+          browserNotificationsEnabled={browserNotificationsEnabled}
+          onBrowserNotificationsEnabled={(enabled) => {
+            void setBrowserNotificationsEnabledWithPermission(enabled);
+          }}
+          browserNotifyOnBlocked={browserNotifyOnBlocked}
+          onBrowserNotifyOnBlocked={setBrowserNotifyOnBlocked}
+          browserNotifyOnDone={browserNotifyOnDone}
+          onBrowserNotifyOnDone={setBrowserNotifyOnDone}
+          browserDocumentBadge={browserDocumentBadge}
+          onBrowserDocumentBadge={setBrowserDocumentBadge}
           navigationSyncMode={navigationSyncMode}
           onNavigationSyncMode={changeNavigationSyncMode}
           agentFeaturesInTabs={agentFeaturesInTabs}
@@ -4359,6 +4520,7 @@ export function BridgeConnectionController({
   setConnectionStates,
   onPaneSelection,
   onAgentActivityChanged,
+  onAgentStatusActivity,
   onAgentPinsChanged,
   onNotesChanged,
 }: {
@@ -4368,12 +4530,14 @@ export function BridgeConnectionController({
   setConnectionStates: Dispatch<SetStateAction<Record<string, BridgeConnectionState>>>;
   onPaneSelection: (bridgeId: BridgeId, paneId: string, workspaceId?: string) => void;
   onAgentActivityChanged: (bridgeId: BridgeId) => void;
+  onAgentStatusActivity: (bridgeId: BridgeId, message: PaneAgentStatusChangedMessage) => void;
   onAgentPinsChanged: (bridgeId: BridgeId) => void;
   onNotesChanged: (bridgeId: BridgeId) => void;
 }) {
   const httpUrlRef = useRef(runtime.httpUrl);
   const wsUrlRef = useRef(runtime.wsUrl);
   const onAgentActivityChangedRef = useRef(onAgentActivityChanged);
+  const onAgentStatusActivityRef = useRef(onAgentStatusActivity);
   const onAgentPinsChangedRef = useRef(onAgentPinsChanged);
   const onNotesChangedRef = useRef(onNotesChanged);
   const followSharedSelectionRef = useRef(followSharedSelection);
@@ -4387,11 +4551,13 @@ export function BridgeConnectionController({
   useEffect(() => {
     followSharedSelectionRef.current = followSharedSelection;
     onAgentActivityChangedRef.current = onAgentActivityChanged;
+    onAgentStatusActivityRef.current = onAgentStatusActivity;
     onAgentPinsChangedRef.current = onAgentPinsChanged;
     onNotesChangedRef.current = onNotesChanged;
   }, [
     followSharedSelection,
     onAgentActivityChanged,
+    onAgentStatusActivity,
     onAgentPinsChanged,
     onNotesChanged,
   ]);
@@ -4528,6 +4694,9 @@ export function BridgeConnectionController({
               loadState: "ready",
             },
           }));
+          if (parsed.message.type === "pane.agent_status_changed") {
+            onAgentStatusActivityRef.current(runtime.id, parsed.message);
+          }
         } else if (result.status === "resync") {
           requestActivityResync();
         }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -78,6 +78,14 @@ import {
   showAgentStatusNotification,
 } from "./browserNotifications";
 import type { BrowserNotificationTarget } from "./browserNotifications";
+import {
+  getCurrentPushSubscription,
+  isWebPushBrowserSupported,
+  registerHerdrServiceWorker,
+  subscribeWebPush,
+  supportsWebPushCapability,
+  unsubscribeWebPush,
+} from "./webPush";
 import { useBridge } from "./bridge";
 import type { BridgeId, BridgeRuntime } from "./bridge";
 import { createCommands, createdPaneId } from "./commands";
@@ -2476,6 +2484,94 @@ export function App() {
     }
   }, []);
 
+  const [webPushEnabled, setWebPushEnabled] = useState(false);
+  const [webPushBusy, setWebPushBusy] = useState(false);
+  const [webPushStatus, setWebPushStatus] = useState<string | null>(null);
+  const webPushPublicKey =
+    selectedRuntime && supportsWebPushCapability(selectedRuntime.capabilities)
+      ? selectedRuntime.capabilities.web_push.public_key
+      : null;
+  const webPushAvailable = Boolean(
+    webPushPublicKey && isWebPushBrowserSupported() && selectedRuntime?.canConnect,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (!webPushAvailable) {
+        if (!cancelled) {
+          setWebPushEnabled(false);
+          setWebPushStatus(
+            !isWebPushBrowserSupported()
+              ? "Background push needs a secure context (HTTPS or localhost)."
+              : !webPushPublicKey
+                ? "This bridge has no VAPID web-push keys."
+                : null,
+          );
+        }
+        return;
+      }
+      const registration = await registerHerdrServiceWorker();
+      const subscription = await getCurrentPushSubscription(registration);
+      if (!cancelled) {
+        setWebPushEnabled(Boolean(subscription));
+        setWebPushStatus(subscription ? "Subscribed to background push." : null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [webPushAvailable, webPushPublicKey, selectedRuntime?.id]);
+
+  const setWebPushEnabledWithSubscribe = useCallback(
+    async (enabled: boolean) => {
+      if (!selectedRuntime || !webPushPublicKey) {
+        setWebPushStatus("Select a bridge that advertises web_push capability.");
+        return;
+      }
+      setWebPushBusy(true);
+      try {
+        const registration = await registerHerdrServiceWorker();
+        if (!registration) {
+          setWebPushEnabled(false);
+          setWebPushStatus("Service worker registration failed.");
+          return;
+        }
+        if (!enabled) {
+          await unsubscribeWebPush({
+            httpUrl: selectedRuntime.httpUrl,
+            registration,
+          });
+          setWebPushEnabled(false);
+          setWebPushStatus("Background push disabled.");
+          return;
+        }
+        const permission = await requestBrowserNotificationPermission();
+        if (permission !== "granted") {
+          setWebPushEnabled(false);
+          setWebPushStatus("Notification permission is required for background push.");
+          return;
+        }
+        await subscribeWebPush({
+          httpUrl: selectedRuntime.httpUrl,
+          publicKey: webPushPublicKey,
+          registration,
+        });
+        setWebPushEnabled(true);
+        setBrowserNotificationsEnabled(true);
+        setWebPushStatus("Subscribed to background push.");
+      } catch (caught) {
+        setWebPushEnabled(false);
+        setWebPushStatus(
+          caught instanceof Error ? caught.message : "Could not update background push.",
+        );
+      } finally {
+        setWebPushBusy(false);
+      }
+    },
+    [selectedRuntime, webPushPublicKey],
+  );
+
   const requestTerminalFocus = () => setTerminalFocusToken((token) => token + 1);
   const requestNoteTitleFocus = (bridgeId: BridgeId, noteId: string) => {
     setNoteTitleFocusRequest((current) => ({
@@ -4434,6 +4530,13 @@ export function App() {
           onBrowserNotifyOnDone={setBrowserNotifyOnDone}
           browserDocumentBadge={browserDocumentBadge}
           onBrowserDocumentBadge={setBrowserDocumentBadge}
+          webPushAvailable={webPushAvailable}
+          webPushEnabled={webPushEnabled}
+          webPushBusy={webPushBusy}
+          webPushStatus={webPushStatus}
+          onWebPushEnabled={(enabled) => {
+            void setWebPushEnabledWithSubscribe(enabled);
+          }}
           navigationSyncMode={navigationSyncMode}
           onNavigationSyncMode={changeNavigationSyncMode}
           agentFeaturesInTabs={agentFeaturesInTabs}

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -69,6 +69,11 @@ type Props = {
   onBrowserNotifyOnDone: (enabled: boolean) => void;
   browserDocumentBadge: boolean;
   onBrowserDocumentBadge: (enabled: boolean) => void;
+  webPushAvailable: boolean;
+  webPushEnabled: boolean;
+  webPushBusy: boolean;
+  webPushStatus: string | null;
+  onWebPushEnabled: (enabled: boolean) => void;
   navigationSyncMode: NavigationSyncMode;
   onNavigationSyncMode: (mode: NavigationSyncMode) => void;
   agentFeaturesInTabs: boolean;
@@ -131,6 +136,11 @@ export function BackendSettingsDialog({
   onBrowserNotifyOnDone,
   browserDocumentBadge,
   onBrowserDocumentBadge,
+  webPushAvailable,
+  webPushEnabled,
+  webPushBusy,
+  webPushStatus,
+  onWebPushEnabled,
   navigationSyncMode,
   onNavigationSyncMode,
   agentFeaturesInTabs,
@@ -633,6 +643,40 @@ export function BackendSettingsDialog({
                       </button>
                     </div>
                   </div>
+                  <div className="settings-row">
+                    <span title="Receive blocked/done alerts when the tab is closed (requires HTTPS or localhost and bridge VAPID)">
+                      Background push
+                    </span>
+                    <div
+                      className="segmented-control"
+                      role="group"
+                      aria-label="Background web push"
+                    >
+                      <button
+                        type="button"
+                        data-on={!webPushEnabled}
+                        aria-pressed={!webPushEnabled}
+                        disabled={!webPushAvailable || webPushBusy}
+                        onClick={() => onWebPushEnabled(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={webPushEnabled}
+                        aria-pressed={webPushEnabled}
+                        disabled={!webPushAvailable || webPushBusy}
+                        onClick={() => onWebPushEnabled(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                  {webPushStatus ? (
+                    <p className="settings-hint" role="status">
+                      {webPushStatus}
+                    </p>
+                  ) : null}
                 </div>
               </>
             ) : null}

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -61,6 +61,14 @@ type Props = {
   showMobileTerminalSettings: boolean;
   notesEnabled: boolean;
   onNotesEnabled: (enabled: boolean) => void;
+  browserNotificationsEnabled: boolean;
+  onBrowserNotificationsEnabled: (enabled: boolean) => void;
+  browserNotifyOnBlocked: boolean;
+  onBrowserNotifyOnBlocked: (enabled: boolean) => void;
+  browserNotifyOnDone: boolean;
+  onBrowserNotifyOnDone: (enabled: boolean) => void;
+  browserDocumentBadge: boolean;
+  onBrowserDocumentBadge: (enabled: boolean) => void;
   navigationSyncMode: NavigationSyncMode;
   onNavigationSyncMode: (mode: NavigationSyncMode) => void;
   agentFeaturesInTabs: boolean;
@@ -115,6 +123,14 @@ export function BackendSettingsDialog({
   showMobileTerminalSettings,
   notesEnabled,
   onNotesEnabled,
+  browserNotificationsEnabled,
+  onBrowserNotificationsEnabled,
+  browserNotifyOnBlocked,
+  onBrowserNotifyOnBlocked,
+  browserNotifyOnDone,
+  onBrowserNotifyOnDone,
+  browserDocumentBadge,
+  onBrowserDocumentBadge,
   navigationSyncMode,
   onNavigationSyncMode,
   agentFeaturesInTabs,
@@ -490,30 +506,135 @@ export function BackendSettingsDialog({
             ) : null}
 
             {activeArea === "features" ? (
-              <div className="settings-section settings-section-flat">
-                <div className="settings-label">Client features</div>
-                <div className="settings-row">
-                  <span>Notes</span>
-                  <div className="segmented-control" role="group" aria-label="Notes feature">
-                    <button
-                      type="button"
-                      data-on={!notesEnabled}
-                      aria-pressed={!notesEnabled}
-                      onClick={() => onNotesEnabled(false)}
-                    >
-                      Off
-                    </button>
-                    <button
-                      type="button"
-                      data-on={notesEnabled}
-                      aria-pressed={notesEnabled}
-                      onClick={() => onNotesEnabled(true)}
-                    >
-                      On
-                    </button>
+              <>
+                <div className="settings-section settings-section-flat">
+                  <div className="settings-label">Client features</div>
+                  <div className="settings-row">
+                    <span>Notes</span>
+                    <div className="segmented-control" role="group" aria-label="Notes feature">
+                      <button
+                        type="button"
+                        data-on={!notesEnabled}
+                        aria-pressed={!notesEnabled}
+                        onClick={() => onNotesEnabled(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={notesEnabled}
+                        aria-pressed={notesEnabled}
+                        onClick={() => onNotesEnabled(true)}
+                      >
+                        On
+                      </button>
+                    </div>
                   </div>
                 </div>
-              </div>
+                <div className="settings-section settings-section-flat">
+                  <div className="settings-label">Browser notifications</div>
+                  <div className="settings-row">
+                    <span title="Show a desktop notification when an agent becomes blocked or done">
+                      Desktop alerts
+                    </span>
+                    <div
+                      className="segmented-control"
+                      role="group"
+                      aria-label="Browser notifications"
+                    >
+                      <button
+                        type="button"
+                        data-on={!browserNotificationsEnabled}
+                        aria-pressed={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotificationsEnabled(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={browserNotificationsEnabled}
+                        aria-pressed={browserNotificationsEnabled}
+                        onClick={() => onBrowserNotificationsEnabled(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                  <div className="settings-row">
+                    <span>Notify when blocked</span>
+                    <div
+                      className="segmented-control"
+                      role="group"
+                      aria-label="Notify when blocked"
+                    >
+                      <button
+                        type="button"
+                        data-on={!browserNotifyOnBlocked}
+                        aria-pressed={!browserNotifyOnBlocked}
+                        disabled={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotifyOnBlocked(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={browserNotifyOnBlocked}
+                        aria-pressed={browserNotifyOnBlocked}
+                        disabled={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotifyOnBlocked(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                  <div className="settings-row">
+                    <span>Notify when done</span>
+                    <div className="segmented-control" role="group" aria-label="Notify when done">
+                      <button
+                        type="button"
+                        data-on={!browserNotifyOnDone}
+                        aria-pressed={!browserNotifyOnDone}
+                        disabled={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotifyOnDone(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={browserNotifyOnDone}
+                        aria-pressed={browserNotifyOnDone}
+                        disabled={!browserNotificationsEnabled}
+                        onClick={() => onBrowserNotifyOnDone(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                  <div className="settings-row">
+                    <span title="Prefix the tab title with the number of blocked or done agents">
+                      Tab badge
+                    </span>
+                    <div className="segmented-control" role="group" aria-label="Document title badge">
+                      <button
+                        type="button"
+                        data-on={!browserDocumentBadge}
+                        aria-pressed={!browserDocumentBadge}
+                        onClick={() => onBrowserDocumentBadge(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={browserDocumentBadge}
+                        aria-pressed={browserDocumentBadge}
+                        onClick={() => onBrowserDocumentBadge(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </>
             ) : null}
 
             {activeArea === "display" ? (

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -681,6 +681,7 @@ function createConnectionHarness({
           setConnectionStates={setConnectionStates}
           onPaneSelection={onPaneSelection}
           onAgentActivityChanged={() => undefined}
+          onAgentStatusActivity={() => undefined}
           onAgentPinsChanged={() => undefined}
           onNotesChanged={onNotesChanged}
         />,

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -48,6 +48,10 @@ export type BridgeCapabilities = {
   launcher_presets?: {
     version: 1;
   };
+  web_push?: {
+    version: 1;
+    public_key: string;
+  };
   bridge_version?: string;
   web_compat?: number;
   min_android_app_compat?: number;
@@ -1085,6 +1089,13 @@ export function parseCapabilities(value: unknown): BridgeCapabilities {
     launcher_presets:
       isRecord(value.launcher_presets) && value.launcher_presets.version === 1
         ? { version: 1 }
+        : undefined,
+    web_push:
+      isRecord(value.web_push) &&
+      value.web_push.version === 1 &&
+      typeof value.web_push.public_key === "string" &&
+      value.web_push.public_key.length > 0
+        ? { version: 1, public_key: value.web_push.public_key }
         : undefined,
   };
 }

--- a/web/src/browserNotifications.test.ts
+++ b/web/src/browserNotifications.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  browserNotificationBody,
+  browserNotificationTag,
+  browserNotificationTitle,
+  browserNotificationTarget,
+  countAttentionPanes,
+  DEFAULT_BROWSER_NOTIFICATION_PREFS,
+  documentTitleWithBadge,
+  parseBrowserNotificationPrefs,
+  parseBrowserNotificationTarget,
+  requestBrowserNotificationPermission,
+  shouldNotifyAgentStatus,
+  showAgentStatusNotification,
+} from "./browserNotifications";
+import type { PaneAgentStatusChangedMessage, PaneInfo } from "./types";
+
+function message(
+  overrides: Partial<PaneAgentStatusChangedMessage> = {},
+): PaneAgentStatusChangedMessage {
+  return {
+    type: "pane.agent_status_changed",
+    pane_id: "w1:p1",
+    workspace_id: "w1",
+    agent_status: "blocked",
+    agent: "claude",
+    title: "fix auth",
+    display_agent: "Claude",
+    state_labels: {},
+    ...overrides,
+  };
+}
+
+describe("browser notification prefs", () => {
+  it("parses known booleans and falls back otherwise", () => {
+    expect(
+      parseBrowserNotificationPrefs({
+        enabled: true,
+        notifyOnBlocked: false,
+        notifyOnDone: true,
+        documentBadge: false,
+      }),
+    ).toEqual({
+      enabled: true,
+      notifyOnBlocked: false,
+      notifyOnDone: true,
+      documentBadge: false,
+    });
+    expect(parseBrowserNotificationPrefs({})).toEqual(DEFAULT_BROWSER_NOTIFICATION_PREFS);
+    expect(parseBrowserNotificationPrefs(null)).toEqual(DEFAULT_BROWSER_NOTIFICATION_PREFS);
+  });
+});
+
+describe("shouldNotifyAgentStatus", () => {
+  it("respects the master switch and per-status toggles", () => {
+    expect(
+      shouldNotifyAgentStatus("blocked", {
+        enabled: false,
+        notifyOnBlocked: true,
+        notifyOnDone: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldNotifyAgentStatus("blocked", {
+        enabled: true,
+        notifyOnBlocked: true,
+        notifyOnDone: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldNotifyAgentStatus("done", {
+        enabled: true,
+        notifyOnBlocked: true,
+        notifyOnDone: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldNotifyAgentStatus("working", {
+        enabled: true,
+        notifyOnBlocked: true,
+        notifyOnDone: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("notification copy and tags", () => {
+  it("builds attention-oriented titles and bodies", () => {
+    expect(browserNotificationTitle(message())).toBe("Claude needs you");
+    expect(browserNotificationTitle(message({ agent_status: "done" }))).toBe("Claude is done");
+    expect(browserNotificationBody(message(), "laptop")).toBe("laptop · fix auth · w1:p1");
+    expect(browserNotificationTag("bridge-a", "w1:p1")).toBe("herdr-web:agent:bridge-a:w1:p1");
+  });
+
+  it("round-trips notification click targets", () => {
+    const target = browserNotificationTarget("b1", message());
+    expect(target).toEqual({ bridgeId: "b1", paneId: "w1:p1", workspaceId: "w1" });
+    expect(parseBrowserNotificationTarget(target)).toEqual(target);
+    expect(parseBrowserNotificationTarget({ bridgeId: "b1" })).toBeNull();
+  });
+});
+
+describe("document title badge", () => {
+  it("prefixes attention counts when enabled", () => {
+    expect(documentTitleWithBadge("herdr-web", 0, true)).toBe("herdr-web");
+    expect(documentTitleWithBadge("herdr-web", 3, true)).toBe("(3) herdr-web");
+    expect(documentTitleWithBadge("herdr-web", 3, false)).toBe("herdr-web");
+  });
+
+  it("counts blocked and done panes", () => {
+    const panes = [
+      { agent_status: "blocked" },
+      { agent_status: "done" },
+      { agent_status: "working" },
+      { agent_status: "idle" },
+    ] as PaneInfo[];
+    expect(countAttentionPanes(panes)).toBe(2);
+  });
+});
+
+describe("showAgentStatusNotification", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a notification when enabled and permission is granted", () => {
+    function MockNotification(this: { close: () => void; onclick: null }, title: string, options?: NotificationOptions) {
+      void title;
+      void options;
+      this.close = vi.fn();
+      this.onclick = null;
+    }
+    MockNotification.permission = "granted" as NotificationPermission;
+    MockNotification.requestPermission = async () => "granted" as NotificationPermission;
+    const NotificationCtor = vi.fn(MockNotification) as unknown as typeof Notification;
+    Object.defineProperty(NotificationCtor, "permission", { value: "granted" });
+
+    const shown = showAgentStatusNotification({
+      bridgeId: "b1",
+      message: message(),
+      prefs: { ...DEFAULT_BROWSER_NOTIFICATION_PREFS, enabled: true },
+      bridgeLabel: "dev",
+      NotificationCtor,
+      onClick: vi.fn(),
+    });
+
+    expect(shown).toBe(true);
+    expect(NotificationCtor).toHaveBeenCalledWith(
+      "Claude needs you",
+      expect.objectContaining({
+        body: "dev · fix auth · w1:p1",
+        tag: "herdr-web:agent:b1:w1:p1",
+        renotify: true,
+        data: { bridgeId: "b1", paneId: "w1:p1", workspaceId: "w1" },
+      }),
+    );
+  });
+
+  it("skips when permission is not granted", () => {
+    function MockNotification() {
+      return undefined;
+    }
+    const NotificationCtor = vi.fn(MockNotification) as unknown as typeof Notification;
+    Object.defineProperty(NotificationCtor, "permission", { value: "denied" });
+    expect(
+      showAgentStatusNotification({
+        bridgeId: "b1",
+        message: message(),
+        prefs: { ...DEFAULT_BROWSER_NOTIFICATION_PREFS, enabled: true },
+        NotificationCtor,
+      }),
+    ).toBe(false);
+    expect(NotificationCtor).not.toHaveBeenCalled();
+  });
+});
+
+describe("requestBrowserNotificationPermission", () => {
+  it("returns unsupported when Notification is missing", async () => {
+    await expect(requestBrowserNotificationPermission(undefined)).resolves.toBe("unsupported");
+  });
+
+  it("requests permission when still default", async () => {
+    const requestPermission = vi.fn(async () => "granted" as NotificationPermission);
+    function MockNotification() {
+      return undefined;
+    }
+    MockNotification.permission = "default" as NotificationPermission;
+    MockNotification.requestPermission = requestPermission;
+    await expect(
+      requestBrowserNotificationPermission(
+        MockNotification as unknown as typeof Notification,
+      ),
+    ).resolves.toBe("granted");
+    expect(requestPermission).toHaveBeenCalled();
+  });
+});

--- a/web/src/browserNotifications.ts
+++ b/web/src/browserNotifications.ts
@@ -1,0 +1,277 @@
+import { isAttention } from "./state";
+import type { AgentStatus, PaneAgentStatusChangedMessage, PaneInfo } from "./types";
+
+export type BrowserNotificationPrefs = {
+  enabled: boolean;
+  notifyOnBlocked: boolean;
+  notifyOnDone: boolean;
+  documentBadge: boolean;
+};
+
+export type BrowserNotificationTarget = {
+  bridgeId: string;
+  paneId: string;
+  workspaceId: string;
+};
+
+export const DEFAULT_BROWSER_NOTIFICATION_PREFS: BrowserNotificationPrefs = {
+  enabled: false,
+  notifyOnBlocked: true,
+  notifyOnDone: true,
+  documentBadge: true,
+};
+
+export const DEFAULT_DOCUMENT_TITLE = "herdr-web";
+
+export function parseBrowserNotificationEnabled(
+  value: unknown,
+  fallback = DEFAULT_BROWSER_NOTIFICATION_PREFS.enabled,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseBrowserNotifyOnBlocked(
+  value: unknown,
+  fallback = DEFAULT_BROWSER_NOTIFICATION_PREFS.notifyOnBlocked,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseBrowserNotifyOnDone(
+  value: unknown,
+  fallback = DEFAULT_BROWSER_NOTIFICATION_PREFS.notifyOnDone,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseBrowserDocumentBadge(
+  value: unknown,
+  fallback = DEFAULT_BROWSER_NOTIFICATION_PREFS.documentBadge,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseBrowserNotificationPrefs(
+  value: Partial<BrowserNotificationPrefs> | null | undefined,
+  fallback: BrowserNotificationPrefs = DEFAULT_BROWSER_NOTIFICATION_PREFS,
+): BrowserNotificationPrefs {
+  return {
+    enabled: parseBrowserNotificationEnabled(value?.enabled, fallback.enabled),
+    notifyOnBlocked: parseBrowserNotifyOnBlocked(value?.notifyOnBlocked, fallback.notifyOnBlocked),
+    notifyOnDone: parseBrowserNotifyOnDone(value?.notifyOnDone, fallback.notifyOnDone),
+    documentBadge: parseBrowserDocumentBadge(value?.documentBadge, fallback.documentBadge),
+  };
+}
+
+/** Statuses that can raise a browser notification when prefs allow. */
+export function shouldNotifyAgentStatus(
+  status: AgentStatus,
+  prefs: Pick<BrowserNotificationPrefs, "enabled" | "notifyOnBlocked" | "notifyOnDone">,
+): boolean {
+  if (!prefs.enabled) {
+    return false;
+  }
+  if (status === "blocked") {
+    return prefs.notifyOnBlocked;
+  }
+  if (status === "done") {
+    return prefs.notifyOnDone;
+  }
+  return false;
+}
+
+export function browserNotificationTag(bridgeId: string, paneId: string) {
+  return `herdr-web:agent:${bridgeId}:${paneId}`;
+}
+
+export function browserNotificationTitle(message: PaneAgentStatusChangedMessage): string {
+  const agent =
+    message.display_agent?.trim() ||
+    message.agent?.trim() ||
+    message.title?.trim() ||
+    "Agent";
+  if (message.agent_status === "blocked") {
+    return `${agent} needs you`;
+  }
+  if (message.agent_status === "done") {
+    return `${agent} is done`;
+  }
+  return agent;
+}
+
+export function browserNotificationBody(
+  message: PaneAgentStatusChangedMessage,
+  bridgeLabel?: string | null,
+): string {
+  const parts: string[] = [];
+  if (bridgeLabel?.trim()) {
+    parts.push(bridgeLabel.trim());
+  }
+  const title = message.title?.trim();
+  if (title && title !== message.display_agent?.trim() && title !== message.agent?.trim()) {
+    parts.push(title);
+  }
+  parts.push(message.pane_id);
+  return parts.join(" · ");
+}
+
+export function browserNotificationTarget(
+  bridgeId: string,
+  message: Pick<PaneAgentStatusChangedMessage, "pane_id" | "workspace_id">,
+): BrowserNotificationTarget {
+  return {
+    bridgeId,
+    paneId: message.pane_id,
+    workspaceId: message.workspace_id,
+  };
+}
+
+export function parseBrowserNotificationTarget(value: unknown): BrowserNotificationTarget | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (
+    typeof value.bridgeId !== "string" ||
+    typeof value.paneId !== "string" ||
+    typeof value.workspaceId !== "string"
+  ) {
+    return null;
+  }
+  return {
+    bridgeId: value.bridgeId,
+    paneId: value.paneId,
+    workspaceId: value.workspaceId,
+  };
+}
+
+export function countAttentionPanes(panes: readonly PaneInfo[]) {
+  return panes.reduce((total, pane) => (isAttention(pane.agent_status) ? total + 1 : total), 0);
+}
+
+export function documentTitleWithBadge(
+  baseTitle: string,
+  attentionCount: number,
+  badgeEnabled: boolean,
+): string {
+  if (!badgeEnabled || attentionCount <= 0) {
+    return baseTitle;
+  }
+  return `(${attentionCount}) ${baseTitle}`;
+}
+
+type NotificationApi = {
+  permission: NotificationPermission;
+  requestPermission: () => Promise<NotificationPermission>;
+  new (title: string, options?: NotificationOptions): Notification;
+};
+
+export function isBrowserNotificationApiSupported(
+  notificationCtor: NotificationApi | typeof Notification | undefined = globalNotification(),
+): boolean {
+  return (
+    typeof notificationCtor === "function" &&
+    typeof (notificationCtor as NotificationApi).permission === "string"
+  );
+}
+
+export function browserNotificationPermission(
+  notificationCtor: NotificationApi | typeof Notification | undefined = globalNotification(),
+): NotificationPermission | "unsupported" {
+  if (!isBrowserNotificationApiSupported(notificationCtor)) {
+    return "unsupported";
+  }
+  return (notificationCtor as NotificationApi).permission;
+}
+
+/**
+ * Request browser permission when enabling notifications.
+ * Returns the resulting permission; does not change prefs.
+ */
+export async function requestBrowserNotificationPermission(
+  notificationCtor: NotificationApi | typeof Notification | undefined = globalNotification(),
+): Promise<NotificationPermission | "unsupported"> {
+  if (!isBrowserNotificationApiSupported(notificationCtor)) {
+    return "unsupported";
+  }
+  const api = notificationCtor as NotificationApi;
+  if (api.permission === "granted" || api.permission === "denied") {
+    return api.permission;
+  }
+  try {
+    return await api.requestPermission();
+  } catch {
+    return "denied";
+  }
+}
+
+export type ShowAgentStatusNotificationOptions = {
+  bridgeId: string;
+  message: PaneAgentStatusChangedMessage;
+  prefs: BrowserNotificationPrefs;
+  bridgeLabel?: string | null;
+  permission?: NotificationPermission | "unsupported";
+  NotificationCtor?: typeof Notification | undefined;
+  onClick?: (target: BrowserNotificationTarget) => void;
+};
+
+/**
+ * Show a desktop Notification for an agent status transition when prefs/permission allow.
+ * Returns true when a notification was created.
+ */
+export function showAgentStatusNotification(options: ShowAgentStatusNotificationOptions): boolean {
+  const {
+    bridgeId,
+    message,
+    prefs,
+    bridgeLabel,
+    onClick,
+  } = options;
+  if (!shouldNotifyAgentStatus(message.agent_status, prefs)) {
+    return false;
+  }
+  const NotificationCtor = options.NotificationCtor ?? globalNotification();
+  if (!isBrowserNotificationApiSupported(NotificationCtor)) {
+    return false;
+  }
+  const permission = options.permission ?? NotificationCtor!.permission;
+  if (permission !== "granted") {
+    return false;
+  }
+
+  const target = browserNotificationTarget(bridgeId, message);
+  const notificationOptions: NotificationOptions & { renotify?: boolean } = {
+    body: browserNotificationBody(message, bridgeLabel),
+    tag: browserNotificationTag(bridgeId, message.pane_id),
+    // Re-alert when the same pane transitions again (same tag).
+    renotify: true,
+    data: target,
+  };
+  const notification = new NotificationCtor!(
+    browserNotificationTitle(message),
+    notificationOptions,
+  );
+
+  if (onClick) {
+    notification.onclick = () => {
+      try {
+        window.focus();
+      } catch {
+        // Some environments restrict focus from notification handlers.
+      }
+      onClick(target);
+      notification.close();
+    };
+  }
+  return true;
+}
+
+function globalNotification(): typeof Notification | undefined {
+  if (typeof Notification === "undefined") {
+    return undefined;
+  }
+  return Notification;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,24 @@ import "./styles.css";
 
 startNativeControls();
 
+/** Runtime marker so you can confirm the loaded bundle in DevTools: `__HERDR_WEB__`. */
+declare global {
+  interface Window {
+    __HERDR_WEB__?: {
+      features: string[];
+    };
+  }
+}
+
+window.__HERDR_WEB__ = {
+  features: ["browser-notifications", "web-push"],
+};
+
+// Register the push-capable service worker early (no-op off secure contexts).
+if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+  void navigator.serviceWorker.register("/sw.js", { scope: "/" }).catch(() => undefined);
+}
+
 const root = document.getElementById("root");
 
 if (!root) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2703,6 +2703,13 @@ button {
   font-size: 12.5px;
 }
 
+.settings-hint {
+  margin: 0;
+  color: var(--overlay1);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .segmented-control {
   display: inline-flex;
   width: 100%;

--- a/web/src/webPush.test.ts
+++ b/web/src/webPush.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  isWebPushBrowserSupported,
+  supportsWebPushCapability,
+  urlBase64ToUint8Array,
+} from "./webPush";
+
+describe("web push helpers", () => {
+  it("detects bridge web_push capability", () => {
+    expect(supportsWebPushCapability({ commands: [] })).toBe(false);
+    expect(
+      supportsWebPushCapability({
+        commands: [],
+        web_push: { version: 1, public_key: "abc" },
+      }),
+    ).toBe(true);
+    expect(
+      supportsWebPushCapability({
+        commands: [],
+        web_push: { version: 1, public_key: "" },
+      }),
+    ).toBe(false);
+  });
+
+  it("decodes applicationServerKey material", () => {
+    const bytes = urlBase64ToUint8Array("AQID");
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+  });
+
+  it("requires secure context APIs for browser support", () => {
+    expect(isWebPushBrowserSupported(undefined, true, true)).toBe(false);
+  });
+});

--- a/web/src/webPush.ts
+++ b/web/src/webPush.ts
@@ -1,0 +1,153 @@
+import type { BridgeCapabilities } from "./bridge";
+import { fetchWithTimeout } from "./fetchWithTimeout";
+import type { BridgeHttpUrl } from "./bridgeApi";
+
+export type WebPushCapability = {
+  version: number;
+  public_key: string;
+};
+
+export type WebPushSubscriptionJson = {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+};
+
+export function supportsWebPushCapability(
+  capabilities: BridgeCapabilities | null | undefined,
+): capabilities is BridgeCapabilities & { web_push: WebPushCapability } {
+  return (
+    !!capabilities &&
+    typeof capabilities.web_push === "object" &&
+    capabilities.web_push !== null &&
+    capabilities.web_push.version === 1 &&
+    typeof capabilities.web_push.public_key === "string" &&
+    capabilities.web_push.public_key.length > 0
+  );
+}
+
+export function isWebPushBrowserSupported(
+  serviceWorker: ServiceWorkerContainer | undefined = globalServiceWorker(),
+  pushManager: boolean = typeof PushManager !== "undefined",
+  notification: boolean = typeof Notification !== "undefined",
+): boolean {
+  return Boolean(serviceWorker && pushManager && notification && window.isSecureContext);
+}
+
+export async function registerHerdrServiceWorker(
+  serviceWorker: ServiceWorkerContainer | undefined = globalServiceWorker(),
+): Promise<ServiceWorkerRegistration | null> {
+  if (!serviceWorker) {
+    return null;
+  }
+  try {
+    return await serviceWorker.register("/sw.js", { scope: "/" });
+  } catch {
+    return null;
+  }
+}
+
+export async function getCurrentPushSubscription(
+  registration: ServiceWorkerRegistration | null,
+): Promise<PushSubscription | null> {
+  if (!registration) {
+    return null;
+  }
+  try {
+    return await registration.pushManager.getSubscription();
+  } catch {
+    return null;
+  }
+}
+
+export async function subscribeWebPush(options: {
+  httpUrl: BridgeHttpUrl;
+  publicKey: string;
+  registration: ServiceWorkerRegistration;
+}): Promise<PushSubscription> {
+  const existing = await options.registration.pushManager.getSubscription();
+  const subscription =
+    existing ??
+    (await options.registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: applicationServerKeyFromBase64(options.publicKey),
+    }));
+  await postSubscription(options.httpUrl, "/api/push/subscribe", subscriptionToJson(subscription));
+  return subscription;
+}
+
+export async function unsubscribeWebPush(options: {
+  httpUrl: BridgeHttpUrl;
+  registration: ServiceWorkerRegistration | null;
+}): Promise<void> {
+  const subscription = options.registration
+    ? await options.registration.pushManager.getSubscription()
+    : null;
+  if (!subscription) {
+    return;
+  }
+  try {
+    await postSubscription(options.httpUrl, "/api/push/unsubscribe", {
+      endpoint: subscription.endpoint,
+    });
+  } finally {
+    await subscription.unsubscribe();
+  }
+}
+
+export function subscriptionToJson(subscription: PushSubscription): WebPushSubscriptionJson {
+  const json = subscription.toJSON();
+  const endpoint = json.endpoint;
+  const p256dh = json.keys?.p256dh;
+  const auth = json.keys?.auth;
+  if (!endpoint || !p256dh || !auth) {
+    throw new Error("incomplete push subscription");
+  }
+  return {
+    endpoint,
+    keys: { p256dh, auth },
+  };
+}
+
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let index = 0; index < raw.length; index += 1) {
+    output[index] = raw.charCodeAt(index);
+  }
+  return output;
+}
+
+function applicationServerKeyFromBase64(base64String: string): ArrayBuffer {
+  const bytes = urlBase64ToUint8Array(base64String);
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+async function postSubscription(
+  httpUrl: BridgeHttpUrl,
+  path: "/api/push/subscribe" | "/api/push/unsubscribe",
+  body: unknown,
+) {
+  const response = await fetchWithTimeout(httpUrl(path), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(text || `push request failed (${response.status})`);
+  }
+}
+
+function globalServiceWorker(): ServiceWorkerContainer | undefined {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+    return undefined;
+  }
+  return navigator.serviceWorker;
+}


### PR DESCRIPTION
## Summary

- Optional Web Push + service worker so blocked/done agent alerts can reach a device when no tab is open.
- Bridge auto-generates VAPID keys (or accepts `HERDR_WEB_VAPID_*`), exposes `web_push` on `/api/capabilities`, and accepts `/api/push/subscribe|unsubscribe`.
- Frontend registers `/sw.js` and adds a Background push toggle under Settings → Features.

## Depends on

- Includes the desktop-notification commit from the sibling PR (browser Notification API + settings).
- Please review/merge the desktop-notifications PR first, or treat this as a stacked follow-up; I can rebase onto `main` after that lands.

## Validation

- `npm run test --prefix web -- src/browserNotifications.test.ts src/webPush.test.ts` (13 passed)
- `npm run lint:web`
- `npm run bridge:test` (135 passed)

## Notes

- Does **not** include CJK IME / `npm run dev` work (that stays on PR #51).
- LAN / non-localhost push still needs HTTPS (secure context); documented in README.
- Changelog under `## [Unreleased]` will get this PR number after open, per repo convention.