### PR TITLE
Repair wrapped URL copying on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,7 @@
 
 ### Fixed
 
-- Mobile terminal copies now remove canvas row gaps that split HTTP(S) links, including indented
-  alphanumeric continuations when terminal edge metadata is unavailable, while preserving ordinary
-  line breaks.
+- Join canvas-wrapped HTTP(S) URLs when copying from a mobile terminal.
   [PR #61](https://github.com/kcosr/herdr-web/pull/61)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Fixed
 
+- Mobile terminal copies now remove canvas row gaps that split HTTP(S) links, including indented
+  alphanumeric continuations when terminal edge metadata is unavailable, while preserving ordinary
+  line breaks.
+  [PR #61](https://github.com/kcosr/herdr-web/pull/61)
+
 ### Removed
 
 ## [0.4.2] - 2026-08-15

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -285,10 +285,7 @@ export function TerminalView({
         }
         return;
       }
-      const copiedText = normalizeMobileTerminalCopyText(
-        event.text,
-        event.lineBreaksAtTerminalRightEdge,
-      ).trim();
+      const copiedText = normalizeMobileTerminalCopyText(event.text).trim();
       setMobileSelectionAction(null);
       if (!copiedText) {
         rendererRef.current?.clearSelection();

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -24,7 +24,11 @@ import {
   terminalConnectionOverlayDelayMs,
 } from "./terminalConnectionStatus";
 import type { TerminalConnectionState } from "./terminalConnectionStatus";
-import { findFirstUrlInSelection, openableHttpUrl } from "./terminalSelection";
+import {
+  findFirstUrlInSelection,
+  normalizeMobileTerminalCopyText,
+  openableHttpUrl,
+} from "./terminalSelection";
 import { GhosttyRenderer } from "./terminalRenderer";
 import type { MobileTerminalTouchEvent, TerminalRenderer, TerminalSize } from "./terminalRenderer";
 import {
@@ -281,19 +285,22 @@ export function TerminalView({
         }
         return;
       }
-      const trimmed = event.text.trim();
+      const copiedText = normalizeMobileTerminalCopyText(
+        event.text,
+        event.lineBreaksAtTerminalRightEdge,
+      ).trim();
       setMobileSelectionAction(null);
-      if (!trimmed) {
+      if (!copiedText) {
         rendererRef.current?.clearSelection();
         return;
       }
-      const url = findFirstUrlInSelection(trimmed);
+      const url = findFirstUrlInSelection(copiedText);
       if (url) {
-        setMobileSelectionAction({ text: trimmed, url });
+        setMobileSelectionAction({ text: copiedText, url });
         return;
       }
       rendererRef.current?.clearSelection();
-      void copyText(trimmed, "Copied selection");
+      void copyText(copiedText, "Copied selection");
     },
     [copyText],
   );

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -114,7 +114,7 @@ type TerminalBufferLine = {
 };
 
 export type MobileTerminalTouchEvent =
-  | { type: "selection"; text: string; lineBreaksAtTerminalRightEdge: readonly boolean[] }
+  | { type: "selection"; text: string }
   | { type: "url"; url: string };
 
 export type TerminalRenderer = {
@@ -799,11 +799,11 @@ export class GhosttyRenderer implements TerminalRenderer {
       const selection = completeTouchSelection(selectionState);
       const selectedText = selection
         ? terminalSelectedTextFromViewportRange(terminal, selection.start, selection.end)
-        : null;
-      if (selectedText?.text && this.#mobileTouchSelectionHandler) {
+        : "";
+      if (selectedText.length > 0 && this.#mobileTouchSelectionHandler) {
         resetTouchSelection(false);
         terminal.textarea?.blur();
-        this.#mobileTouchSelectionHandler({ type: "selection", ...selectedText });
+        this.#mobileTouchSelectionHandler({ type: "selection", text: selectedText });
       } else {
         resetTouchSelection(true);
         terminal.textarea?.blur();
@@ -815,12 +815,12 @@ export class GhosttyRenderer implements TerminalRenderer {
       const selectedText =
         simpleSelectionStart && simpleSelectionEnd
           ? terminalSelectedTextFromViewportRange(terminal, simpleSelectionStart, simpleSelectionEnd)
-          : null;
+          : "";
       stopSimpleTouchSelection();
       terminal.textarea?.blur();
-      if (selectedText?.text.trim() && this.#mobileTouchSelectionHandler) {
-        this.#mobileTouchSelectionHandler({ type: "selection", ...selectedText });
-        if (!findFirstUrlInSelection(selectedText.text.trim())) {
+      if (selectedText.trim() && this.#mobileTouchSelectionHandler) {
+        this.#mobileTouchSelectionHandler({ type: "selection", text: selectedText });
+        if (!findFirstUrlInSelection(selectedText.trim())) {
           clearSelectionClearTimer();
           selectionClearTimer = window.setTimeout(() => {
             selectionClearTimer = null;
@@ -1594,7 +1594,6 @@ function terminalSelectedTextFromViewportRange(
   const range = terminalSelectionRange(start, end, terminal.cols);
 
   const selectedLines: string[] = [];
-  const lineBreaksAtTerminalRightEdge: boolean[] = [];
   for (let row = range.from.row; row <= range.to.row; row += 1) {
     const bufferRow = terminalBufferRow(terminal, row);
     const line = terminal.buffer.active.getLine(bufferRow) as TerminalBufferLine | undefined;
@@ -1610,21 +1609,8 @@ function terminalSelectedTextFromViewportRange(
           ).trimEnd()
         : "",
     );
-    if (row < range.to.row) {
-      lineBreaksAtTerminalRightEdge.push(terminalBufferLineHasNonBlankLastCell(line, terminal.cols));
-    }
   }
-  return { text: selectedLines.join("\n"), lineBreaksAtTerminalRightEdge };
-}
-
-// Herdr's cursor-positioned TerminalAnsi frames do not preserve Ghostty's soft-wrap flag.
-// A nonblank last column is the strongest row-boundary evidence available to the web client.
-function terminalBufferLineHasNonBlankLastCell(
-  line: TerminalBufferLine | undefined,
-  terminalColumns: number,
-) {
-  const codepoint = line?.getCell(terminalColumns - 1)?.getCodepoint() ?? 0;
-  return codepoint > 32;
+  return selectedLines.join("\n");
 }
 
 // Cells holding multi-codepoint grapheme clusters (combining marks, emoji with

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -114,7 +114,7 @@ type TerminalBufferLine = {
 };
 
 export type MobileTerminalTouchEvent =
-  | { type: "selection"; text: string }
+  | { type: "selection"; text: string; lineBreaksAtTerminalRightEdge: readonly boolean[] }
   | { type: "url"; url: string };
 
 export type TerminalRenderer = {
@@ -799,11 +799,11 @@ export class GhosttyRenderer implements TerminalRenderer {
       const selection = completeTouchSelection(selectionState);
       const selectedText = selection
         ? terminalSelectedTextFromViewportRange(terminal, selection.start, selection.end)
-        : "";
-      if (selectedText.length > 0 && this.#mobileTouchSelectionHandler) {
+        : null;
+      if (selectedText?.text && this.#mobileTouchSelectionHandler) {
         resetTouchSelection(false);
         terminal.textarea?.blur();
-        this.#mobileTouchSelectionHandler({ type: "selection", text: selectedText });
+        this.#mobileTouchSelectionHandler({ type: "selection", ...selectedText });
       } else {
         resetTouchSelection(true);
         terminal.textarea?.blur();
@@ -815,12 +815,12 @@ export class GhosttyRenderer implements TerminalRenderer {
       const selectedText =
         simpleSelectionStart && simpleSelectionEnd
           ? terminalSelectedTextFromViewportRange(terminal, simpleSelectionStart, simpleSelectionEnd)
-          : "";
+          : null;
       stopSimpleTouchSelection();
       terminal.textarea?.blur();
-      if (selectedText.trim() && this.#mobileTouchSelectionHandler) {
-        this.#mobileTouchSelectionHandler({ type: "selection", text: selectedText });
-        if (!findFirstUrlInSelection(selectedText.trim())) {
+      if (selectedText?.text.trim() && this.#mobileTouchSelectionHandler) {
+        this.#mobileTouchSelectionHandler({ type: "selection", ...selectedText });
+        if (!findFirstUrlInSelection(selectedText.text.trim())) {
           clearSelectionClearTimer();
           selectionClearTimer = window.setTimeout(() => {
             selectionClearTimer = null;
@@ -1594,6 +1594,7 @@ function terminalSelectedTextFromViewportRange(
   const range = terminalSelectionRange(start, end, terminal.cols);
 
   const selectedLines: string[] = [];
+  const lineBreaksAtTerminalRightEdge: boolean[] = [];
   for (let row = range.from.row; row <= range.to.row; row += 1) {
     const bufferRow = terminalBufferRow(terminal, row);
     const line = terminal.buffer.active.getLine(bufferRow) as TerminalBufferLine | undefined;
@@ -1609,8 +1610,21 @@ function terminalSelectedTextFromViewportRange(
           ).trimEnd()
         : "",
     );
+    if (row < range.to.row) {
+      lineBreaksAtTerminalRightEdge.push(terminalBufferLineHasNonBlankLastCell(line, terminal.cols));
+    }
   }
-  return selectedLines.join("\n");
+  return { text: selectedLines.join("\n"), lineBreaksAtTerminalRightEdge };
+}
+
+// Herdr's cursor-positioned TerminalAnsi frames do not preserve Ghostty's soft-wrap flag.
+// A nonblank last column is the strongest row-boundary evidence available to the web client.
+function terminalBufferLineHasNonBlankLastCell(
+  line: TerminalBufferLine | undefined,
+  terminalColumns: number,
+) {
+  const codepoint = line?.getCell(terminalColumns - 1)?.getCodepoint() ?? 0;
+  return codepoint > 32;
 }
 
 // Cells holding multi-codepoint grapheme clusters (combining marks, emoji with

--- a/web/src/terminalSelection.test.ts
+++ b/web/src/terminalSelection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   findFirstUrlInSelection,
+  normalizeMobileTerminalCopyText,
   normalizeSelectionForUrl,
   openableHttpUrl,
   selectedTextFromVisibleRows,
@@ -30,6 +31,65 @@ describe("terminal selection helpers", () => {
   it("does not trim balanced URL closing delimiters", () => {
     expect(findFirstUrlInSelection("https://example.com/a_(b)")).toBe(
       "https://example.com/a_(b)",
+    );
+  });
+
+  it("removes a visual row boundary from a copied mobile URL", () => {
+    expect(
+      normalizeMobileTerminalCopyText(
+        "http://100.112.72.93:8765/herdr-hollow-centered\n-handle-d872ae6.apk",
+      ),
+    ).toBe("http://100.112.72.93:8765/herdr-hollow-centered-handle-d872ae6.apk");
+  });
+
+  it("rejoins an alphanumeric URL continuation at the terminal right edge", () => {
+    expect(
+      normalizeMobileTerminalCopyText(
+        "http://100.112.72.93:4100/herdr-web-rebased-v2-ab\n 689b6-android-debug.apk",
+        [true],
+      ),
+    ).toBe("http://100.112.72.93:4100/herdr-web-rebased-v2-ab689b6-android-debug.apk");
+  });
+
+  it("rejoins an indented URL continuation when canvas row evidence is unavailable", () => {
+    expect(
+      normalizeMobileTerminalCopyText(
+        "http://100.112.72.93:4100/herdr-web-copy-fix-v3-9\n 1c39e1.apk",
+        [false],
+      ),
+    ).toBe("http://100.112.72.93:4100/herdr-web-copy-fix-v3-91c39e1.apk");
+  });
+
+  it("preserves an unindented alphanumeric hard line break without right-edge evidence", () => {
+    expect(
+      normalizeMobileTerminalCopyText(
+        "http://100.112.72.93:4100/herdr-web-rebased-v2-ab\n689b6-android-debug.apk",
+        [false],
+      ),
+    ).toBe("http://100.112.72.93:4100/herdr-web-rebased-v2-ab\n689b6-android-debug.apk");
+  });
+
+  it("preserves an indented prose word after a URL", () => {
+    expect(
+      normalizeMobileTerminalCopyText("https://example.com/release\n Next", [false]),
+    ).toBe("https://example.com/release\n Next");
+  });
+
+  it("preserves copied prose line boundaries and spaces", () => {
+    expect(normalizeMobileTerminalCopyText("first line\nsecond line with spaces", [true])).toBe(
+      "first line\nsecond line with spaces",
+    );
+  });
+
+  it("preserves a hard line boundary after a complete URL", () => {
+    expect(normalizeMobileTerminalCopyText("https://example.com/release\nNext step")).toBe(
+      "https://example.com/release\nNext step",
+    );
+  });
+
+  it("preserves a hard line boundary before list prose", () => {
+    expect(normalizeMobileTerminalCopyText("https://example.com/release/\n- Next step", [true])).toBe(
+      "https://example.com/release/\n- Next step",
     );
   });
 

--- a/web/src/terminalSelection.test.ts
+++ b/web/src/terminalSelection.test.ts
@@ -34,61 +34,50 @@ describe("terminal selection helpers", () => {
     );
   });
 
-  it("removes a visual row boundary from a copied mobile URL", () => {
+  it("rejoins a copied URL split before a hyphen", () => {
     expect(
-      normalizeMobileTerminalCopyText(
-        "http://100.112.72.93:8765/herdr-hollow-centered\n-handle-d872ae6.apk",
-      ),
-    ).toBe("http://100.112.72.93:8765/herdr-hollow-centered-handle-d872ae6.apk");
+      normalizeMobileTerminalCopyText("https://example.com/herdr-hollow-centered\n-handle.apk"),
+    ).toBe("https://example.com/herdr-hollow-centered-handle.apk");
   });
 
-  it("rejoins an alphanumeric URL continuation at the terminal right edge", () => {
-    expect(
-      normalizeMobileTerminalCopyText(
-        "http://100.112.72.93:4100/herdr-web-rebased-v2-ab\n 689b6-android-debug.apk",
-        [true],
-      ),
-    ).toBe("http://100.112.72.93:4100/herdr-web-rebased-v2-ab689b6-android-debug.apk");
+  it("rejoins an indented URL continuation", () => {
+    expect(normalizeMobileTerminalCopyText("https://example.com/copy-fix-v3-9\n 1c39e1.apk")).toBe(
+      "https://example.com/copy-fix-v3-91c39e1.apk",
+    );
   });
 
-  it("rejoins an indented URL continuation when canvas row evidence is unavailable", () => {
-    expect(
-      normalizeMobileTerminalCopyText(
-        "http://100.112.72.93:4100/herdr-web-copy-fix-v3-9\n 1c39e1.apk",
-        [false],
-      ),
-    ).toBe("http://100.112.72.93:4100/herdr-web-copy-fix-v3-91c39e1.apk");
+  it("rejoins a URL that ends on a path delimiter", () => {
+    expect(normalizeMobileTerminalCopyText("https://example.com/release/\nNext")).toBe(
+      "https://example.com/release/Next",
+    );
   });
 
-  it("preserves an unindented alphanumeric hard line break without right-edge evidence", () => {
+  it("preserves an unindented alphanumeric line break", () => {
     expect(
-      normalizeMobileTerminalCopyText(
-        "http://100.112.72.93:4100/herdr-web-rebased-v2-ab\n689b6-android-debug.apk",
-        [false],
-      ),
-    ).toBe("http://100.112.72.93:4100/herdr-web-rebased-v2-ab\n689b6-android-debug.apk");
+      normalizeMobileTerminalCopyText("https://example.com/rebased-v2-ab\n689b6-android-debug.apk"),
+    ).toBe("https://example.com/rebased-v2-ab\n689b6-android-debug.apk");
   });
 
   it("preserves an indented prose word after a URL", () => {
-    expect(
-      normalizeMobileTerminalCopyText("https://example.com/release\n Next", [false]),
-    ).toBe("https://example.com/release\n Next");
+    expect(normalizeMobileTerminalCopyText("https://example.com/release\n Next")).toBe(
+      "https://example.com/release\n Next",
+    );
   });
 
   it("preserves copied prose line boundaries and spaces", () => {
-    expect(normalizeMobileTerminalCopyText("first line\nsecond line with spaces", [true])).toBe(
+    expect(normalizeMobileTerminalCopyText("first line\nsecond line with spaces")).toBe(
       "first line\nsecond line with spaces",
     );
   });
 
-  it("preserves a hard line boundary after a complete URL", () => {
+  it("preserves a hard line break after a complete URL", () => {
     expect(normalizeMobileTerminalCopyText("https://example.com/release\nNext step")).toBe(
       "https://example.com/release\nNext step",
     );
   });
 
-  it("preserves a hard line boundary before list prose", () => {
-    expect(normalizeMobileTerminalCopyText("https://example.com/release/\n- Next step", [true])).toBe(
+  it("preserves a hard line break before list prose", () => {
+    expect(normalizeMobileTerminalCopyText("https://example.com/release/\n- Next step")).toBe(
       "https://example.com/release/\n- Next step",
     );
   });

--- a/web/src/terminalSelection.ts
+++ b/web/src/terminalSelection.ts
@@ -129,3 +129,43 @@ function countChars(value: string, char: string) {
   }
   return count;
 }
+
+const TRAILING_URL_PATTERN = /\bhttps?:\/\/[^\s"'<>`]+$/iu;
+const INDENTED_URL_CONTINUATION_EVIDENCE = /[0-9/?#&=._~%+-]/u;
+
+function shouldJoinCanvasWrappedUrl(nextLine: string, url: string, continuation: string) {
+  return (
+    (/^[ \t]+/u.test(nextLine) && INDENTED_URL_CONTINUATION_EVIDENCE.test(continuation)) ||
+    shouldJoinWrappedUrl(url, continuation)
+  );
+}
+
+/** Rejoins copied mobile URL rows; right-edge flags align one-for-one with selection newlines. */
+export function normalizeMobileTerminalCopyText(
+  selection: string,
+  lineBreaksAtTerminalRightEdge: readonly boolean[] = [],
+) {
+  const lines = selection.replace(/\r\n?/gu, "\n").split("\n");
+  const logicalLines: string[] = [];
+  let currentLine = lines[0] ?? "";
+
+  for (const [lineBreakIndex, nextLine] of lines.slice(1).entries()) {
+    const url = currentLine.match(TRAILING_URL_PATTERN)?.[0] ?? "";
+    const trimmedNextLine = nextLine.trimStart();
+    const continuation = trimmedNextLine.match(URL_CONTINUATION_PATTERN)?.[0] ?? "";
+    const hasVisualWrapEvidence = lineBreaksAtTerminalRightEdge[lineBreakIndex] === true;
+    if (
+      url &&
+      continuation.length === trimmedNextLine.length &&
+      (hasVisualWrapEvidence || shouldJoinCanvasWrappedUrl(nextLine, url, continuation))
+    ) {
+      currentLine += trimmedNextLine;
+    } else {
+      logicalLines.push(currentLine);
+      currentLine = nextLine;
+    }
+  }
+
+  logicalLines.push(currentLine);
+  return logicalLines.join("\n");
+}

--- a/web/src/terminalSelection.ts
+++ b/web/src/terminalSelection.ts
@@ -1,5 +1,6 @@
 const URL_PATTERN = /\bhttps?:\/\/[^\s"'<>`]+/iu;
 const URL_CONTINUATION_PATTERN = /^[^\s"'<>`]+/u;
+const TRAILING_URL_PATTERN = /\bhttps?:\/\/[^\s"'<>`]+$/iu;
 const TRAILING_URL_PUNCTUATION = /[.,;:!?]+$/u;
 const TRAILING_BALANCED_CLOSERS = /[)\]}]+$/u;
 
@@ -73,6 +74,32 @@ export function terminalUrlTapTarget(value: string | null, mouseTracking: boolea
   return openableHttpUrl(value);
 }
 
+export function normalizeMobileTerminalCopyText(selection: string) {
+  const lines = selection.replace(/\r\n?/gu, "\n").split("\n");
+  const logicalLines: string[] = [];
+  let currentLine = lines[0] ?? "";
+
+  for (const nextLine of lines.slice(1)) {
+    const url = currentLine.match(TRAILING_URL_PATTERN)?.[0] ?? "";
+    const trimmedNextLine = nextLine.trimStart();
+    const continuation = trimmedNextLine.match(URL_CONTINUATION_PATTERN)?.[0] ?? "";
+    if (
+      url &&
+      continuation === trimmedNextLine &&
+      (shouldJoinWrappedUrl(url, continuation) ||
+        shouldJoinIndentedUrlContinuation(nextLine, continuation))
+    ) {
+      currentLine += trimmedNextLine;
+    } else {
+      logicalLines.push(currentLine);
+      currentLine = nextLine;
+    }
+  }
+
+  logicalLines.push(currentLine);
+  return logicalLines.join("\n");
+}
+
 export function normalizeSelectionForUrl(selection: string) {
   return selection.replace(/\s*\n\s*/gu, "").replace(/[ \t\r\f\v]+/gu, " ").trim();
 }
@@ -98,6 +125,10 @@ function wrappedUrl(lines: string[], startIndex: number, match: RegExpMatchArray
 
 function shouldJoinWrappedUrl(url: string, continuation: string) {
   return /[/?#&=._~%+-]$/u.test(url) || /^[/?#&=._~%+-]/u.test(continuation);
+}
+
+function shouldJoinIndentedUrlContinuation(nextLine: string, continuation: string) {
+  return /^[ \t]+/u.test(nextLine) && /[0-9/?#&=._~%+-]/u.test(continuation);
 }
 
 export function trimUrlPunctuation(value: string) {
@@ -128,44 +159,4 @@ function countChars(value: string, char: string) {
     }
   }
   return count;
-}
-
-const TRAILING_URL_PATTERN = /\bhttps?:\/\/[^\s"'<>`]+$/iu;
-const INDENTED_URL_CONTINUATION_EVIDENCE = /[0-9/?#&=._~%+-]/u;
-
-function shouldJoinCanvasWrappedUrl(nextLine: string, url: string, continuation: string) {
-  return (
-    (/^[ \t]+/u.test(nextLine) && INDENTED_URL_CONTINUATION_EVIDENCE.test(continuation)) ||
-    shouldJoinWrappedUrl(url, continuation)
-  );
-}
-
-/** Rejoins copied mobile URL rows; right-edge flags align one-for-one with selection newlines. */
-export function normalizeMobileTerminalCopyText(
-  selection: string,
-  lineBreaksAtTerminalRightEdge: readonly boolean[] = [],
-) {
-  const lines = selection.replace(/\r\n?/gu, "\n").split("\n");
-  const logicalLines: string[] = [];
-  let currentLine = lines[0] ?? "";
-
-  for (const [lineBreakIndex, nextLine] of lines.slice(1).entries()) {
-    const url = currentLine.match(TRAILING_URL_PATTERN)?.[0] ?? "";
-    const trimmedNextLine = nextLine.trimStart();
-    const continuation = trimmedNextLine.match(URL_CONTINUATION_PATTERN)?.[0] ?? "";
-    const hasVisualWrapEvidence = lineBreaksAtTerminalRightEdge[lineBreakIndex] === true;
-    if (
-      url &&
-      continuation.length === trimmedNextLine.length &&
-      (hasVisualWrapEvidence || shouldJoinCanvasWrappedUrl(nextLine, url, continuation))
-    ) {
-      currentLine += trimmedNextLine;
-    } else {
-      logicalLines.push(currentLine);
-      currentLine = nextLine;
-    }
-  }
-
-  logicalLines.push(currentLine);
-  return logicalLines.join("\n");
 }


### PR DESCRIPTION
On Android, a URL that wraps across two terminal rows can be copied with a newline and leading space in the middle:

```text
http://100.112.72.93:4100/herdr-web-copy-fix-v3-9
 1c39e1.apk
```

That produces a broken link.

This PR joins wrapped URL rows before showing the mobile copy actions. Two kinds of evidence trigger a join: the URL ends on a path delimiter (such as `/` or `-`) and the next row continues with URL characters, or the next row is indented and starts with a URL character such as a digit.

The joining leaves normal prose, lists, spaces, and hard line breaks alone. It only changes the mobile selection path; the bridge protocol is unchanged.

I tested the original failure on a Pixel 9 Pro XL. The example above now copies as one URL.

Tested with `npm run check`:

- 272 web tests
- 114 compatibility tests
- 136 bridge tests
- web and bridge production builds