### PR TITLE
Fix icon centering in square icon buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Fixed icons rendering slightly off-center in square icon buttons (sidebar section header
+  actions and the tab bar's new-tab button) by resetting the user-agent button padding, and
+  removed the per-icon transform that compensated for it.
+
 ### Removed
 
 ## [0.4.1] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Fixed icons rendering slightly off-center in square icon buttons (sidebar section header
   actions and the tab bar's new-tab button) by resetting the user-agent button padding, and
   removed the per-icon transform that compensated for it.
+  [PR #55](https://github.com/kcosr/herdr-web/pull/55), contributed by
+  [Philippe SEGATORI (@tigitz)](https://github.com/tigitz).
 
 ### Removed
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7325,7 +7325,7 @@ function Switcher({
                 ) : null}
                 {showPinnedOnlyControl ? (
                   <button
-                    className="sec-add sec-add-pin"
+                    className="sec-add"
                     type="button"
                     aria-label={`Show ${pinnedOnlyLabel} only`}
                     title="Pinned only"
@@ -7338,7 +7338,7 @@ function Switcher({
                 ) : null}
                 {showActiveOnlyControl ? (
                   <button
-                    className="sec-add sec-add-active"
+                    className="sec-add"
                     type="button"
                     aria-label={`Show active ${sidebarView === "tabs" ? "agents" : "statuses"} only`}
                     title={sidebarView === "tabs" ? "Active agents only" : "Active statuses only"}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -278,6 +278,7 @@ button {
   height: 34px;
   flex: 0 0 auto;
   place-items: center;
+  padding: 0;
   border: 1px solid transparent;
   border-radius: var(--r-sm);
   color: var(--subtext0);
@@ -1057,6 +1058,7 @@ button {
   height: 26px;
   flex: 0 0 auto;
   place-items: center;
+  padding: 0;
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   color: var(--overlay1);
@@ -1778,6 +1780,7 @@ button {
   width: 34px;
   height: 34px;
   place-items: center;
+  padding: 0;
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   background: color-mix(in srgb, var(--mantle) 86%, black);
@@ -2165,6 +2168,7 @@ button {
   height: 24px;
   flex: 0 0 auto;
   place-items: center;
+  padding: 0;
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   color: var(--overlay1);
@@ -2182,11 +2186,6 @@ button {
   border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
   color: var(--accent);
   background: color-mix(in srgb, var(--accent) 12%, transparent);
-}
-
-.sec-add-pin svg,
-.sec-add-active svg {
-  transform: translateX(-1.5px);
 }
 
 .tab-head {


### PR DESCRIPTION
Hello, I think i found my new personal setup for mobile clauding 🙂 thanks for the project !

I just noted a slight missalignment in some icons, here's claude context and fix, hope it's not too verbose:

## Problem

Icons in the square icon buttons render slightly off-center to the right:

- sidebar section header buttons (`.sec-add`): **+2px** — visible on the Spaces `+` and the Agents/Tabs list options `⋮`
- tab bar new-tab button (`.tabbar-add`): **+1px**

### Sidebar section headers

| Before | After |
| --- | --- |
| <img width="640" height="1300" alt="before-sidebar-crop" src="https://github.com/user-attachments/assets/7ec53b12-1275-482e-bffb-d745ce3d5c3b" /> | <img width="640" height="1300" alt="after-sidebar-crop" src="https://github.com/user-attachments/assets/a6a08547-821d-44a9-a48f-42a0f645ce27" />

### Tab bar

**Before**

<img width="2160" height="80" alt="before-tabbar" src="https://github.com/user-attachments/assets/03de5a80-1f0d-44f4-9473-47fd700103c3" />
-screenshots/before-tabbar.png)

**After**

<img width="2160" height="80" alt="after-tabbar" src="https://github.com/user-attachments/assets/77664f96-5056-41f6-9352-2061f882c821" />

## Root cause

These buttons keep the user-agent `<button>` padding (`1px 6px`). With `box-sizing: border-box` the content box ends up narrower than the icon (e.g. 24 − 2 border − 12 padding = 10px for a 14px icon in `.sec-add`). A grid item wider than its track is start-aligned rather than centered, so the icon overflows to the right of the content box.

The existing `.sec-add-pin svg, .sec-add-active svg { transform: translateX(-1.5px); }` rule was compensating for exactly this offset on the two 13px filter icons.

## Fix

- `padding: 0` on the four square `place-items: center` icon button classes: `.sec-add`, `.tabbar-add`, `.icon-btn`, `.terminal-upload-fab` (matching `.space-reorder-cancel` and `.pane-note-tab-new`, which already reset it).
- Removed the `translateX(-1.5px)` compensation and the now style-less `sec-add-pin` / `sec-add-active` class names.

`.icon-btn` and `.terminal-upload-fab` had no visible offset (their icons still fit the shrunken content box) but shared the same latent bug; no visual change for them since the UA padding is symmetric.

## Testing

- `npm run check` (ESLint + Vitest + build) passes. Bridge unaffected (CSS/TSX only).
- Measured `icon center − button center` on the built app for every `.sec-add`/`.tabbar-add`/`.icon-btn`/`.terminal-upload-fab`: all offsets are now `0.00px` (previously +2/+1px).

## Checklist

- [ ] Update the `CHANGELOG.md` entry with this PR's number before merging (per AGENTS.md).
