### PR TITLE
Add supervised dev server workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - Added `npm run dev` to supervise the bridge and Vite HMR server together, wait for bridge
   readiness, proxy API and WebSocket traffic, and stop both processes cleanly.
+  [PR #57](https://github.com/kcosr/herdr-web/pull/57), based on work proposed by
+  [Hopkins (@LosEcher)](https://github.com/LosEcher) in
+  [PR #51](https://github.com/kcosr/herdr-web/pull/51).
 - Declared the existing Herdr logo as the browser favicon.
   [PR #56](https://github.com/kcosr/herdr-web/pull/56), contributed by
   [Craig P. Motlin (@motlin)](https://github.com/motlin).
@@ -16,6 +19,9 @@
 
 - Static bridge responses now explicitly revalidate HTML and public files while caching successful
   content-hashed Vite assets as immutable. Error responses are never marked immutable.
+  [PR #57](https://github.com/kcosr/herdr-web/pull/57), based on work proposed by
+  [Hopkins (@LosEcher)](https://github.com/LosEcher) in
+  [PR #51](https://github.com/kcosr/herdr-web/pull/51).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@
 
 ### Added
 
+- Added `npm run dev` to supervise the bridge and Vite HMR server together, wait for bridge
+  readiness, proxy API and WebSocket traffic, and stop both processes cleanly.
 - Declared the existing Herdr logo as the browser favicon.
   [PR #56](https://github.com/kcosr/herdr-web/pull/56), contributed by
   [Craig P. Motlin (@motlin)](https://github.com/motlin).
 
 ### Changed
+
+- Static bridge responses now explicitly revalidate HTML and public files while caching successful
+  content-hashed Vite assets as immutable. Error responses are never marked immutable.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+herdr-web is intentionally a small, focused application. It is maintained primarily as a personal
+development tool, not as a general-purpose platform.
+
+Contributions are welcome when they strengthen existing workflows without substantially broadening
+the product's feature set.
+
+## Scope
+
+Keep each pull request focused on one clear concern. It may include the code, tests, documentation,
+and cleanup needed for that concern, but should not bundle unrelated features or broad refactors.
+
+Good contributions include:
+
+- Bug fixes
+- Focused usability improvements
+- Tests and documentation
+- Small improvements to existing workflows
+- Maintenance that keeps the application reliable and understandable
+
+Scope matters more than line count: a substantial fix can still be tightly scoped, while several
+small unrelated features belong in separate pull requests.
+
+Before starting a larger feature, new product area, architectural redesign, or change that
+meaningfully expands the application's responsibilities, open an issue for discussion. Early
+discussion helps confirm whether the idea fits the project before significant work begins.
+
+## Pull Requests
+
+- Explain the problem and the chosen approach.
+- Keep unrelated changes out of the pull request.
+- Add or update tests where practical.
+- Add user-facing changes to `CHANGELOG.md` under `Unreleased`.
+- Link any relevant issue, prior pull request, or discussion.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 > It is experimental, Herdr compatibility code is vendored, and the runtime/API shape is expected to
 > change.
 
+> This is an intentionally minimal personal development tool. Focused contributions are welcome;
+> please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+
 Browser UI for Herdr workspaces and agent panes.
 
 This repository is structured as a standalone app that can be distributed without asking users to

--- a/README.md
+++ b/README.md
@@ -117,6 +117,32 @@ npm install
 npm install --prefix web
 ```
 
+## Development Server (HMR)
+
+Start the bridge and Vite together from the repository root:
+
+```bash
+npm run dev
+```
+
+Open `http://127.0.0.1:5173`. Vite serves the live frontend with hot module replacement and proxies
+`/api` and `/ws` to the managed bridge at `http://127.0.0.1:8787`. Stopping either process stops the
+other. The command builds the bridge when its binary is missing; after later Rust changes, stop the
+server, run `npm run bridge:build`, and restart it.
+
+The bridge targets the stable Herdr socket by default. Point it at another session socket or pass
+other bridge options as needed:
+
+```bash
+HERDR_SOCKET_PATH="$HOME/.config/herdr-dev/herdr.sock" npm run dev
+npm run dev -- --session SESSION_NAME
+```
+
+Development addresses use namespaced variables so unrelated `HOST` or `PORT` settings cannot expose
+the local bridge accidentally: `HERDR_WEB_BRIDGE_HOST`, `HERDR_WEB_BRIDGE_PORT`,
+`HERDR_WEB_DEV_HOST`, and `HERDR_WEB_DEV_PORT`. The defaults bind both servers to loopback. Advanced
+overrides are `HERDR_WEB_BRIDGE_BIN` and `HERDR_WEB_STATIC_DIR`.
+
 ## Development Build And Test
 
 ```bash
@@ -128,6 +154,8 @@ npm run build
 Useful narrower commands:
 
 ```bash
+npm run dev
+npm run test:dev
 npm run lint:web
 npm run test:web
 npm run build:web

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -14,7 +14,7 @@ use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{DefaultBodyLimit, Path as AxumPath, Query, State};
 use axum::http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
-    ACCESS_CONTROL_MAX_AGE, ACCESS_CONTROL_REQUEST_HEADERS, HOST, ORIGIN, VARY,
+    ACCESS_CONTROL_MAX_AGE, ACCESS_CONTROL_REQUEST_HEADERS, CACHE_CONTROL, HOST, ORIGIN, VARY,
 };
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
@@ -1060,6 +1060,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         .route("/ws/terminal", get(terminal_ws_handler))
         .fallback_service(
             ServiceBuilder::new()
+                .layer(middleware::from_fn(add_static_cache_headers))
                 .layer(CompressionLayer::new())
                 .service(ServeDir::new(options.static_dir)),
         )
@@ -1095,6 +1096,28 @@ async fn add_security_headers(
         insert_cors_headers(headers, origin);
     }
     response
+}
+
+async fn add_static_cache_headers(request: AxumRequest, next: Next) -> Response {
+    let path = request.uri().path().to_string();
+    let mut response = next.run(request).await;
+    let status = response.status();
+    insert_static_cache_header(response.headers_mut(), &path, status);
+    response
+}
+
+fn insert_static_cache_header(headers: &mut HeaderMap, path: &str, status: StatusCode) {
+    if headers.contains_key(CACHE_CONTROL)
+        || (!status.is_success() && status != StatusCode::NOT_MODIFIED)
+    {
+        return;
+    }
+    let value = if path.starts_with("/assets/") {
+        HeaderValue::from_static("public, max-age=31536000, immutable")
+    } else {
+        HeaderValue::from_static("no-cache")
+    };
+    headers.insert(CACHE_CONTROL, value);
 }
 
 async fn preflight_handler(
@@ -4434,6 +4457,40 @@ fn startup_daemon_error(err: BridgeError) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn static_cache_headers_revalidate_entrypoints_and_public_files() {
+        for path in ["/", "/index.html", "/manifest.json", "/herdr-logo.svg"] {
+            let mut headers = HeaderMap::new();
+            insert_static_cache_header(&mut headers, path, StatusCode::OK);
+            assert_eq!(headers.get(CACHE_CONTROL).unwrap(), "no-cache", "{path}");
+        }
+    }
+
+    #[test]
+    fn static_cache_headers_make_successful_vite_assets_immutable() {
+        let mut headers = HeaderMap::new();
+        insert_static_cache_header(&mut headers, "/assets/index-AbCd1234.js", StatusCode::OK);
+        assert_eq!(
+            headers.get(CACHE_CONTROL).unwrap(),
+            "public, max-age=31536000, immutable"
+        );
+    }
+
+    #[test]
+    fn static_cache_headers_do_not_cache_missing_assets() {
+        let mut headers = HeaderMap::new();
+        insert_static_cache_header(&mut headers, "/assets/missing.js", StatusCode::NOT_FOUND);
+        assert!(!headers.contains_key(CACHE_CONTROL));
+    }
+
+    #[test]
+    fn static_cache_headers_preserve_service_policy() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+        insert_static_cache_header(&mut headers, "/index.html", StatusCode::OK);
+        assert_eq!(headers.get(CACHE_CONTROL).unwrap(), "no-store");
+    }
 
     #[test]
     fn coalescer_sends_first_output_immediately() {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "dev": "node scripts/dev.mjs",
     "dev:web": "npm run dev --prefix web",
     "build:web": "npm run build --prefix web",
+    "test:dev": "node --test scripts/dev.test.mjs",
     "test:web": "npm run test --prefix web",
     "lint:web": "npm run lint --prefix web",
     "vendor:check": "scripts/check-vendor.sh",
@@ -17,7 +19,7 @@
     "android:open": "cap open android",
     "package:tarball": "scripts/package-tarball.sh",
     "build": "npm run build:web && npm run bridge:build",
-    "test": "npm run test:web && npm run bridge:test",
+    "test": "npm run test:dev && npm run test:web && npm run bridge:test",
     "lint": "npm run lint:web && npm run bridge:fmt",
     "check": "npm run vendor:check && npm run lint && npm run test && npm run build"
   },

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,365 @@
+#!/usr/bin/env node
+
+import { constants as fsConstants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const WEB_DIR = path.join(ROOT, "web");
+const DEFAULT_BRIDGE_BIN = path.join(
+  ROOT,
+  "bridge",
+  "target",
+  "debug",
+  process.platform === "win32" ? "herdr-web-bridge.exe" : "herdr-web-bridge",
+);
+const DEFAULT_STATIC_DIR = path.join(WEB_DIR, "dist");
+const START_TIMEOUT_MS = 15_000;
+const SHUTDOWN_TIMEOUT_MS = 3_000;
+
+class ChildExitError extends Error {
+  constructor(label, result) {
+    const detail = result.code === null ? `signal ${result.signal}` : `status ${result.code}`;
+    super(`${label} exited before it became ready (${detail})`);
+    this.result = result;
+  }
+}
+
+class RequestedSignalError extends Error {
+  constructor(signal) {
+    super(`received ${signal}`);
+    this.signal = signal;
+  }
+}
+
+function parsePort(name, fallback) {
+  const raw = process.env[name] ?? String(fallback);
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
+    throw new Error(`${name} must be an integer between 1 and 65535 (received ${JSON.stringify(raw)})`);
+  }
+  return value;
+}
+
+function configuredHost(name, fallback) {
+  const value = process.env[name] ?? fallback;
+  if (value.length === 0) {
+    throw new Error(`${name} must not be empty`);
+  }
+  return value;
+}
+
+function connectHost(bindHost) {
+  if (bindHost === "0.0.0.0") return "127.0.0.1";
+  if (bindHost === "::") return "::1";
+  return bindHost;
+}
+
+function httpUrl(host, port) {
+  const urlHost = net.isIP(host) === 6 ? `[${host}]` : host;
+  return `http://${urlHost}:${port}`;
+}
+
+function childResult(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function pathIsExecutable(filePath) {
+  try {
+    await access(
+      filePath,
+      process.platform === "win32" ? fsConstants.F_OK : fsConstants.X_OK,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function directoryExists(directory) {
+  try {
+    return (await stat(directory)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function spawnChild(command, args, options = {}) {
+  return spawn(command, args, {
+    cwd: ROOT,
+    env: process.env,
+    stdio: "inherit",
+    detached: process.platform !== "win32",
+    ...options,
+  });
+}
+
+async function runCommand(command, args, signalPromise) {
+  const child = spawnChild(command, args);
+  const exited = childResult(child);
+  const outcome = await Promise.race([
+    exited.then((result) => ({ source: "child", result })),
+    signalPromise,
+  ]);
+  if (outcome.source === "signal") {
+    await stopChild(child, command);
+    throw new RequestedSignalError(outcome.signal);
+  }
+  const { result } = outcome;
+  if (result.code !== 0) {
+    const detail = result.code === null ? `signal ${result.signal}` : `status ${result.code}`;
+    throw new Error(`${command} failed (${detail})`);
+  }
+}
+
+function sendSignal(child, signal) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  if (!Number.isInteger(child.pid)) return;
+  try {
+    if (process.platform === "win32") {
+      child.kill(signal);
+    } else {
+      process.kill(-child.pid, signal);
+    }
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
+async function stopChild(child, label) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  const exited = childResult(child);
+  sendSignal(child, "SIGTERM");
+  let timeout;
+  const result = await Promise.race([
+    exited,
+    new Promise((resolve) => {
+      timeout = setTimeout(() => resolve(null), SHUTDOWN_TIMEOUT_MS);
+    }),
+  ]);
+  clearTimeout(timeout);
+  if (result !== null) return;
+
+  console.error(`${label} did not stop after ${SHUTDOWN_TIMEOUT_MS}ms; killing it`);
+  sendSignal(child, "SIGKILL");
+  await exited.catch(() => {});
+}
+
+async function portIsOccupied(host, port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let settled = false;
+    const finish = (occupied) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(occupied);
+    };
+    socket.setTimeout(300);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
+}
+
+async function waitForBridgeReady(url, bridge, exitPromise, signalPromise) {
+  const deadline = Date.now() + START_TIMEOUT_MS;
+  let lastFailure = "no response";
+  while (Date.now() < deadline) {
+    if (bridge.exitCode !== null || bridge.signalCode !== null) {
+      throw new ChildExitError("bridge", await exitPromise);
+    }
+    try {
+      const response = await fetch(`${url}/api/capabilities`, {
+        signal: AbortSignal.timeout(500),
+      });
+      if (!response.ok) {
+        lastFailure = `HTTP ${response.status}`;
+        await response.body?.cancel();
+      } else {
+        const capabilities = await response.json();
+        if (Array.isArray(capabilities?.commands)) {
+          if (bridge.exitCode === null && bridge.signalCode === null) return;
+        } else {
+          lastFailure = "invalid capabilities response";
+        }
+      }
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error);
+    }
+
+    const outcome = await Promise.race([
+      exitPromise.then((result) => ({ source: "bridge", result })),
+      signalPromise,
+      delay(100).then(() => ({ source: "delay" })),
+    ]);
+    if (outcome.source === "bridge") throw new ChildExitError("bridge", outcome.result);
+    if (outcome.source === "signal") throw new RequestedSignalError(outcome.signal);
+  }
+  throw new Error(
+    `bridge did not become ready at ${url} within ${START_TIMEOUT_MS}ms (${lastFailure})`,
+  );
+}
+
+function stableSocketEnvironment() {
+  const env = { ...process.env };
+  if (env.HERDR_SOCKET_PATH) return env;
+  const configHome = env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  env.HERDR_SOCKET_PATH = path.join(configHome, "herdr", "herdr.sock");
+  return env;
+}
+
+function rejectAddressOverrides(args) {
+  const reserved = new Set(["--host", "--port", "--static-dir"]);
+  for (const argument of args) {
+    if (reserved.has(argument) || [...reserved].some((option) => argument.startsWith(`${option}=`))) {
+      throw new Error(
+        `${argument} is controlled by the dev server; use HERDR_WEB_BRIDGE_HOST, ` +
+          "HERDR_WEB_BRIDGE_PORT, or HERDR_WEB_STATIC_DIR",
+      );
+    }
+  }
+}
+
+function exitStatus(result, unexpected) {
+  if (result.code !== null) {
+    return unexpected && result.code === 0 ? 1 : result.code;
+  }
+  return result.signal === "SIGINT" ? 130 : result.signal === "SIGTERM" ? 143 : 1;
+}
+
+async function main() {
+  let bridge;
+  let vite;
+  let requestedSignal;
+  let resolveSignal;
+  const signalPromise = new Promise((resolve) => {
+    resolveSignal = resolve;
+  });
+  const handleSignal = (signal) => {
+    if (requestedSignal) return;
+    requestedSignal = signal;
+    resolveSignal({ source: "signal", signal });
+  };
+  const handleSigint = () => handleSignal("SIGINT");
+  const handleSigterm = () => handleSignal("SIGTERM");
+  process.once("SIGINT", handleSigint);
+  process.once("SIGTERM", handleSigterm);
+
+  try {
+    const bridgeHost = configuredHost("HERDR_WEB_BRIDGE_HOST", "127.0.0.1");
+    const bridgePort = parsePort("HERDR_WEB_BRIDGE_PORT", 8787);
+    const devHost = configuredHost("HERDR_WEB_DEV_HOST", "127.0.0.1");
+    const devPort = parsePort("HERDR_WEB_DEV_PORT", 5173);
+    const configuredBridgeBin = process.env.HERDR_WEB_BRIDGE_BIN;
+    const bridgeBin = path.resolve(ROOT, configuredBridgeBin ?? DEFAULT_BRIDGE_BIN);
+    const staticDir = path.resolve(ROOT, process.env.HERDR_WEB_STATIC_DIR ?? DEFAULT_STATIC_DIR);
+    const bridgeArgs = process.argv.slice(2);
+    rejectAddressOverrides(bridgeArgs);
+
+    if (!(await directoryExists(path.join(WEB_DIR, "node_modules")))) {
+      throw new Error("web dependencies are missing; run: npm install --prefix web");
+    }
+    if (!(await pathIsExecutable(bridgeBin))) {
+      if (configuredBridgeBin) {
+        throw new Error(`HERDR_WEB_BRIDGE_BIN is not executable: ${bridgeBin}`);
+      }
+      console.log("bridge binary is missing; building it first...");
+      await runCommand(
+        process.platform === "win32" ? "npm.cmd" : "npm",
+        ["run", "bridge:build"],
+        signalPromise,
+      );
+    }
+    if (requestedSignal) throw new RequestedSignalError(requestedSignal);
+    if (!(await pathIsExecutable(bridgeBin))) {
+      throw new Error(`bridge build did not produce an executable at ${bridgeBin}`);
+    }
+
+    const proxyHost = connectHost(bridgeHost);
+    const bridgeUrl = httpUrl(proxyHost, bridgePort);
+    if (await portIsOccupied(proxyHost, bridgePort)) {
+      throw new Error(
+        `bridge address ${bridgeUrl} is already in use; ` +
+          "stop that process or set HERDR_WEB_BRIDGE_PORT",
+      );
+    }
+    if (requestedSignal) throw new RequestedSignalError(requestedSignal);
+
+    const bridgeEnv = stableSocketEnvironment();
+    console.log(`starting bridge on ${httpUrl(bridgeHost, bridgePort)}`);
+    console.log(`  HERDR_SOCKET_PATH=${bridgeEnv.HERDR_SOCKET_PATH ?? "<unset>"}`);
+    bridge = spawnChild(
+      bridgeBin,
+      [...bridgeArgs, "--host", bridgeHost, "--port", String(bridgePort), "--static-dir", staticDir],
+      { env: bridgeEnv },
+    );
+    const bridgeExit = childResult(bridge);
+    await waitForBridgeReady(bridgeUrl, bridge, bridgeExit, signalPromise);
+
+    console.log(`starting Vite HMR on ${httpUrl(devHost, devPort)} (proxy -> ${bridgeUrl})`);
+    console.log("open the Vite URL; bridge source changes still require a rebuild and restart");
+    const viteEnv = { ...process.env, HERDR_WEB_BRIDGE: bridgeUrl };
+    vite = spawnChild(
+      process.platform === "win32" ? "npm.cmd" : "npm",
+      [
+        "--prefix",
+        WEB_DIR,
+        "run",
+        "dev",
+        "--",
+        "--host",
+        devHost,
+        "--port",
+        String(devPort),
+        "--strictPort",
+      ],
+      { env: viteEnv },
+    );
+    const viteExit = childResult(vite);
+
+    const outcome = await Promise.race([
+      bridgeExit.then((result) => ({ source: "bridge", result })),
+      viteExit.then((result) => ({ source: "vite", result })),
+      signalPromise,
+    ]);
+    if (outcome.source === "signal") {
+      return outcome.signal === "SIGINT" ? 130 : 143;
+    }
+    if (outcome.source === "bridge") {
+      console.error("bridge stopped; shutting down Vite");
+      return exitStatus(outcome.result, true);
+    }
+    return exitStatus(outcome.result, false);
+  } catch (error) {
+    if (error instanceof ChildExitError) return exitStatus(error.result, true);
+    if (error instanceof RequestedSignalError) return error.signal === "SIGINT" ? 130 : 143;
+    throw error;
+  } finally {
+    process.removeListener("SIGINT", handleSigint);
+    process.removeListener("SIGTERM", handleSigterm);
+    await Promise.all([stopChild(vite, "Vite"), stopChild(bridge, "bridge")]);
+  }
+}
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  console.error(`dev server failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+}

--- a/scripts/dev.test.mjs
+++ b/scripts/dev.test.mjs
@@ -1,0 +1,313 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DEV_SCRIPT = path.join(ROOT, "scripts", "dev.mjs");
+
+const FAKE_BRIDGE = `#!/usr/bin/env node
+const http = require("node:http");
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_BRIDGE_LOG, JSON.stringify(args) + "\\n");
+if (process.env.FAKE_BRIDGE_FAIL) process.exit(Number(process.env.FAKE_BRIDGE_FAIL));
+const valueAfter = (name) => args[args.lastIndexOf(name) + 1];
+const server = http.createServer((request, response) => {
+  const status = request.url === "/api/capabilities"
+    ? Number(process.env.FAKE_BRIDGE_STATUS || 200)
+    : 404;
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(status === 200 ? '{"commands":[]}' : '{}');
+});
+const stop = () => {
+  fs.appendFileSync(process.env.FAKE_BRIDGE_STOP_LOG, "stopped\\n");
+  server.close(() => process.exit(0));
+  server.closeAllConnections?.();
+};
+process.on("SIGTERM", stop);
+process.on("SIGINT", stop);
+server.listen(Number(valueAfter("--port")), valueAfter("--host"));
+if (process.env.FAKE_BRIDGE_EXIT_AFTER_MS) {
+  setTimeout(
+    () => process.exit(Number(process.env.FAKE_BRIDGE_EXIT_CODE || 1)),
+    Number(process.env.FAKE_BRIDGE_EXIT_AFTER_MS),
+  );
+}
+`;
+
+const FAKE_NPM = `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (args.includes("bridge:build") && process.env.FAKE_BUILD_HANG) {
+  fs.appendFileSync(process.env.FAKE_BUILD_LOG, "started\\n");
+  const stop = () => {
+    fs.appendFileSync(process.env.FAKE_BUILD_STOP_LOG, "stopped\\n");
+    process.exit(0);
+  };
+  process.on("SIGTERM", stop);
+  process.on("SIGINT", stop);
+  setInterval(() => {}, 1000);
+} else {
+  fs.appendFileSync(process.env.FAKE_VITE_LOG, JSON.stringify({
+    args,
+    bridge: process.env.HERDR_WEB_BRIDGE,
+  }) + "\\n");
+  const stop = () => {
+    fs.appendFileSync(process.env.FAKE_VITE_STOP_LOG, "stopped\\n");
+    process.exit(0);
+  };
+  process.on("SIGTERM", stop);
+  process.on("SIGINT", stop);
+  if (process.env.FAKE_VITE_EXIT_MS) {
+    setTimeout(() => process.exit(Number(process.env.FAKE_VITE_EXIT_CODE || 0)), Number(process.env.FAKE_VITE_EXIT_MS));
+  }
+  setInterval(() => {}, 1000);
+}
+`;
+
+async function reservePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function makeFixture() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "herdr-web-dev-test-"));
+  const binDirectory = path.join(directory, "bin");
+  const bridgeBin = path.join(directory, "fake-bridge");
+  await mkdir(binDirectory);
+  await writeFile(bridgeBin, FAKE_BRIDGE);
+  await writeFile(path.join(binDirectory, "npm"), FAKE_NPM);
+  await chmod(bridgeBin, 0o755);
+  await chmod(path.join(binDirectory, "npm"), 0o755);
+  return {
+    directory,
+    bridgeBin,
+    bridgeLog: path.join(directory, "bridge.log"),
+    bridgeStopLog: path.join(directory, "bridge-stop.log"),
+    viteLog: path.join(directory, "vite.log"),
+    viteStopLog: path.join(directory, "vite-stop.log"),
+    buildLog: path.join(directory, "build.log"),
+    buildStopLog: path.join(directory, "build-stop.log"),
+  };
+}
+
+function runDev(fixture, bridgePort, extraEnv = {}, extraArgs = []) {
+  const env = {
+    ...process.env,
+    PATH: `${path.join(fixture.directory, "bin")}${path.delimiter}${process.env.PATH}`,
+    HERDR_WEB_BRIDGE_BIN: fixture.bridgeBin,
+    HERDR_WEB_BRIDGE_HOST: "127.0.0.1",
+    HERDR_WEB_BRIDGE_PORT: String(bridgePort),
+    HERDR_WEB_DEV_HOST: "127.0.0.1",
+    HERDR_WEB_DEV_PORT: String(bridgePort + 1),
+    FAKE_BRIDGE_LOG: fixture.bridgeLog,
+    FAKE_BRIDGE_STOP_LOG: fixture.bridgeStopLog,
+    FAKE_VITE_LOG: fixture.viteLog,
+    FAKE_VITE_STOP_LOG: fixture.viteStopLog,
+    FAKE_BUILD_LOG: fixture.buildLog,
+    FAKE_BUILD_STOP_LOG: fixture.buildStopLog,
+    ...extraEnv,
+  };
+  const child = spawn(process.execPath, [DEV_SCRIPT, ...extraArgs], {
+    cwd: ROOT,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout.on("data", (chunk) => (output += chunk));
+  child.stderr.on("data", (chunk) => (output += chunk));
+  const result = new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal, output }));
+  });
+  return { child, result };
+}
+
+async function stopRun(run) {
+  if (!run) return;
+  if (run.child.exitCode === null && run.child.signalCode === null) {
+    run.child.kill("SIGTERM");
+  }
+  let timeout;
+  const stopped = await Promise.race([
+    run.result.then(() => true),
+    new Promise((resolve) => {
+      timeout = setTimeout(() => resolve(false), 5_000);
+    }),
+  ]);
+  clearTimeout(timeout);
+  if (!stopped && run.child.exitCode === null && run.child.signalCode === null) {
+    run.child.kill("SIGKILL");
+  }
+  await run.result;
+}
+
+async function fileText(filePath) {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") return "";
+    throw error;
+  }
+}
+
+async function waitForFile(filePath) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if ((await fileText(filePath)).length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for ${filePath}`);
+}
+
+test("Vite exit stops the bridge and preserves configured arguments", { concurrency: false }, async () => {
+  const fixture = await makeFixture();
+  let run;
+  try {
+    const port = await reservePort();
+    run = runDev(
+      fixture,
+      port,
+      {
+        FAKE_VITE_EXIT_MS: "100",
+        HERDR_WEB_BRIDGE: "http://wrong.example:9999",
+        HOST: "0.0.0.0",
+        PORT: "1",
+      },
+      ["--session", "dev session"],
+    );
+    const outcome = await run.result;
+    assert.equal(outcome.code, 0, outcome.output);
+    assert.match(await fileText(fixture.bridgeStopLog), /stopped/);
+
+    const bridgeArgs = JSON.parse((await fileText(fixture.bridgeLog)).trim());
+    assert.deepEqual(bridgeArgs.slice(0, 2), ["--session", "dev session"]);
+    assert.deepEqual(bridgeArgs.slice(-6), [
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--static-dir",
+      path.join(ROOT, "web", "dist"),
+    ]);
+    const vite = JSON.parse((await fileText(fixture.viteLog)).trim());
+    assert.equal(vite.bridge, `http://127.0.0.1:${port}`);
+    assert.deepEqual(vite.args.slice(-6), [
+      "--",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(port + 1),
+      "--strictPort",
+    ]);
+  } finally {
+    await stopRun(run);
+    await rm(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("bridge startup failure does not start Vite", { concurrency: false }, async () => {
+  const fixture = await makeFixture();
+  let run;
+  try {
+    const port = await reservePort();
+    run = runDev(fixture, port, { FAKE_BRIDGE_FAIL: "23" });
+    const outcome = await run.result;
+    assert.equal(outcome.code, 23, outcome.output);
+    assert.equal(await fileText(fixture.viteLog), "");
+  } finally {
+    await stopRun(run);
+    await rm(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("unhealthy capabilities response does not start Vite", { concurrency: false }, async () => {
+  const fixture = await makeFixture();
+  let run;
+  try {
+    const port = await reservePort();
+    run = runDev(fixture, port, {
+      FAKE_BRIDGE_STATUS: "503",
+      FAKE_BRIDGE_EXIT_AFTER_MS: "200",
+      FAKE_BRIDGE_EXIT_CODE: "24",
+    });
+    const outcome = await run.result;
+    assert.equal(outcome.code, 24, outcome.output);
+    assert.equal(await fileText(fixture.viteLog), "");
+  } finally {
+    await stopRun(run);
+    await rm(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("SIGTERM stops both managed processes", { concurrency: false }, async () => {
+  const fixture = await makeFixture();
+  let run;
+  try {
+    const port = await reservePort();
+    run = runDev(fixture, port);
+    await waitForFile(fixture.viteLog);
+    run.child.kill("SIGTERM");
+    const outcome = await run.result;
+    assert.equal(outcome.code, 143, outcome.output);
+    assert.match(await fileText(fixture.bridgeStopLog), /stopped/);
+    assert.match(await fileText(fixture.viteStopLog), /stopped/);
+  } finally {
+    await stopRun(run);
+    await rm(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("SIGTERM during an automatic bridge build stops the build process", { concurrency: false }, async () => {
+  const fixture = await makeFixture();
+  let run;
+  try {
+    const projectRoot = path.join(fixture.directory, "project");
+    const scriptPath = path.join(projectRoot, "scripts", "dev.mjs");
+    await mkdir(path.join(projectRoot, "scripts"), { recursive: true });
+    await mkdir(path.join(projectRoot, "web", "node_modules"), { recursive: true });
+    await copyFile(DEV_SCRIPT, scriptPath);
+    const env = {
+      ...process.env,
+      PATH: `${path.join(fixture.directory, "bin")}${path.delimiter}${process.env.PATH}`,
+      FAKE_BUILD_HANG: "1",
+      FAKE_BUILD_LOG: fixture.buildLog,
+      FAKE_BUILD_STOP_LOG: fixture.buildStopLog,
+    };
+    delete env.HERDR_WEB_BRIDGE_BIN;
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: projectRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    const result = new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (code, signal) => resolve({ code, signal, output }));
+    });
+    run = { child, result };
+
+    await waitForFile(fixture.buildLog);
+    child.kill("SIGTERM");
+    const outcome = await result;
+    assert.equal(outcome.code, 143, outcome.output);
+    assert.match(await fileText(fixture.buildStopLog), /stopped/);
+  } finally {
+    await stopRun(run);
+    await rm(fixture.directory, { recursive: true, force: true });
+  }
+});

--- a/web/README.md
+++ b/web/README.md
@@ -15,14 +15,22 @@ npm run build
 The production build is written to `web/dist/` and served by `herdr-web-bridge` through
 `scripts/run-bridge.sh`.
 
-During development, run the bridge separately and use the Vite server for the frontend:
+For the normal one-command development workflow, start the bridge and Vite from the repository root:
 
 ```bash
-# terminal 1, from repo root
-npm run bridge:build
-scripts/run-bridge.sh
+npm run dev
+```
 
-# terminal 2, from repo root
+Open `http://127.0.0.1:5173`. Vite proxies `/api` and `/ws` to the managed bridge and hot-reloads
+frontend edits. See the root README for address and socket overrides.
+
+To manage the two processes separately instead:
+
+```bash
+# terminal 1, from the repository root
+npm run bridge:build && scripts/run-bridge.sh
+
+# terminal 2, from the repository root
 npm run dev:web
 ```
 


### PR DESCRIPTION
## Summary

- add supervised `npm run dev` with bridge readiness, Vite HMR proxying, and clean shutdown
- add scoped cache headers for static entrypoints and hashed assets
- add lifecycle/cache tests and documentation
- document the project’s intentionally focused contribution scope

Builds on the dev-server and cache-policy foundation proposed by @LosEcher in #51; CJK/IME changes remain out of scope.

## Validation

- `npm run check`
- live Vite/API/WebSocket and shutdown smoke
- `claude-default` iterative review: clean