### PR TITLE
Fix terminal IME composition handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ### Fixed
 
+- Fixed CJK and other IME terminal input so preedit stays local, committed text is sent exactly
+  once, canceled composition is discarded, and the candidate window and visible preedit stay near
+  the terminal cursor. Based on work proposed by [Hopkins (@LosEcher)](https://github.com/LosEcher)
+  in [PR #51](https://github.com/kcosr/herdr-web/pull/51).
 - Fixed icons rendering slightly off-center in square icon buttons (sidebar section header
   actions and the tab bar's new-tab button) by resetting the user-agent button padding, and
   removed the per-icon transform that compensated for it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@
 
 - Fixed CJK and other IME terminal input so preedit stays local, committed text is sent exactly
   once, canceled composition is discarded, and the candidate window and visible preedit stay near
-  the terminal cursor. Based on work proposed by [Hopkins (@LosEcher)](https://github.com/LosEcher)
-  in [PR #51](https://github.com/kcosr/herdr-web/pull/51).
+  the terminal cursor. [PR #58](https://github.com/kcosr/herdr-web/pull/58), based on work proposed
+  by [Hopkins (@LosEcher)](https://github.com/LosEcher) in
+  [PR #51](https://github.com/kcosr/herdr-web/pull/51).
 - Fixed icons rendering slightly off-center in square icon buttons (sidebar section header
   actions and the tab bar's new-tab button) by resetting the user-agent button padding, and
   removed the per-icon transform that compensated for it.

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1741,23 +1741,50 @@ button {
 
 .terminal-host .ghostty-hidden-input {
   position: fixed !important;
-  left: -10000px !important;
-  top: 0 !important;
-  width: 1px !important;
-  height: 1px !important;
+  left: var(--ghostty-ime-left, -10000px) !important;
+  top: var(--ghostty-ime-top, 0px) !important;
+  width: var(--ghostty-ime-width, 1px) !important;
+  height: var(--ghostty-ime-height, 1px) !important;
   opacity: 0 !important;
   color: transparent !important;
   background: transparent !important;
   caret-color: transparent !important;
   overflow: hidden !important;
   resize: none !important;
-}
-
-.terminal-host .ghostty-hidden-input.ghostty-keyboard-input {
-  left: 1px !important;
-  top: 1px !important;
+  border: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
   pointer-events: none !important;
   z-index: 0 !important;
+}
+
+.terminal-host .ghostty-hidden-input.ghostty-keyboard-input,
+.terminal-host .ghostty-hidden-input.ghostty-ime-composing {
+  left: var(--ghostty-ime-left, 1px) !important;
+  top: var(--ghostty-ime-top, 1px) !important;
+  width: var(--ghostty-ime-width, 1px) !important;
+  height: var(--ghostty-ime-height, 16px) !important;
+  z-index: 5 !important;
+}
+
+.terminal-host .ghostty-ime-preedit {
+  position: fixed;
+  z-index: 6;
+  box-sizing: border-box;
+  padding: 0 2px;
+  margin: 0;
+  border: 0;
+  border-radius: 2px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--surface0) 88%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--blue) 35%, transparent);
+  color: var(--text);
+  text-decoration: underline;
+  text-decoration-color: var(--blue);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  white-space: pre;
+  pointer-events: none;
 }
 
 .terminal-file-input {

--- a/web/src/terminalImeFocus.test.ts
+++ b/web/src/terminalImeFocus.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { installTerminalImeFocusRedirect } from "./terminalImeFocus";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("terminal IME focus redirect", () => {
+  it("restores the textarea after terminal selection focuses the host", () => {
+    const container = document.createElement("div");
+    container.tabIndex = 0;
+    const textarea = document.createElement("textarea");
+    container.append(textarea);
+    document.body.append(container);
+    const cleanup = installTerminalImeFocusRedirect({
+      container,
+      textarea,
+      hasAlternateTapFocus: () => false,
+      focusTextarea: () => textarea.focus(),
+    });
+
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+    container.focus();
+    expect(document.activeElement).toBe(textarea);
+
+    cleanup();
+  });
+
+  it("does not steal focus when mobile uses an alternate tap target", () => {
+    const container = document.createElement("div");
+    container.tabIndex = 0;
+    const textarea = document.createElement("textarea");
+    container.append(textarea);
+    document.body.append(container);
+    const cleanup = installTerminalImeFocusRedirect({
+      container,
+      textarea,
+      hasAlternateTapFocus: () => true,
+      focusTextarea: () => textarea.focus(),
+    });
+
+    container.focus();
+    expect(document.activeElement).toBe(container);
+
+    cleanup();
+  });
+});

--- a/web/src/terminalImeFocus.ts
+++ b/web/src/terminalImeFocus.ts
@@ -1,0 +1,24 @@
+/**
+ * Keep desktop terminal focus on the editable textarea after Ghostty's
+ * selection manager moves it back to the non-editable terminal host.
+ */
+export function installTerminalImeFocusRedirect(options: {
+  container: HTMLElement;
+  textarea: HTMLTextAreaElement;
+  hasAlternateTapFocus: () => boolean;
+  focusTextarea: () => void;
+}) {
+  const onFocusIn = (event: FocusEvent) => {
+    const target = event.target;
+    if (!(target instanceof Node) || !options.container.contains(target)) {
+      return;
+    }
+    if (target === options.textarea || options.hasAlternateTapFocus()) {
+      return;
+    }
+    options.focusTextarea();
+  };
+
+  options.container.addEventListener("focusin", onFocusIn);
+  return () => options.container.removeEventListener("focusin", onFocusIn);
+}

--- a/web/src/terminalImeInput.test.ts
+++ b/web/src/terminalImeInput.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import {
+  beforeInputOutput,
+  idleTerminalImeState,
+  imeTextareaAnchor,
+  isImeComposingKeyEvent,
+  keyboardEventOutput,
+  reduceTerminalImeState,
+  shouldDeferBeforeInputToIme,
+  textareaDelta,
+} from "./terminalImeInput";
+import type { TerminalImeEvent, TerminalImeState } from "./terminalImeInput";
+
+function reduceSequence(events: TerminalImeEvent[]) {
+  let state = idleTerminalImeState();
+  const output: string[] = [];
+  const transitions = events.map((event) => {
+    const transition = reduceTerminalImeState(state, event);
+    state = transition.state;
+    if (transition.output) {
+      output.push(transition.output);
+    }
+    return transition;
+  });
+  return { state, output, transitions };
+}
+
+describe("terminal IME event sequences", () => {
+  it("keeps preedit local and commits once when input precedes compositionend", () => {
+    const result = reduceSequence([
+      { type: "compositionstart", data: "", textareaValue: "" },
+      { type: "compositionupdate", data: "ni", textareaValue: "" },
+      {
+        type: "input",
+        data: "ni",
+        inputType: "insertCompositionText",
+        isComposing: true,
+        textareaValue: "ni",
+      },
+      { type: "compositionupdate", data: "你好", textareaValue: "ni" },
+      {
+        type: "input",
+        data: "你好",
+        inputType: "insertCompositionText",
+        isComposing: false,
+        textareaValue: "你好",
+      },
+      { type: "compositionend", data: "你好", textareaValue: "你好" },
+      { type: "settle" },
+    ]);
+
+    expect(result.output).toEqual(["你好"]);
+    expect(result.transitions[2].suppressInput).toBe(true);
+    expect(result.transitions[2].state.preedit).toBe("ni");
+    expect(result.state).toEqual(idleTerminalImeState());
+  });
+
+  it("suppresses a composition input dispatched after compositionend", () => {
+    const result = reduceSequence([
+      { type: "compositionstart", data: "", textareaValue: "" },
+      { type: "compositionupdate", data: "にほん", textareaValue: "" },
+      { type: "compositionend", data: "日本", textareaValue: "日本" },
+      {
+        type: "input",
+        data: "日本",
+        inputType: "insertCompositionText",
+        isComposing: false,
+        textareaValue: "日本",
+      },
+    ]);
+
+    expect(result.output).toEqual(["日本"]);
+    expect(result.transitions[3]).toMatchObject({
+      suppressInput: true,
+      clearTextarea: true,
+    });
+  });
+
+  it("suppresses a matching insertText dispatched after compositionend", () => {
+    const result = reduceSequence([
+      { type: "compositionstart", data: "", textareaValue: "" },
+      { type: "compositionend", data: "한글", textareaValue: "한글" },
+      {
+        type: "input",
+        data: "한글",
+        inputType: "insertText",
+        isComposing: false,
+        textareaValue: "한글",
+      },
+    ]);
+
+    expect(result.output).toEqual(["한글"]);
+    expect(result.transitions[2].suppressInput).toBe(true);
+  });
+
+  it("does not turn canceled preedit into terminal input", () => {
+    const result = reduceSequence([
+      { type: "compositionstart", data: "", textareaValue: "" },
+      { type: "compositionupdate", data: "nihao", textareaValue: "nihao" },
+      { type: "compositionupdate", data: "", textareaValue: "nihao" },
+      { type: "compositionend", data: "", textareaValue: "nihao" },
+      { type: "settle" },
+    ]);
+
+    expect(result.output).toEqual([]);
+    expect(result.transitions[2].state.preedit).toBe("");
+    expect(result.transitions[3]).toMatchObject({ clearTextarea: true, output: null });
+  });
+
+  it("lets a trailing insertText provide a commit when compositionend data is unavailable", () => {
+    const result = reduceSequence([
+      { type: "compositionstart", data: "", textareaValue: "" },
+      { type: "compositionupdate", data: "", textareaValue: "é" },
+      { type: "compositionend", data: "", textareaValue: "é" },
+      {
+        type: "input",
+        data: "é",
+        inputType: "insertText",
+        isComposing: false,
+        textareaValue: "é",
+      },
+    ]);
+
+    expect(result.output).toEqual([]);
+    expect(result.transitions[3].suppressInput).toBe(false);
+    expect(textareaDelta("", "é")).toBe("é");
+  });
+
+  it("does not suppress a later ordinary key after the composition settles", () => {
+    const result = reduceSequence([
+      { type: "compositionstart", data: "", textareaValue: "" },
+      { type: "compositionend", data: "a", textareaValue: "a" },
+      { type: "settle" },
+      {
+        type: "input",
+        data: "a",
+        inputType: "insertText",
+        isComposing: false,
+        textareaValue: "a",
+      },
+    ]);
+
+    expect(result.output).toEqual(["a"]);
+    expect(result.transitions[3].suppressInput).toBe(false);
+  });
+});
+
+describe("terminal IME guards", () => {
+  it("recognizes composing key events including legacy keyCode 229", () => {
+    expect(isImeComposingKeyEvent({ isComposing: true, keyCode: 65 })).toBe(true);
+    expect(isImeComposingKeyEvent({ isComposing: false, keyCode: 229 })).toBe(true);
+    expect(isImeComposingKeyEvent({ isComposing: false, keyCode: 65 })).toBe(false);
+  });
+
+  it("defers composition beforeinput and a matching trailing commit", () => {
+    const composing: TerminalImeState = {
+      phase: "composing",
+      baseline: "",
+      preedit: "ni",
+      pendingCommit: null,
+    };
+    expect(
+      shouldDeferBeforeInputToIme(composing, {
+        data: "ni",
+        inputType: "insertCompositionText",
+        isComposing: true,
+      }),
+    ).toBe(true);
+
+    const pending: TerminalImeState = { phase: "idle", preedit: "", pendingCommit: "你好" };
+    expect(
+      shouldDeferBeforeInputToIme(pending, {
+        data: "你好",
+        inputType: "insertText",
+        isComposing: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferBeforeInputToIme(pending, {
+        data: "a",
+        inputType: "insertText",
+        isComposing: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("maps ordinary beforeinput, keyboard, and textarea changes", () => {
+    expect(beforeInputOutput({ inputType: "insertText", data: "a" })).toBe("a");
+    expect(beforeInputOutput({ inputType: "insertLineBreak", data: null })).toBe("\r");
+    expect(beforeInputOutput({ inputType: "deleteContentBackward", data: null })).toBe("\x7F");
+    expect(beforeInputOutput({ inputType: "insertCompositionText", data: "ni" })).toBe(null);
+    expect(
+      keyboardEventOutput({ ctrlKey: false, altKey: false, metaKey: false, key: "Enter" }),
+    ).toBe("\r");
+    expect(textareaDelta("abc", "adc")).toBe("\x7F\x7Fdc");
+  });
+});
+
+describe("IME textarea anchor", () => {
+  it("positions the textarea at the terminal cursor", () => {
+    expect(
+      imeTextareaAnchor({
+        terminalLeft: 100,
+        terminalTop: 50,
+        terminalWidth: 180,
+        terminalHeight: 64,
+        browserWidth: 800,
+        browserHeight: 600,
+        cellWidth: 9,
+        cellHeight: 16,
+        cursorCol: 2,
+        cursorRow: 1,
+        fontSizePx: 14,
+      }),
+    ).toEqual({ left: 118, top: 66, width: 9, height: 16, fontSizePx: 14 });
+  });
+
+  it("clamps the textarea to both terminal cells and the browser viewport", () => {
+    expect(
+      imeTextareaAnchor({
+        terminalLeft: 790,
+        terminalTop: 595,
+        terminalWidth: 90,
+        terminalHeight: 32,
+        browserWidth: 800,
+        browserHeight: 600,
+        cellWidth: 9,
+        cellHeight: 16,
+        cursorCol: 99,
+        cursorRow: 99,
+        fontSizePx: 12,
+      }),
+    ).toMatchObject({ left: 790, top: 583 });
+  });
+});

--- a/web/src/terminalImeInput.test.ts
+++ b/web/src/terminalImeInput.test.ts
@@ -107,23 +107,90 @@ describe("terminal IME event sequences", () => {
     expect(result.transitions[3]).toMatchObject({ clearTextarea: true, output: null });
   });
 
-  it("lets a trailing insertText provide a commit when compositionend data is unavailable", () => {
+  it("discards canceled Pinyin replay without swallowing the following character", () => {
     const result = reduceSequence([
       { type: "compositionstart", data: "", textareaValue: "" },
-      { type: "compositionupdate", data: "", textareaValue: "é" },
-      { type: "compositionend", data: "", textareaValue: "é" },
+      { type: "compositionupdate", data: "n", textareaValue: "n" },
+      { type: "compositionend", data: "", textareaValue: "n" },
       {
         type: "input",
-        data: "é",
+        data: "n",
         inputType: "insertText",
         isComposing: false,
-        textareaValue: "é",
+        textareaValue: "n",
+      },
+      { type: "settle" },
+      {
+        type: "input",
+        data: "C",
+        inputType: "insertText",
+        isComposing: false,
+        textareaValue: "C",
       },
     ]);
 
     expect(result.output).toEqual([]);
+    expect(
+      shouldDeferBeforeInputToIme(result.transitions[2].state, {
+        data: "n",
+        inputType: "insertText",
+        isComposing: false,
+      }),
+    ).toBe(true);
+    expect(result.transitions[3]).toMatchObject({ suppressInput: true, clearTextarea: true });
+    expect(result.transitions[5].suppressInput).toBe(false);
+    expect(textareaDelta("", "C")).toBe("C");
+  });
+
+  it("discards a canceled preedit replayed in multiple insertText fragments", () => {
+    const result = reduceSequence([
+      { type: "compositionstart", data: "", textareaValue: "" },
+      { type: "compositionupdate", data: "ni", textareaValue: "ni" },
+      { type: "compositionend", data: "", textareaValue: "ni" },
+      {
+        type: "input",
+        data: "n",
+        inputType: "insertText",
+        isComposing: false,
+        textareaValue: "n",
+      },
+      {
+        type: "input",
+        data: "i",
+        inputType: "insertText",
+        isComposing: false,
+        textareaValue: "i",
+      },
+    ]);
+
+    expect(result.transitions[3]).toMatchObject({ suppressInput: true, clearTextarea: true });
+    expect(result.transitions[4]).toMatchObject({ suppressInput: true, clearTextarea: true });
+    expect(result.state).toEqual(idleTerminalImeState());
+  });
+
+  it("does not swallow a keydown-less paste after canceled composition", () => {
+    const result = reduceSequence([
+      { type: "compositionstart", data: "", textareaValue: "" },
+      { type: "compositionupdate", data: "n", textareaValue: "n" },
+      { type: "compositionend", data: "", textareaValue: "n" },
+      {
+        type: "input",
+        data: "PASTE",
+        inputType: "insertFromPaste",
+        isComposing: false,
+        textareaValue: "PASTE",
+      },
+    ]);
+
+    expect(
+      shouldDeferBeforeInputToIme(result.transitions[2].state, {
+        data: "PASTE",
+        inputType: "insertFromPaste",
+        isComposing: false,
+      }),
+    ).toBe(false);
     expect(result.transitions[3].suppressInput).toBe(false);
-    expect(textareaDelta("", "é")).toBe("é");
+    expect(result.state).toEqual(idleTerminalImeState());
   });
 
   it("does not suppress a later ordinary key after the composition settles", () => {
@@ -189,7 +256,7 @@ describe("terminal IME event sequences", () => {
       phase: "composing",
       baseline: "",
       preedit: "に",
-      pendingCommit: null,
+      pendingInput: null,
     };
     expect(reduceTerminalImeState(composing, { type: "settle" }).state).toBe(composing);
   });
@@ -207,7 +274,7 @@ describe("terminal IME guards", () => {
       phase: "composing",
       baseline: "",
       preedit: "ni",
-      pendingCommit: null,
+      pendingInput: null,
     };
     expect(
       shouldDeferBeforeInputToIme(composing, {
@@ -217,7 +284,11 @@ describe("terminal IME guards", () => {
       }),
     ).toBe(true);
 
-    const pending: TerminalImeState = { phase: "idle", preedit: "", pendingCommit: "你好" };
+    const pending: TerminalImeState = {
+      phase: "idle",
+      preedit: "",
+      pendingInput: { kind: "commit", text: "你好" },
+    };
     expect(
       shouldDeferBeforeInputToIme(pending, {
         data: "你好",

--- a/web/src/terminalImeInput.test.ts
+++ b/web/src/terminalImeInput.test.ts
@@ -143,6 +143,56 @@ describe("terminal IME event sequences", () => {
     expect(result.output).toEqual(["a"]);
     expect(result.transitions[3].suppressInput).toBe(false);
   });
+
+  it("derives local preedit from the textarea when InputEvent.data is null", () => {
+    const result = reduceSequence([
+      { type: "compositionstart", data: "", textareaValue: "prefix" },
+      {
+        type: "input",
+        data: null,
+        inputType: "insertCompositionText",
+        isComposing: true,
+        textareaValue: "prefixnihao",
+      },
+    ]);
+
+    expect(result.output).toEqual([]);
+    expect(result.transitions[1]).toMatchObject({ suppressInput: true, clearTextarea: false });
+    expect(result.state).toMatchObject({ phase: "composing", preedit: "nihao" });
+  });
+
+  it("discards an active composition on reset without changing an idle state", () => {
+    const composing = reduceTerminalImeState(idleTerminalImeState(), {
+      type: "compositionstart",
+      data: "ni",
+      textareaValue: "ni",
+    }).state;
+    const reset = reduceTerminalImeState(composing, { type: "reset" });
+    expect(reset).toEqual({
+      state: idleTerminalImeState(),
+      output: null,
+      suppressInput: true,
+      clearTextarea: true,
+    });
+
+    const idleReset = reduceTerminalImeState(idleTerminalImeState(), { type: "reset" });
+    expect(idleReset).toEqual({
+      state: idleTerminalImeState(),
+      output: null,
+      suppressInput: false,
+      clearTextarea: false,
+    });
+  });
+
+  it("does not settle an active composition", () => {
+    const composing: TerminalImeState = {
+      phase: "composing",
+      baseline: "",
+      preedit: "に",
+      pendingCommit: null,
+    };
+    expect(reduceTerminalImeState(composing, { type: "settle" }).state).toBe(composing);
+  });
 });
 
 describe("terminal IME guards", () => {

--- a/web/src/terminalImeInput.ts
+++ b/web/src/terminalImeInput.ts
@@ -9,13 +9,16 @@ export type TerminalImeState =
   | {
       phase: "idle";
       preedit: "";
-      pendingCommit: string | null;
+      pendingInput:
+        | { kind: "commit"; text: string }
+        | { kind: "cancellation"; remaining: string }
+        | null;
     }
   | {
       phase: "composing";
       baseline: string;
       preedit: string;
-      pendingCommit: null;
+      pendingInput: null;
     };
 
 export type TerminalImeEvent =
@@ -48,7 +51,7 @@ export type ImeTextareaAnchor = {
 };
 
 export function idleTerminalImeState(): TerminalImeState {
-  return { phase: "idle", preedit: "", pendingCommit: null };
+  return { phase: "idle", preedit: "", pendingInput: null };
 }
 
 /**
@@ -56,9 +59,11 @@ export function idleTerminalImeState(): TerminalImeState {
  *
  * Browsers disagree about whether their final input event occurs before or
  * after compositionend. A completed composition is emitted at compositionend;
- * pendingCommit suppresses a matching trailing input without swallowing the
- * next unrelated keystroke. Call settle in a microtask after compositionend so
- * that suppression cannot leak into a later user action.
+ * pendingInput suppresses a matching trailing commit or canceled-preedit
+ * replay without swallowing unrelated input. Call settle after the trailing
+ * composition edit window; canceled composition may need to remain armed until
+ * the next keydown because some browsers replay canceled preedit after a
+ * microtask.
  */
 export function reduceTerminalImeState(
   state: TerminalImeState,
@@ -70,7 +75,7 @@ export function reduceTerminalImeState(
         phase: "composing",
         baseline: event.textareaValue,
         preedit: event.data,
-        pendingCommit: null,
+        pendingInput: null,
       });
 
     case "compositionupdate":
@@ -84,14 +89,20 @@ export function reduceTerminalImeState(
         return transition(state, { suppressInput: true });
       }
       const output = normalizeTerminalText(event.data);
+      const canceledPreedit =
+        output === null
+          ? normalizeTerminalText(state.preedit) ??
+            normalizeTerminalText(textareaSuffix(state.baseline, event.textareaValue))
+          : null;
       return transition(
         {
           phase: "idle",
           preedit: "",
-          // An empty string is intentional: it lets a later insertText supply
-          // a commit when compositionend did not expose data, without treating
-          // the textarea's possibly canceled preedit as committed text.
-          pendingCommit: output ?? "",
+          pendingInput: output
+            ? { kind: "commit", text: output }
+            : canceledPreedit
+              ? { kind: "cancellation", remaining: canceledPreedit }
+              : null,
         },
         {
           output,
@@ -109,20 +120,35 @@ export function reduceTerminalImeState(
 
       if (event.isComposing || isImeCompositionInputType(event.inputType)) {
         return transition(
-          { ...state, pendingCommit: null },
+          { ...state, pendingInput: null },
           { suppressInput: true, clearTextarea: true },
         );
       }
 
-      if (state.pendingCommit !== null) {
+      if (state.pendingInput !== null) {
         const candidate = inputCandidate(event.data, event.textareaValue);
-        if (candidate === state.pendingCommit) {
+        if (state.pendingInput.kind === "commit" && candidate === state.pendingInput.text) {
           return transition(
-            { ...state, pendingCommit: null },
+            { ...state, pendingInput: null },
             { suppressInput: true, clearTextarea: true },
           );
         }
-        return transition({ ...state, pendingCommit: null });
+        if (
+          state.pendingInput.kind === "cancellation" &&
+          event.inputType === "insertText" &&
+          candidate !== "" &&
+          state.pendingInput.remaining.startsWith(candidate)
+        ) {
+          const remaining = state.pendingInput.remaining.slice(candidate.length);
+          return transition(
+            {
+              ...state,
+              pendingInput: remaining ? { kind: "cancellation", remaining } : null,
+            },
+            { suppressInput: true, clearTextarea: true },
+          );
+        }
+        return transition({ ...state, pendingInput: null });
       }
 
       return transition(state);
@@ -130,7 +156,7 @@ export function reduceTerminalImeState(
 
     case "settle":
       return state.phase === "idle"
-        ? transition({ ...state, pendingCommit: null })
+        ? transition({ ...state, pendingInput: null })
         : transition(state);
 
     case "reset":
@@ -152,10 +178,18 @@ export function shouldDeferBeforeInputToIme(
   if (state.phase === "composing" || event.isComposing || isImeCompositionInputType(event.inputType)) {
     return true;
   }
-  if (state.pendingCommit === null) {
+  if (state.pendingInput === null) {
     return false;
   }
-  return normalizeTerminalText(event.data) === state.pendingCommit;
+  const candidate = normalizeTerminalText(event.data);
+  if (state.pendingInput.kind === "commit") {
+    return candidate === state.pendingInput.text;
+  }
+  return (
+    event.inputType === "insertText" &&
+    candidate !== null &&
+    state.pendingInput.remaining.startsWith(candidate)
+  );
 }
 
 export function isImeComposingKeyEvent(
@@ -287,6 +321,10 @@ function inputPreedit(
     return event.textareaValue.slice(baseline.length);
   }
   return event.textareaValue;
+}
+
+function textareaSuffix(baseline: string, value: string) {
+  return value.startsWith(baseline) ? value.slice(baseline.length) : value;
 }
 
 function inputCandidate(data: string | null, textareaValue: string) {

--- a/web/src/terminalImeInput.ts
+++ b/web/src/terminalImeInput.ts
@@ -1,0 +1,315 @@
+/**
+ * Browser IME helpers for the terminal's hidden textarea.
+ *
+ * Composition preedit stays in the textarea. Only a completed composition or
+ * ordinary, non-composition input is allowed to reach the PTY.
+ */
+
+export type TerminalImeState =
+  | {
+      phase: "idle";
+      preedit: "";
+      pendingCommit: string | null;
+    }
+  | {
+      phase: "composing";
+      baseline: string;
+      preedit: string;
+      pendingCommit: null;
+    };
+
+export type TerminalImeEvent =
+  | { type: "compositionstart"; data: string; textareaValue: string }
+  | { type: "compositionupdate"; data: string; textareaValue: string }
+  | { type: "compositionend"; data: string; textareaValue: string }
+  | {
+      type: "input";
+      data: string | null;
+      inputType: string;
+      isComposing: boolean;
+      textareaValue: string;
+    }
+  | { type: "settle" }
+  | { type: "reset" };
+
+export type TerminalImeTransition = {
+  state: TerminalImeState;
+  output: string | null;
+  suppressInput: boolean;
+  clearTextarea: boolean;
+};
+
+export type ImeTextareaAnchor = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  fontSizePx: number;
+};
+
+export function idleTerminalImeState(): TerminalImeState {
+  return { phase: "idle", preedit: "", pendingCommit: null };
+}
+
+/**
+ * Reduce browser composition/input events into terminal output.
+ *
+ * Browsers disagree about whether their final input event occurs before or
+ * after compositionend. A completed composition is emitted at compositionend;
+ * pendingCommit suppresses a matching trailing input without swallowing the
+ * next unrelated keystroke. Call settle in a microtask after compositionend so
+ * that suppression cannot leak into a later user action.
+ */
+export function reduceTerminalImeState(
+  state: TerminalImeState,
+  event: TerminalImeEvent,
+): TerminalImeTransition {
+  switch (event.type) {
+    case "compositionstart":
+      return transition({
+        phase: "composing",
+        baseline: event.textareaValue,
+        preedit: event.data,
+        pendingCommit: null,
+      });
+
+    case "compositionupdate":
+      if (state.phase !== "composing") {
+        return transition(state);
+      }
+      return transition({ ...state, preedit: event.data });
+
+    case "compositionend": {
+      if (state.phase !== "composing") {
+        return transition(state, { suppressInput: true });
+      }
+      const output = normalizeTerminalText(event.data);
+      return transition(
+        {
+          phase: "idle",
+          preedit: "",
+          // An empty string is intentional: it lets a later insertText supply
+          // a commit when compositionend did not expose data, without treating
+          // the textarea's possibly canceled preedit as committed text.
+          pendingCommit: output ?? "",
+        },
+        {
+          output,
+          suppressInput: true,
+          clearTextarea: true,
+        },
+      );
+    }
+
+    case "input": {
+      if (state.phase === "composing") {
+        const preedit = inputPreedit(state.baseline, event);
+        return transition({ ...state, preedit }, { suppressInput: true });
+      }
+
+      if (event.isComposing || isImeCompositionInputType(event.inputType)) {
+        return transition(
+          { ...state, pendingCommit: null },
+          { suppressInput: true, clearTextarea: true },
+        );
+      }
+
+      if (state.pendingCommit !== null) {
+        const candidate = inputCandidate(event.data, event.textareaValue);
+        if (candidate === state.pendingCommit) {
+          return transition(
+            { ...state, pendingCommit: null },
+            { suppressInput: true, clearTextarea: true },
+          );
+        }
+        return transition({ ...state, pendingCommit: null });
+      }
+
+      return transition(state);
+    }
+
+    case "settle":
+      return state.phase === "idle"
+        ? transition({ ...state, pendingCommit: null })
+        : transition(state);
+
+    case "reset":
+      return transition(idleTerminalImeState(), {
+        suppressInput: state.phase === "composing",
+        clearTextarea: state.phase === "composing",
+      });
+  }
+}
+
+/**
+ * Return true when beforeinput belongs to composition and must be left in the
+ * textarea instead of being sent directly to the PTY.
+ */
+export function shouldDeferBeforeInputToIme(
+  state: TerminalImeState,
+  event: Pick<InputEvent, "data" | "inputType" | "isComposing">,
+): boolean {
+  if (state.phase === "composing" || event.isComposing || isImeCompositionInputType(event.inputType)) {
+    return true;
+  }
+  if (state.pendingCommit === null) {
+    return false;
+  }
+  return normalizeTerminalText(event.data) === state.pendingCommit;
+}
+
+export function isImeComposingKeyEvent(
+  event: Pick<KeyboardEvent, "isComposing" | "keyCode">,
+): boolean {
+  return event.isComposing || event.keyCode === 229;
+}
+
+export function isImeCompositionInputType(inputType: string): boolean {
+  return (
+    inputType === "insertCompositionText" ||
+    inputType === "deleteCompositionText" ||
+    inputType === "insertFromComposition" ||
+    inputType === "deleteByComposition"
+  );
+}
+
+export function beforeInputOutput(event: Pick<InputEvent, "inputType" | "data">): string | null {
+  switch (event.inputType) {
+    case "insertText":
+    case "insertReplacementText":
+      return normalizeTerminalText(event.data);
+    case "insertLineBreak":
+    case "insertParagraph":
+      return "\r";
+    case "deleteContentBackward":
+      return "\x7F";
+    case "deleteContentForward":
+      return "\x1B[3~";
+    default:
+      return null;
+  }
+}
+
+export function textareaDelta(previousValue: string, nextValue: string): string {
+  if (nextValue.startsWith(previousValue)) {
+    return nextValue.slice(previousValue.length).replace(/\n/g, "\r");
+  }
+
+  const previousChars = Array.from(previousValue);
+  const nextChars = Array.from(nextValue);
+  let commonPrefixLength = 0;
+  while (
+    commonPrefixLength < previousChars.length &&
+    commonPrefixLength < nextChars.length &&
+    previousChars[commonPrefixLength] === nextChars[commonPrefixLength]
+  ) {
+    commonPrefixLength += 1;
+  }
+
+  const deletes = "\x7F".repeat(previousChars.length - commonPrefixLength);
+  const inserts = nextChars.slice(commonPrefixLength).join("").replace(/\n/g, "\r");
+  return `${deletes}${inserts}`;
+}
+
+export function keyboardEventOutput(
+  event: Pick<KeyboardEvent, "ctrlKey" | "altKey" | "metaKey" | "key">,
+): string | null {
+  if (event.ctrlKey || event.altKey || event.metaKey) {
+    return null;
+  }
+  if (event.key.length === 1) {
+    return event.key;
+  }
+  switch (event.key) {
+    case "Enter":
+      return "\r";
+    case "Backspace":
+      return "\x7F";
+    case "Delete":
+      return "\x1B[3~";
+    default:
+      return null;
+  }
+}
+
+/** Position the hidden textarea over the visible terminal cursor cell. */
+export function imeTextareaAnchor(options: {
+  terminalLeft: number;
+  terminalTop: number;
+  terminalWidth: number;
+  terminalHeight: number;
+  browserWidth: number;
+  browserHeight: number;
+  cellWidth: number;
+  cellHeight: number;
+  cursorCol: number;
+  cursorRow: number;
+  fontSizePx: number;
+}): ImeTextareaAnchor {
+  const cellWidth = Math.max(1, options.cellWidth);
+  const cellHeight = Math.max(1, options.cellHeight);
+  const maxCol = Math.max(0, Math.floor(options.terminalWidth / cellWidth) - 1);
+  const maxRow = Math.max(0, Math.floor(options.terminalHeight / cellHeight) - 1);
+  const col = clampInteger(options.cursorCol, 0, maxCol);
+  const row = clampInteger(options.cursorRow, 0, maxRow);
+  const maxLeft = Math.max(1, options.browserWidth - cellWidth - 1);
+  const maxTop = Math.max(1, options.browserHeight - cellHeight - 1);
+  return {
+    left: clampNumber(options.terminalLeft + col * cellWidth, 1, maxLeft),
+    top: clampNumber(options.terminalTop + row * cellHeight, 1, maxTop),
+    width: cellWidth,
+    height: cellHeight,
+    fontSizePx: Math.max(1, options.fontSizePx),
+  };
+}
+
+function transition(
+  state: TerminalImeState,
+  overrides: Partial<Omit<TerminalImeTransition, "state">> = {},
+): TerminalImeTransition {
+  return {
+    state,
+    output: null,
+    suppressInput: false,
+    clearTextarea: false,
+    ...overrides,
+  };
+}
+
+function inputPreedit(
+  baseline: string,
+  event: Extract<TerminalImeEvent, { type: "input" }>,
+) {
+  if (typeof event.data === "string") {
+    return event.data;
+  }
+  if (event.textareaValue.startsWith(baseline)) {
+    return event.textareaValue.slice(baseline.length);
+  }
+  return event.textareaValue;
+}
+
+function inputCandidate(data: string | null, textareaValue: string) {
+  return normalizeTerminalText(data) ?? normalizeTerminalText(textareaValue) ?? "";
+}
+
+function normalizeTerminalText(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+  return value.replace(/\n/g, "\r");
+}
+
+function clampInteger(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(max, Math.max(min, Math.trunc(value)));
+}
+
+function clampNumber(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(max, Math.max(min, value));
+}

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -1154,7 +1154,16 @@ export class GhosttyRenderer implements TerminalRenderer {
 
     const onKeydown = (event: KeyboardEvent) => {
       if (imeState.phase === "composing" || isImeComposingKeyEvent(event)) {
+        event.stopPropagation();
+        if (typeof event.stopImmediatePropagation === "function") {
+          event.stopImmediatePropagation();
+        }
         return;
+      }
+      if (imeState.pendingInput !== null) {
+        // A real keydown marks the boundary after any trailing composition
+        // edit, so cancellation suppression must not consume this new key.
+        imeState = reduceTerminalImeState(imeState, { type: "settle" }).state;
       }
       const customOutput = textareaKeyboardEventOutput(event);
       if (customOutput) {
@@ -1287,8 +1296,16 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
 
       // A browser's trailing input event, when present, is dispatched in the
-      // same event task. Do not let its one-shot dedupe affect a later key.
+      // same event task. Do not let a successful commit's one-shot dedupe
+      // affect a later key. Cancellation remains armed until the next keydown
+      // because browsers may replay canceled preedit after a microtask.
       const endedState = imeState;
+      if (
+        endedState.phase === "idle" &&
+        endedState.pendingInput?.kind === "cancellation"
+      ) {
+        return;
+      }
       queueMicrotask(() => {
         if (imeState === endedState) {
           imeState = reduceTerminalImeState(imeState, { type: "settle" }).state;

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -38,6 +38,7 @@ import {
   textareaDelta,
 } from "./terminalImeInput";
 import type { TerminalImeState } from "./terminalImeInput";
+import { installTerminalImeFocusRedirect } from "./terminalImeFocus";
 
 const TERMINAL_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace';
@@ -145,6 +146,7 @@ export class GhosttyRenderer implements TerminalRenderer {
   #scrollCallback: ((lines: number) => void) | null = null;
   #touchCleanup: (() => void) | null = null;
   #mobileInputCleanup: (() => void) | null = null;
+  #imeFocusCleanup: (() => void) | null = null;
   #tapFocusHandler: (() => TerminalTapFocusResult) | null = null;
   #mobileLongPressBehavior: MobileLongPressBehavior = "off";
   #mobileTouchSelectionHandler: ((event: MobileTerminalTouchEvent) => void) | null = null;
@@ -222,6 +224,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     this.#fitAddon = fitAddon;
     this.#installScrollHandlers();
     this.#installMobileInputBridge();
+    this.#installImeFocusRedirect();
     return this.fit();
   }
 
@@ -326,6 +329,8 @@ export class GhosttyRenderer implements TerminalRenderer {
     this.#touchCleanup = null;
     this.#mobileInputCleanup?.();
     this.#mobileInputCleanup = null;
+    this.#imeFocusCleanup?.();
+    this.#imeFocusCleanup = null;
     this.#fitAddon?.dispose();
     this.#fitAddon = null;
     this.#terminal?.dispose();
@@ -1323,6 +1328,23 @@ export class GhosttyRenderer implements TerminalRenderer {
       textarea.removeEventListener("blur", onBlur);
       preeditOverlay.remove();
     };
+  }
+
+  #installImeFocusRedirect() {
+    const terminal = this.#requireTerminal();
+    const container = this.#container;
+    const textarea = terminal.textarea;
+    if (!container || !textarea) {
+      return;
+    }
+
+    this.#imeFocusCleanup?.();
+    this.#imeFocusCleanup = installTerminalImeFocusRedirect({
+      container,
+      textarea,
+      hasAlternateTapFocus: () => this.#tapFocusHandler !== null,
+      focusTextarea: () => this.focusTextInput(),
+    });
   }
 }
 

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -27,6 +27,17 @@ import type {
   MobileTouchSelectionEndpointTimeoutMs,
 } from "./mobileTerminalPrefs";
 import { DEFAULT_TERMINAL_FONT_SIZE_PX } from "./terminalPrefs";
+import {
+  beforeInputOutput,
+  idleTerminalImeState,
+  imeTextareaAnchor,
+  isImeComposingKeyEvent,
+  keyboardEventOutput,
+  reduceTerminalImeState,
+  shouldDeferBeforeInputToIme,
+  textareaDelta,
+} from "./terminalImeInput";
+import type { TerminalImeState } from "./terminalImeInput";
 
 const TERMINAL_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace';
@@ -188,6 +199,9 @@ export class GhosttyRenderer implements TerminalRenderer {
     terminal.loadAddon(fitAddon);
     terminal.open(container);
     terminal.attachCustomKeyEventHandler((event) => {
+      if (isImeComposingKeyEvent(event)) {
+        return false;
+      }
       const output = customKeyboardEventOutput(event);
       if (!output) {
         return false;
@@ -273,22 +287,27 @@ export class GhosttyRenderer implements TerminalRenderer {
   }
 
   focus() {
-    this.#terminal?.focus();
+    this.focusTextInput();
   }
 
   focusTextInput() {
-    const textarea = this.#terminal?.textarea;
-    if (!textarea) {
+    const terminal = this.#terminal;
+    const textarea = terminal?.textarea;
+    if (!textarea || !terminal) {
       this.#terminal?.focus();
       return;
     }
     this.#textInputTapGraceUntil = performance.now() + TERMINAL_TEXT_INPUT_TAP_GRACE_MS;
+    positionGhosttyTextareaForInput(textarea, terminal);
     textarea.classList.add("ghostty-keyboard-input");
     textarea.focus({ preventScroll: true });
     window.setTimeout(() => {
       if (textarea.isConnected) {
+        positionGhosttyTextareaForInput(textarea, this.#terminal);
         textarea.classList.add("ghostty-keyboard-input");
-        textarea.focus({ preventScroll: true });
+        if (document.activeElement !== textarea) {
+          textarea.focus({ preventScroll: true });
+        }
       }
     }, 0);
   }
@@ -1088,16 +1107,50 @@ export class GhosttyRenderer implements TerminalRenderer {
   #installMobileInputBridge() {
     const terminal = this.#requireTerminal();
     const textarea = terminal.textarea;
-    if (!textarea) {
+    const host = this.#container;
+    if (!textarea || !host) {
       return;
     }
     textarea.classList.add("ghostty-hidden-input");
     hideGhosttyTextarea(textarea);
-    cleanupEditableArtifacts(this.#container);
+    cleanupEditableArtifacts(host);
+
+    const preeditOverlay = document.createElement("div");
+    preeditOverlay.className = "ghostty-ime-preedit";
+    preeditOverlay.setAttribute("aria-hidden", "true");
+    preeditOverlay.hidden = true;
+    host.append(preeditOverlay);
 
     let lastKeydown: { data: string; time: number } | null = null;
     let processedTextareaValue = "";
+    let imeState: TerminalImeState = idleTerminalImeState();
+
+    const sendTerminalText = (output: string) => {
+      terminal.input(output, true);
+      cleanupEditableArtifacts(host);
+    };
+    const clearTextareaState = () => {
+      textarea.value = "";
+      processedTextareaValue = "";
+      lastKeydown = null;
+    };
+    const hidePreedit = () => {
+      preeditOverlay.hidden = true;
+      preeditOverlay.textContent = "";
+    };
+    const refreshCompositionUi = () => {
+      positionGhosttyTextareaForInput(textarea, terminal);
+      if (imeState.phase !== "composing" || !imeState.preedit) {
+        hidePreedit();
+        return;
+      }
+      updateImePreeditOverlay(preeditOverlay, imeState.preedit, textarea, terminal);
+    };
+
     const onKeydown = (event: KeyboardEvent) => {
+      if (imeState.phase === "composing" || isImeComposingKeyEvent(event)) {
+        return;
+      }
       const customOutput = textareaKeyboardEventOutput(event);
       if (customOutput) {
         event.preventDefault();
@@ -1105,10 +1158,8 @@ export class GhosttyRenderer implements TerminalRenderer {
         if (typeof event.stopImmediatePropagation === "function") {
           event.stopImmediatePropagation();
         }
-        textarea.value = "";
-        processedTextareaValue = "";
-        terminal.input(customOutput, true);
-        cleanupEditableArtifacts(this.#container);
+        clearTextareaState();
+        sendTerminalText(customOutput);
         return;
       }
       const output = keyboardEventOutput(event);
@@ -1117,6 +1168,9 @@ export class GhosttyRenderer implements TerminalRenderer {
       }
     };
     const onBeforeInput = (event: InputEvent) => {
+      if (shouldDeferBeforeInputToIme(imeState, event)) {
+        return;
+      }
       const output = beforeInputOutput(event);
       if (!output) {
         return;
@@ -1130,16 +1184,13 @@ export class GhosttyRenderer implements TerminalRenderer {
 
       const now = performance.now();
       if (lastKeydown && lastKeydown.data === output && now - lastKeydown.time < 100) {
-        textarea.value = "";
-        processedTextareaValue = "";
-        cleanupEditableArtifacts(this.#container);
+        clearTextareaState();
+        cleanupEditableArtifacts(host);
         return;
       }
 
-      textarea.value = "";
-      processedTextareaValue = "";
-      terminal.input(output, true);
-      cleanupEditableArtifacts(this.#container);
+      clearTextareaState();
+      sendTerminalText(output);
     };
     const sendTextareaDelta = () => {
       const value = textarea.value;
@@ -1150,22 +1201,54 @@ export class GhosttyRenderer implements TerminalRenderer {
       const output = textareaDelta(processedTextareaValue, value);
       processedTextareaValue = value;
       if (output) {
-        terminal.input(output, true);
+        sendTerminalText(output);
+      } else {
+        cleanupEditableArtifacts(host);
       }
-      cleanupEditableArtifacts(this.#container);
     };
-    const onInput = () => {
+    const onInput = (event: Event) => {
+      const inputEvent = event as InputEvent;
+      const transition = reduceTerminalImeState(imeState, {
+        type: "input",
+        data: inputEvent.data,
+        inputType: inputEvent.inputType,
+        isComposing: inputEvent.isComposing,
+        textareaValue: textarea.value,
+      });
+      imeState = transition.state;
+      if (transition.suppressInput) {
+        if (transition.clearTextarea) {
+          clearTextareaState();
+        }
+        refreshCompositionUi();
+        cleanupEditableArtifacts(host);
+        return;
+      }
       sendTextareaDelta();
     };
     const onCompositionStart = (event: CompositionEvent) => {
+      imeState = reduceTerminalImeState(imeState, {
+        type: "compositionstart",
+        data: event.data,
+        textareaValue: textarea.value,
+      }).state;
       processedTextareaValue = textarea.value;
+      lastKeydown = null;
+      textarea.classList.add("ghostty-ime-composing");
+      refreshCompositionUi();
       event.stopPropagation();
       if (typeof event.stopImmediatePropagation === "function") {
         event.stopImmediatePropagation();
       }
-      cleanupEditableArtifacts(this.#container);
+      cleanupEditableArtifacts(host);
     };
     const onCompositionUpdate = (event: CompositionEvent) => {
+      imeState = reduceTerminalImeState(imeState, {
+        type: "compositionupdate",
+        data: event.data,
+        textareaValue: textarea.value,
+      }).state;
+      refreshCompositionUi();
       event.stopPropagation();
       if (typeof event.stopImmediatePropagation === "function") {
         event.stopImmediatePropagation();
@@ -1176,14 +1259,49 @@ export class GhosttyRenderer implements TerminalRenderer {
       if (typeof event.stopImmediatePropagation === "function") {
         event.stopImmediatePropagation();
       }
-      sendTextareaDelta();
-      textarea.value = "";
-      processedTextareaValue = "";
-      cleanupEditableArtifacts(this.#container);
+      const transition = reduceTerminalImeState(imeState, {
+        type: "compositionend",
+        data: event.data,
+        textareaValue: textarea.value,
+      });
+      imeState = transition.state;
+      textarea.classList.remove("ghostty-ime-composing");
+      hidePreedit();
+      if (transition.clearTextarea) {
+        clearTextareaState();
+      }
+      if (transition.output) {
+        sendTerminalText(transition.output);
+      } else {
+        cleanupEditableArtifacts(host);
+      }
+      if (document.activeElement === textarea) {
+        positionGhosttyTextareaForInput(textarea, terminal);
+      } else {
+        hideGhosttyTextarea(textarea);
+      }
+
+      // A browser's trailing input event, when present, is dispatched in the
+      // same event task. Do not let its one-shot dedupe affect a later key.
+      const endedState = imeState;
+      queueMicrotask(() => {
+        if (imeState === endedState) {
+          imeState = reduceTerminalImeState(imeState, { type: "settle" }).state;
+        }
+      });
+    };
+    const onFocus = () => {
+      textarea.classList.add("ghostty-keyboard-input");
+      positionGhosttyTextareaForInput(textarea, terminal);
     };
     const onBlur = () => {
       textarea.classList.remove("ghostty-keyboard-input");
+      textarea.classList.remove("ghostty-ime-composing");
+      imeState = reduceTerminalImeState(imeState, { type: "reset" }).state;
+      clearTextareaState();
       this.#textInputTapGraceUntil = 0;
+      hidePreedit();
+      hideGhosttyTextarea(textarea);
     };
 
     textarea.addEventListener("keydown", onKeydown, { capture: true });
@@ -1192,6 +1310,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     textarea.addEventListener("compositionstart", onCompositionStart, { capture: true });
     textarea.addEventListener("compositionupdate", onCompositionUpdate, { capture: true });
     textarea.addEventListener("compositionend", onCompositionEnd, { capture: true });
+    textarea.addEventListener("focus", onFocus);
     textarea.addEventListener("blur", onBlur);
     this.#mobileInputCleanup = () => {
       textarea.removeEventListener("keydown", onKeydown, { capture: true });
@@ -1200,7 +1319,9 @@ export class GhosttyRenderer implements TerminalRenderer {
       textarea.removeEventListener("compositionstart", onCompositionStart, { capture: true });
       textarea.removeEventListener("compositionupdate", onCompositionUpdate, { capture: true });
       textarea.removeEventListener("compositionend", onCompositionEnd, { capture: true });
+      textarea.removeEventListener("focus", onFocus);
       textarea.removeEventListener("blur", onBlur);
+      preeditOverlay.remove();
     };
   }
 }
@@ -1216,6 +1337,103 @@ function hideGhosttyTextarea(textarea: HTMLTextAreaElement) {
   textarea.style.background = "transparent";
   textarea.style.caretColor = "transparent";
   textarea.style.overflow = "hidden";
+  textarea.style.fontFamily = "";
+  textarea.style.fontSize = "";
+  textarea.style.lineHeight = "";
+  textarea.style.zIndex = "";
+  textarea.style.setProperty("--ghostty-ime-left", "-10000px");
+  textarea.style.setProperty("--ghostty-ime-top", "0px");
+  textarea.style.setProperty("--ghostty-ime-width", "1px");
+  textarea.style.setProperty("--ghostty-ime-height", "1px");
+}
+
+function positionGhosttyTextareaForInput(
+  textarea: HTMLTextAreaElement,
+  terminal: Terminal | null | undefined,
+) {
+  if (!terminal) {
+    hideGhosttyTextarea(textarea);
+    return;
+  }
+  const canvas = terminal.renderer?.getCanvas();
+  const host = canvas ?? terminal.element;
+  const rect = host?.getBoundingClientRect();
+  const metrics = terminal.renderer?.getMetrics();
+  if (!rect || rect.width <= 0 || rect.height <= 0) {
+    hideGhosttyTextarea(textarea);
+    return;
+  }
+
+  const cursor = terminal.buffer?.active;
+  const anchor = imeTextareaAnchor({
+    terminalLeft: rect.left,
+    terminalTop: rect.top,
+    terminalWidth: rect.width,
+    terminalHeight: rect.height,
+    browserWidth: window.innerWidth,
+    browserHeight: window.innerHeight,
+    cellWidth: metrics?.width ?? 9,
+    cellHeight: metrics?.height ?? 16,
+    cursorCol: cursor?.cursorX ?? 0,
+    cursorRow: cursor?.cursorY ?? 0,
+    fontSizePx: terminal.options.fontSize ?? DEFAULT_TERMINAL_FONT_SIZE_PX,
+  });
+
+  textarea.style.position = "fixed";
+  textarea.style.left = `${anchor.left}px`;
+  textarea.style.top = `${anchor.top}px`;
+  textarea.style.width = `${anchor.width}px`;
+  textarea.style.height = `${anchor.height}px`;
+  textarea.style.opacity = "0";
+  textarea.style.color = "transparent";
+  textarea.style.background = "transparent";
+  textarea.style.caretColor = "transparent";
+  textarea.style.overflow = "hidden";
+  textarea.style.fontFamily = TERMINAL_FONT_FAMILY;
+  textarea.style.fontSize = `${anchor.fontSizePx}px`;
+  textarea.style.lineHeight = `${anchor.height}px`;
+  textarea.style.zIndex = "5";
+  textarea.style.setProperty("--ghostty-ime-left", `${anchor.left}px`);
+  textarea.style.setProperty("--ghostty-ime-top", `${anchor.top}px`);
+  textarea.style.setProperty("--ghostty-ime-width", `${anchor.width}px`);
+  textarea.style.setProperty("--ghostty-ime-height", `${anchor.height}px`);
+}
+
+function updateImePreeditOverlay(
+  overlay: HTMLDivElement,
+  preedit: string,
+  textarea: HTMLTextAreaElement,
+  terminal: Terminal,
+) {
+  if (!preedit) {
+    overlay.hidden = true;
+    overlay.textContent = "";
+    return;
+  }
+
+  const canvas = terminal.renderer?.getCanvas();
+  const terminalRect = (canvas ?? terminal.element)?.getBoundingClientRect();
+  const fontSize = terminal.options.fontSize ?? DEFAULT_TERMINAL_FONT_SIZE_PX;
+  const lineHeight = textarea.style.height || `${Math.ceil(fontSize * 1.2)}px`;
+  const anchorLeft = Number.parseFloat(textarea.style.left) || 1;
+  const anchorTop = Number.parseFloat(textarea.style.top) || 1;
+  const visibleLeft = Math.max(4, terminalRect?.left ?? 4);
+  const visibleRight = Math.min(window.innerWidth - 4, terminalRect?.right ?? window.innerWidth - 4);
+  const maxWidth = Math.max(1, Math.min(576, visibleRight - visibleLeft));
+
+  overlay.hidden = false;
+  overlay.textContent = preedit;
+  overlay.style.left = `${anchorLeft}px`;
+  overlay.style.top = `${anchorTop}px`;
+  overlay.style.maxWidth = `${maxWidth}px`;
+  overlay.style.fontFamily = TERMINAL_FONT_FAMILY;
+  overlay.style.fontSize = `${fontSize}px`;
+  overlay.style.lineHeight = lineHeight;
+  overlay.style.minHeight = lineHeight;
+
+  const overlayRect = overlay.getBoundingClientRect();
+  const maxLeft = Math.max(visibleLeft, visibleRight - overlayRect.width);
+  overlay.style.left = `${clampNumber(anchorLeft, visibleLeft, maxLeft)}px`;
 }
 
 function isGhosttyDisposedError(error: unknown) {
@@ -1230,63 +1448,6 @@ function cleanupEditableArtifacts(container: HTMLElement | null) {
     if (node.nodeType === Node.TEXT_NODE) {
       node.remove();
     }
-  }
-}
-
-function beforeInputOutput(event: InputEvent) {
-  switch (event.inputType) {
-    case "insertText":
-    case "insertReplacementText":
-      return event.data ? event.data.replace(/\n/g, "\r") : null;
-    case "insertLineBreak":
-    case "insertParagraph":
-      return "\r";
-    case "deleteContentBackward":
-      return "\x7F";
-    case "deleteContentForward":
-      return "\x1B[3~";
-    default:
-      return null;
-  }
-}
-
-function textareaDelta(previousValue: string, nextValue: string) {
-  if (nextValue.startsWith(previousValue)) {
-    return nextValue.slice(previousValue.length).replace(/\n/g, "\r");
-  }
-
-  const previousChars = Array.from(previousValue);
-  const nextChars = Array.from(nextValue);
-  let commonPrefixLength = 0;
-  while (
-    commonPrefixLength < previousChars.length &&
-    commonPrefixLength < nextChars.length &&
-    previousChars[commonPrefixLength] === nextChars[commonPrefixLength]
-  ) {
-    commonPrefixLength += 1;
-  }
-
-  const deletes = "\x7F".repeat(previousChars.length - commonPrefixLength);
-  const inserts = nextChars.slice(commonPrefixLength).join("").replace(/\n/g, "\r");
-  return `${deletes}${inserts}`;
-}
-
-function keyboardEventOutput(event: KeyboardEvent) {
-  if (event.ctrlKey || event.altKey || event.metaKey) {
-    return null;
-  }
-  if (event.key.length === 1) {
-    return event.key;
-  }
-  switch (event.key) {
-    case "Enter":
-      return "\r";
-    case "Backspace":
-      return "\x7F";
-    case "Delete":
-      return "\x1B[3~";
-    default:
-      return null;
   }
 }
 


### PR DESCRIPTION
## Summary

- keep IME preedit local and send committed terminal text exactly once
- discard canceled composition and anchor candidate/preedit UI at the terminal cursor
- cover Chrome/Firefox event ordering and cancellation in reducer tests

Based on the IME work proposed by @LosEcher in #51. Its dev-server and cache work was handled separately in #57.

## Testing

- `npm run check`
- `claude-default` iterative review: clean