### PR TITLE
Improve dialog and menu focus behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 - Improved keyboard focus behavior for dialogs and action menus: modal focus stays contained,
   menus support arrow, Home, and End navigation, Tab exits menus normally, and dismissing an
-  overlay restores its opener. Based on work proposed by
-  [shuv (@shuv1337)](https://github.com/shuv1337) in
+  overlay restores its opener. [PR #62](https://github.com/kcosr/herdr-web/pull/62), based on work
+  proposed by [shuv (@shuv1337)](https://github.com/shuv1337) in
   [PR #37](https://github.com/kcosr/herdr-web/pull/37).
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+- Improved keyboard focus behavior for dialogs and action menus: modal focus stays contained,
+  menus support arrow, Home, and End navigation, Tab exits menus normally, and dismissing an
+  overlay restores its opener. Based on work proposed by
+  [shuv (@shuv1337)](https://github.com/shuv1337) in
+  [PR #37](https://github.com/kcosr/herdr-web/pull/37).
+
 ### Removed
 
 ## [0.4.2] - 2026-08-15

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -134,6 +134,7 @@ import {
 import type { NavigationSyncMode } from "./navigationPrefs";
 import { ActionMenu, ConfirmDialog, RenameDialog, useLongPress } from "./overlays";
 import type { MenuItem } from "./overlays";
+import { focusableElements, trapFocusWithin, useFocusReturn } from "./overlayFocus";
 import { createSnapshotRefreshController } from "./refreshCoordinator";
 import { TerminalView } from "./TerminalView";
 import {
@@ -7576,6 +7577,7 @@ function OptionsMenuShell({
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  useFocusReturn();
 
   useLayoutEffect(() => {
     const el = ref.current;
@@ -7593,8 +7595,14 @@ function OptionsMenuShell({
       top = window.innerHeight - margin - rect.height;
     }
     setPos({ left, top: Math.max(margin, top) });
-    el.focus();
   }, [x, y]);
+
+  useLayoutEffect(() => {
+    if (!pos || !ref.current) {
+      return;
+    }
+    (focusableElements(ref.current)[0] ?? ref.current).focus();
+  }, [pos]);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -7618,6 +7626,7 @@ function OptionsMenuShell({
       <button
         className="overlay-scrim overlay-scrim-clear"
         type="button"
+        tabIndex={-1}
         aria-label="Close list options"
         onClick={onClose}
       />
@@ -7627,6 +7636,7 @@ function OptionsMenuShell({
         role="dialog"
         aria-label={ariaLabel}
         tabIndex={-1}
+        onKeyDown={trapFocusWithin}
         style={{
           left: pos?.left ?? x,
           top: pos?.top ?? y,
@@ -7656,6 +7666,7 @@ export function QuickPaneNoteDialog({
   const dialogRef = useRef<HTMLFormElement | null>(null);
   const titleInputRef = useRef<HTMLInputElement | null>(null);
   const bodyInputRef = useRef<HTMLTextAreaElement | null>(null);
+  useFocusReturn();
 
   useEffect(() => {
     titleInputRef.current?.focus();
@@ -7691,39 +7702,12 @@ export function QuickPaneNoteDialog({
     }
     onSubmit(trimmedTitle, bodyExpanded ? body : "");
   };
-  const trapDialogFocus = (event: ReactKeyboardEvent<HTMLFormElement>) => {
-    if (event.key !== "Tab") {
-      return;
-    }
-    const dialog = dialogRef.current;
-    if (!dialog) {
-      return;
-    }
-    const focusable = Array.from(
-      dialog.querySelectorAll<HTMLElement>(
-        "button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex='-1'])",
-      ),
-    );
-    if (focusable.length === 0) {
-      return;
-    }
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    const active = document.activeElement;
-    if (event.shiftKey && active === first) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && active === last) {
-      event.preventDefault();
-      first.focus();
-    }
-  };
-
   return (
     <div className="overlay-root">
       <button
         className="overlay-scrim"
         type="button"
+        tabIndex={-1}
         aria-label="Cancel"
         disabled={busy}
         onClick={cancel}
@@ -7741,7 +7725,7 @@ export function QuickPaneNoteDialog({
             cancel();
             return;
           }
-          trapDialogFocus(event);
+          trapFocusWithin(event);
         }}
       >
         <div className="modal-title">Add note</div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -134,7 +134,12 @@ import {
 import type { NavigationSyncMode } from "./navigationPrefs";
 import { ActionMenu, ConfirmDialog, RenameDialog, useLongPress } from "./overlays";
 import type { MenuItem } from "./overlays";
-import { focusableElements, trapFocusWithin, useFocusReturn } from "./overlayFocus";
+import {
+  focusableElements,
+  focusOverlayTrigger,
+  trapFocusWithin,
+  useFocusReturn,
+} from "./overlayFocus";
 import { createSnapshotRefreshController } from "./refreshCoordinator";
 import { TerminalView } from "./TerminalView";
 import {
@@ -3922,7 +3927,14 @@ export function App() {
           >
             {isCompactLayout ? <ChevronLeft size={20} /> : <PanelLeft size={18} />}
           </button>
-          <div className="stage-id" {...selectedPaneMenuPress}>
+          <div
+            className="stage-id"
+            role="button"
+            tabIndex={0}
+            aria-haspopup="menu"
+            aria-label="Selected pane actions"
+            {...selectedPaneMenuPress}
+          >
             <span className="stage-title">{selectedPane ? paneTitle(selectedPane) : "herdr-web"}</span>
             <span className="stage-sub mono">
               {stageBreadcrumb(snapshot, selectedPane, loadState, selectedRuntime?.canConnect ?? false)}
@@ -3936,16 +3948,17 @@ export function App() {
                 aria-label="Split right"
                 title="Split right"
                 disabled={busy}
-                onClick={() =>
-                  selectedRuntime
-                    ? setLaunchTarget({
-                        mode: "split",
-                        pane: selectedPane,
-                        direction: "right",
-                        bridgeId: selectedRuntime.id,
-                      })
-                    : undefined
-                }
+                onClick={(event) => {
+                  focusOverlayTrigger(event.currentTarget);
+                  if (selectedRuntime) {
+                    setLaunchTarget({
+                      mode: "split",
+                      pane: selectedPane,
+                      direction: "right",
+                      bridgeId: selectedRuntime.id,
+                    });
+                  }
+                }}
               >
                 <SplitSquareHorizontal size={18} />
               </button>
@@ -3955,16 +3968,17 @@ export function App() {
                 aria-label="Split down"
                 title="Split down"
                 disabled={busy}
-                onClick={() =>
-                  selectedRuntime
-                    ? setLaunchTarget({
-                        mode: "split",
-                        pane: selectedPane,
-                        direction: "down",
-                        bridgeId: selectedRuntime.id,
-                      })
-                    : undefined
-                }
+                onClick={(event) => {
+                  focusOverlayTrigger(event.currentTarget);
+                  if (selectedRuntime) {
+                    setLaunchTarget({
+                      mode: "split",
+                      pane: selectedPane,
+                      direction: "down",
+                      bridgeId: selectedRuntime.id,
+                    });
+                  }
+                }}
               >
                 <SplitSquareVertical size={18} />
               </button>
@@ -5873,7 +5887,17 @@ function TabBar({
               onClick={() => onSelectTab(tab.tab_id)}
               onContextMenu={(event) => {
                 event.preventDefault();
+                focusOverlayTrigger(event.currentTarget);
                 onMenu("tab", tab.tab_id, label, event.clientX, event.clientY, canClearTabName(tab));
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== "ContextMenu" && !(event.shiftKey && event.key === "F10")) {
+                  return;
+                }
+                event.preventDefault();
+                focusOverlayTrigger(event.currentTarget);
+                const rect = event.currentTarget.getBoundingClientRect();
+                onMenu("tab", tab.tab_id, label, rect.left, rect.bottom, canClearTabName(tab));
               }}
             >
               <span className="dot" data-status={tab.agent_status} />
@@ -5887,7 +5911,10 @@ function TabBar({
         type="button"
         aria-label="New tab"
         title="New tab"
-        onClick={() => onCreateTab(activeSpace.workspace_id)}
+        onClick={(event) => {
+          focusOverlayTrigger(event.currentTarget);
+          onCreateTab(activeSpace.workspace_id);
+        }}
       >
         <Plus size={14} />
       </button>
@@ -7074,7 +7101,10 @@ function Switcher({
           aria-label="Settings"
           title={`Settings; bridge: ${bridgeLabel}`}
           data-spin={capabilityState === "probing" ? "" : undefined}
-          onClick={onBackendSettings}
+          onClick={(event) => {
+            focusOverlayTrigger(event.currentTarget);
+            onBackendSettings();
+          }}
         >
           <Settings size={16} />
         </button>
@@ -7084,7 +7114,10 @@ function Switcher({
           aria-label="Refresh"
           title="Refresh"
           data-spin={loadState === "loading" ? "" : undefined}
-          onClick={onRefresh}
+          onClick={(event) => {
+            focusOverlayTrigger(event.currentTarget);
+            onRefresh();
+          }}
         >
           <RefreshCw size={16} />
         </button>
@@ -7190,7 +7223,14 @@ function Switcher({
                   : ""}
             </span>
             {bridgeBlocked ? (
-              <button type="button" className="btn" onClick={onBackendSettings}>
+              <button
+                type="button"
+                className="btn"
+                onClick={(event) => {
+                  focusOverlayTrigger(event.currentTarget);
+                  onBackendSettings();
+                }}
+              >
                 Settings
               </button>
             ) : null}
@@ -7224,6 +7264,7 @@ function Switcher({
                     aria-haspopup="dialog"
                     aria-expanded={spaceOptionsMenu ? "true" : "false"}
                     onClick={(event) => {
+                      focusOverlayTrigger(event.currentTarget);
                       const rect = event.currentTarget.getBoundingClientRect();
                       setOptionsMenu(null);
                       setSpaceOptionsMenu({ x: rect.right, y: rect.bottom + 4 });
@@ -7304,11 +7345,12 @@ function Switcher({
                     type="button"
                     aria-label="New tab"
                     title="New tab"
-                    onClick={() =>
-                      selectedBridgeId && activeSpace
-                        ? onCreateTab(selectedBridgeId, activeSpace.workspace_id)
-                        : undefined
-                    }
+                    onClick={(event) => {
+                      focusOverlayTrigger(event.currentTarget);
+                      if (selectedBridgeId && activeSpace) {
+                        onCreateTab(selectedBridgeId, activeSpace.workspace_id);
+                      }
+                    }}
                   >
                     <Plus size={14} />
                   </button>
@@ -7378,6 +7420,7 @@ function Switcher({
                     aria-haspopup="dialog"
                     aria-expanded={optionsMenu ? "true" : "false"}
                     onClick={(event) => {
+                      focusOverlayTrigger(event.currentTarget);
                       const rect = event.currentTarget.getBoundingClientRect();
                       setSpaceOptionsMenu(null);
                       setOptionsMenu({ x: rect.right, y: rect.bottom + 4 });
@@ -8523,7 +8566,10 @@ export function NoteEditor({
               type="button"
               aria-label="Delete note"
               title="Delete"
-              onClick={() => onDelete(entry)}
+              onClick={(event) => {
+                focusOverlayTrigger(event.currentTarget);
+                onDelete(entry);
+              }}
             >
               <Trash2 size={16} />
             </button>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2114,7 +2114,7 @@ export function App() {
       return firstNote ? { bridgeId: selectedRuntimeId, noteId: firstNote.note_id } : null;
     });
   }, [selectedPaneKey, selectedPaneNotes, selectedRuntimeId]);
-  const selectedPaneMenuPress = useLongPress((x, y) => {
+  const openSelectedPaneMenu = (x: number, y: number) => {
     if (selectedPane && selectedRuntime) {
       setMenu({
         kind: "pane",
@@ -2126,7 +2126,8 @@ export function App() {
         pinLabel: isAgentPane(selectedPane) ? "agent" : "pane",
       });
     }
-  });
+  };
+  const selectedPaneMenuPress = useLongPress(openSelectedPaneMenu, openSelectedPaneMenu);
 
   useEffect(() => {
     if (isCompactLayout) {
@@ -3932,6 +3933,13 @@ export function App() {
             role="button"
             tabIndex={0}
             aria-haspopup="menu"
+            aria-expanded={
+              menu?.kind === "pane" &&
+              menu.bridgeId === selectedRuntime?.id &&
+              menu.id === selectedPane?.pane_id
+                ? "true"
+                : "false"
+            }
             aria-label="Selected pane actions"
             {...selectedPaneMenuPress}
           >

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -53,6 +53,7 @@ import type {
   MobileTouchSelectionEndpointTimeoutMs,
 } from "./mobileTerminalPrefs";
 import type { NavigationSyncMode } from "./navigationPrefs";
+import { trapFocusWithin, useFocusReturn } from "./overlayFocus";
 import { TERMINAL_INPUT_BATCH_DELAY_OPTIONS_MS } from "./terminalInputTransport";
 import type { TerminalInputTransport } from "./terminalInputTransport";
 import { TERMINAL_OUTPUT_COALESCE_OPTIONS_MS } from "./terminalOutputCoalescing";
@@ -155,6 +156,7 @@ export function BackendSettingsDialog({
   const bridge = useBridge();
   const titleId = useId();
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  useFocusReturn();
   const [form, setForm] = useState<FormState>(() => newBackendForm(bridge.store.backends));
   const [selectionMode, setSelectionMode] = useState<SelectionMode>(
     initialSelectionMode(bridge.lastSelectedBridgeId, bridge.sameOriginAvailable),
@@ -294,7 +296,13 @@ export function BackendSettingsDialog({
 
   return (
     <div className="overlay-root">
-      <button className="overlay-scrim" type="button" aria-label="Close settings" onClick={onClose} />
+      <button
+        className="overlay-scrim"
+        type="button"
+        tabIndex={-1}
+        aria-label="Close settings"
+        onClick={onClose}
+      />
       <form
         className="modal backend-modal"
         role="dialog"
@@ -305,7 +313,9 @@ export function BackendSettingsDialog({
           if (event.key === "Escape") {
             event.preventDefault();
             onClose();
+            return;
           }
+          trapFocusWithin(event);
         }}
         onSubmit={(event) => {
           event.preventDefault();

--- a/web/src/LaunchDialog.test.tsx
+++ b/web/src/LaunchDialog.test.tsx
@@ -187,6 +187,31 @@ describe("LaunchDialog", () => {
     expect(titleInput(container).value).toBe("reviewer");
     expect(launchOptions(container)[0].getAttribute("aria-checked")).toBe("true");
   });
+
+  it("contains modal focus and restores the opener", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+    const { container, root } = await renderDialog([
+      preset("builtin:shell", "Shell", null, true),
+    ]);
+    const dialog = requiredElement<HTMLFormElement>(container, '[role="dialog"]');
+    const option = launchOptions(container)[0];
+    const create = createButton(container);
+
+    expect(dialog.getAttribute("aria-labelledby")).toBe(
+      requiredElement(container, ".modal-title").id,
+    );
+    expect(requiredElement<HTMLButtonElement>(container, ".overlay-scrim").tabIndex).toBe(-1);
+    create.focus();
+    await press(create, "Tab");
+    expect(document.activeElement).toBe(option);
+    await press(option, "Tab", { shiftKey: true });
+    expect(document.activeElement).toBe(create);
+
+    await act(async () => root.render(null));
+    expect(document.activeElement).toBe(opener);
+  });
 });
 
 async function renderDialog(options: LauncherPresetOption[], emptyMessage?: string) {
@@ -231,6 +256,25 @@ function createButton(container: HTMLElement) {
     throw new Error("missing create button");
   }
   return button;
+}
+
+async function press(target: HTMLElement, key: string, init: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", {
+    ...init,
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  await act(async () => target.dispatchEvent(event));
+  return event;
+}
+
+function requiredElement<T extends Element = HTMLElement>(container: ParentNode, selector: string) {
+  const element = container.querySelector<T>(selector);
+  if (!element) {
+    throw new Error(`missing element: ${selector}`);
+  }
+  return element;
 }
 
 function preset(

--- a/web/src/LaunchDialog.tsx
+++ b/web/src/LaunchDialog.tsx
@@ -1,10 +1,11 @@
 import { Terminal } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { AgentIcon, agentIconKindFromHint } from "./AgentIcon";
 import { launchPresetLabel } from "./launch";
 import type { LaunchSpec, LaunchTarget } from "./launch";
 import type { LauncherPresetOption } from "./launcherPresets";
+import { trapFocusWithin, useFocusReturn } from "./overlayFocus";
 
 export function LaunchDialog({
   target,
@@ -27,6 +28,8 @@ export function LaunchDialog({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const optionRefs = useRef(new Map<string, HTMLButtonElement>());
   const selectedLabelRef = useRef(firstOption?.label ?? "");
+  const titleId = useId();
+  useFocusReturn();
 
   const matchedOption = options.find((option) => option.id === presetId) ?? null;
   const selectedOption = matchedOption ?? firstOption;
@@ -85,19 +88,31 @@ export function LaunchDialog({
 
   return (
     <div className="overlay-root">
-      <button className="overlay-scrim" type="button" aria-label="Cancel" onClick={onCancel} />
+      <button
+        className="overlay-scrim"
+        type="button"
+        tabIndex={-1}
+        aria-label="Cancel"
+        onClick={onCancel}
+      />
       <form
         className="modal launch-modal"
         role="dialog"
         aria-modal="true"
+        aria-labelledby={titleId}
         onSubmit={submit}
         onKeyDown={(event) => {
           if (event.key === "Escape") {
+            event.preventDefault();
             onCancel();
+            return;
           }
+          trapFocusWithin(event);
         }}
       >
-        <div className="modal-title">{launchTitle(target)}</div>
+        <div id={titleId} className="modal-title">
+          {launchTitle(target)}
+        </div>
         <div className="launch-grid" role="radiogroup" aria-label="Launch type">
           {options.length === 0 ? (
             <div className="launch-empty mono" role="status">

--- a/web/src/NoteEditor.test.tsx
+++ b/web/src/NoteEditor.test.tsx
@@ -135,6 +135,9 @@ describe("BridgeConnectionController sockets", () => {
 
 describe("QuickPaneNoteDialog", () => {
   it("selects the title and submits an optional body", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -156,6 +159,7 @@ describe("QuickPaneNoteDialog", () => {
       throw new Error("missing quick note title input");
     }
     expect(document.activeElement).toBe(titleInput);
+    expect(container.querySelector<HTMLButtonElement>(".overlay-scrim")?.tabIndex).toBe(-1);
     expect(titleInput.selectionStart).toBe(0);
     expect(titleInput.selectionEnd).toBe(titleInput.value.length);
     const createButton = buttonByText(container, "Create");
@@ -181,6 +185,9 @@ describe("QuickPaneNoteDialog", () => {
       buttonByText(container, "Create").click();
     });
     expect(onSubmit).toHaveBeenLastCalledWith("Untitled note", "Follow-up details");
+
+    await act(async () => root.render(null));
+    expect(document.activeElement).toBe(opener);
   });
 });
 

--- a/web/src/overlayFocus.ts
+++ b/web/src/overlayFocus.ts
@@ -1,0 +1,122 @@
+import { useLayoutEffect, useRef } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not(:disabled)",
+  "input:not(:disabled):not([type='hidden'])",
+  "select:not(:disabled)",
+  "textarea:not(:disabled)",
+  "[contenteditable='true']",
+  "[tabindex]",
+].join(",");
+
+export function focusableElements(container: ParentNode) {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter(isFocusable)
+    .sort((left, right) => {
+      const leftTabIndex = left.tabIndex;
+      const rightTabIndex = right.tabIndex;
+      if (leftTabIndex > 0 || rightTabIndex > 0) {
+        if (leftTabIndex <= 0) {
+          return 1;
+        }
+        if (rightTabIndex <= 0) {
+          return -1;
+        }
+        if (leftTabIndex !== rightTabIndex) {
+          return leftTabIndex - rightTabIndex;
+        }
+      }
+      return left.compareDocumentPosition(right) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
+    });
+}
+
+export function trapFocusWithin<T extends HTMLElement>(event: ReactKeyboardEvent<T>) {
+  if (event.key !== "Tab") {
+    return;
+  }
+
+  const container = event.currentTarget;
+  const focusable = focusableElements(container);
+  if (focusable.length === 0) {
+    event.preventDefault();
+    container.focus();
+    return;
+  }
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+  const outside = active === container || !container.contains(active);
+  if (event.shiftKey && (active === first || outside)) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && (active === last || outside)) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+export function useFocusReturn() {
+  const targetRef = useRef<HTMLElement | null>(null);
+  const restoreRef = useRef(true);
+
+  useLayoutEffect(() => {
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && active !== document.body) {
+      targetRef.current = active;
+    }
+
+    return () => {
+      const target = targetRef.current;
+      if (restoreRef.current && target?.isConnected) {
+        target.focus();
+      }
+    };
+  }, []);
+
+  return {
+    targetRef,
+    skipFocusReturn: () => {
+      restoreRef.current = false;
+    },
+  };
+}
+
+export function focusNextTo(
+  origin: HTMLElement | null,
+  excludedRoot: HTMLElement | null,
+  backwards: boolean,
+) {
+  if (!origin?.isConnected || !document.body) {
+    return false;
+  }
+
+  const candidates = focusableElements(document.body).filter(
+    (element) => !excludedRoot?.contains(element),
+  );
+  const originIndex = candidates.indexOf(origin);
+  if (originIndex < 0 || candidates.length < 2) {
+    return false;
+  }
+
+  const offset = backwards ? -1 : 1;
+  const target = candidates[(originIndex + offset + candidates.length) % candidates.length];
+  target.focus();
+  return document.activeElement === target;
+}
+
+function isFocusable(element: HTMLElement) {
+  if (element.tabIndex < 0 || element.closest("[hidden], [inert], [aria-hidden='true']")) {
+    return false;
+  }
+
+  for (let current: HTMLElement | null = element; current; current = current.parentElement) {
+    const style = window.getComputedStyle(current);
+    if (style.display === "none" || style.visibility === "hidden") {
+      return false;
+    }
+  }
+  return true;
+}

--- a/web/src/overlayFocus.ts
+++ b/web/src/overlayFocus.ts
@@ -107,6 +107,10 @@ export function focusNextTo(
   return document.activeElement === target;
 }
 
+export function focusOverlayTrigger(trigger: HTMLElement) {
+  trigger.focus({ preventScroll: true });
+}
+
 function isFocusable(element: HTMLElement) {
   if (element.tabIndex < 0 || element.closest("[hidden], [inert], [aria-hidden='true']")) {
     return false;

--- a/web/src/overlays.test.tsx
+++ b/web/src/overlays.test.tsx
@@ -116,6 +116,25 @@ describe("ActionMenu", () => {
     await press(firstItem, "Escape");
     expect(document.activeElement).toBe(trigger);
   });
+
+  it("opens a custom menu trigger consistently by click and keyboard", async () => {
+    const { container } = await render(<CustomMenuTriggerHarness />);
+    const trigger = requiredElement<HTMLElement>(container, "[data-custom-menu-trigger]");
+
+    await act(async () => trigger.click());
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(document.activeElement).toBe(
+      requiredElement<HTMLButtonElement>(container, '[role="menuitem"]'),
+    );
+
+    await press(document.activeElement as HTMLElement, "Escape");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    trigger.focus();
+    await press(trigger, "Enter");
+    expect(document.activeElement).toBe(
+      requiredElement<HTMLButtonElement>(container, '[role="menuitem"]'),
+    );
+  });
 });
 
 describe("RenameDialog", () => {
@@ -221,6 +240,35 @@ function PointerMenuHarness() {
       <button type="button" data-menu-trigger="true" {...press}>
         Open actions
       </button>
+      {position ? (
+        <ActionMenu
+          x={position.x}
+          y={position.y}
+          items={menuItems}
+          onPick={vi.fn()}
+          onClose={() => setPosition(null)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function CustomMenuTriggerHarness() {
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
+  const open = (x: number, y: number) => setPosition({ x, y });
+  const press = useLongPress(open, open);
+  return (
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-haspopup="menu"
+        aria-expanded={position ? "true" : "false"}
+        data-custom-menu-trigger="true"
+        {...press}
+      >
+        Open actions
+      </div>
       {position ? (
         <ActionMenu
           x={position.x}

--- a/web/src/overlays.test.tsx
+++ b/web/src/overlays.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ActionMenu, ConfirmDialog, RenameDialog } from "./overlays";
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) {
+      root.unmount();
+    }
+  });
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("ActionMenu", () => {
+  it("focuses the first item and supports standard menu navigation", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+    const { container } = await render(
+      <ActionMenu
+        x={20}
+        y={30}
+        title="Pane actions"
+        items={menuItems}
+        onPick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const menu = requiredElement<HTMLDivElement>(container, '[role="menu"]');
+    const items = Array.from(menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
+
+    expect(menu.getAttribute("aria-labelledby")).toBe(
+      requiredElement(container, ".menu-title").id,
+    );
+    expect(requiredElement<HTMLButtonElement>(container, ".overlay-scrim").tabIndex).toBe(-1);
+    expect(document.activeElement).toBe(items[0]);
+
+    await press(items[0], "ArrowDown");
+    expect(document.activeElement).toBe(items[1]);
+    await press(items[1], "End");
+    expect(document.activeElement).toBe(items[2]);
+    await press(items[2], "ArrowDown");
+    expect(document.activeElement).toBe(items[0]);
+    await press(items[0], "ArrowUp");
+    expect(document.activeElement).toBe(items[2]);
+    await press(items[2], "Home");
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it.each([
+    { shiftKey: false, expected: "after" },
+    { shiftKey: true, expected: "before" },
+  ])("closes on Tab and moves focus $expected the opener", async ({ shiftKey, expected }) => {
+    const before = pageButton("before");
+    const opener = pageButton("opener");
+    const after = pageButton("after");
+    opener.focus();
+    const onClose = vi.fn();
+    const { container } = await render(<MenuHarness onClose={onClose} />);
+    const firstItem = requiredElement<HTMLButtonElement>(container, '[role="menuitem"]');
+
+    const event = await press(firstItem, "Tab", { shiftKey });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+    expect(document.activeElement).toBe(expected === "after" ? after : before);
+  });
+
+  it("restores focus to the opener when dismissed with Escape", async () => {
+    const opener = pageButton("opener");
+    opener.focus();
+    const onClose = vi.fn();
+    const { container } = await render(<MenuHarness onClose={onClose} />);
+    const firstItem = requiredElement<HTMLButtonElement>(container, '[role="menuitem"]');
+
+    const event = await press(firstItem, "Escape");
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(opener);
+  });
+});
+
+describe("RenameDialog", () => {
+  it("labels the modal, traps focus, and restores its opener", async () => {
+    const opener = pageButton("opener");
+    opener.focus();
+    const { container, root } = await render(
+      <RenameDialog
+        title="Rename pane"
+        initial="Build"
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const dialog = requiredElement<HTMLFormElement>(container, '[role="dialog"]');
+    const input = requiredElement<HTMLInputElement>(dialog, "input");
+    const buttons = Array.from(dialog.querySelectorAll<HTMLButtonElement>("button"));
+    const last = buttons.at(-1);
+    if (!last) {
+      throw new Error("missing dialog action");
+    }
+
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBe(
+      requiredElement(container, ".modal-title").id,
+    );
+    expect(document.activeElement).toBe(input);
+    await press(input, "Tab", { shiftKey: true });
+    expect(document.activeElement).toBe(last);
+    await press(last, "Tab");
+    expect(document.activeElement).toBe(input);
+
+    await act(async () => root.render(null));
+    expect(document.activeElement).toBe(opener);
+  });
+});
+
+describe("ConfirmDialog", () => {
+  it("labels its content, traps focus, and restores its opener", async () => {
+    const opener = pageButton("opener");
+    opener.focus();
+    const { container, root } = await render(
+      <ConfirmDialog
+        title="Delete pane?"
+        message="This cannot be undone."
+        confirmLabel="Delete"
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+    const dialog = requiredElement<HTMLDivElement>(container, '[role="dialog"]');
+    const actions = Array.from(dialog.querySelectorAll<HTMLButtonElement>("button"));
+
+    expect(dialog.getAttribute("aria-labelledby")).toBe(
+      requiredElement(container, ".modal-title").id,
+    );
+    expect(dialog.getAttribute("aria-describedby")).toBe(
+      requiredElement(container, ".modal-message").id,
+    );
+    expect(document.activeElement).toBe(dialog);
+    await press(dialog, "Tab");
+    expect(document.activeElement).toBe(actions[0]);
+    await press(actions[0], "Tab", { shiftKey: true });
+    expect(document.activeElement).toBe(actions.at(-1));
+    await press(actions.at(-1) ?? actions[0], "Tab");
+    expect(document.activeElement).toBe(actions[0]);
+
+    await act(async () => root.render(null));
+    expect(document.activeElement).toBe(opener);
+  });
+});
+
+const menuItems = [
+  { key: "rename", label: "Rename" },
+  { key: "duplicate", label: "Duplicate" },
+  { key: "delete", label: "Delete", danger: true },
+];
+
+function MenuHarness({ onClose }: { onClose: () => void }) {
+  const [open, setOpen] = useState(true);
+  if (!open) {
+    return null;
+  }
+  return (
+    <ActionMenu
+      x={20}
+      y={30}
+      items={menuItems}
+      onPick={vi.fn()}
+      onClose={() => {
+        onClose();
+        setOpen(false);
+      }}
+    />
+  );
+}
+
+async function render(node: React.ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => root.render(node));
+  return { container, root };
+}
+
+function pageButton(label: string) {
+  const button = document.createElement("button");
+  button.textContent = label;
+  document.body.appendChild(button);
+  return button;
+}
+
+async function press(target: HTMLElement, key: string, init: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", {
+    ...init,
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  await act(async () => target.dispatchEvent(event));
+  return event;
+}
+
+function requiredElement<T extends Element = HTMLElement>(container: ParentNode, selector: string) {
+  const element = container.querySelector<T>(selector);
+  if (!element) {
+    throw new Error(`missing element: ${selector}`);
+  }
+  return element;
+}

--- a/web/src/overlays.test.tsx
+++ b/web/src/overlays.test.tsx
@@ -4,7 +4,7 @@
 import { act, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ActionMenu, ConfirmDialog, RenameDialog } from "./overlays";
+import { ActionMenu, ConfirmDialog, RenameDialog, useLongPress } from "./overlays";
 
 const roots: Root[] = [];
 
@@ -92,6 +92,29 @@ describe("ActionMenu", () => {
     expect(event.defaultPrevented).toBe(true);
     expect(onClose).toHaveBeenCalledOnce();
     expect(document.activeElement).toBe(opener);
+  });
+
+  it("records the real pointer trigger before opening the menu", async () => {
+    const unrelated = pageButton("unrelated");
+    unrelated.focus();
+    const { container } = await render(<PointerMenuHarness />);
+    const trigger = requiredElement<HTMLButtonElement>(container, "[data-menu-trigger]");
+
+    await act(async () => {
+      trigger.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX: 20,
+          clientY: 30,
+        }),
+      );
+    });
+    const firstItem = requiredElement<HTMLButtonElement>(container, '[role="menuitem"]');
+    expect(document.activeElement).toBe(firstItem);
+
+    await press(firstItem, "Escape");
+    expect(document.activeElement).toBe(trigger);
   });
 });
 
@@ -187,6 +210,27 @@ function MenuHarness({ onClose }: { onClose: () => void }) {
         setOpen(false);
       }}
     />
+  );
+}
+
+function PointerMenuHarness() {
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
+  const press = useLongPress((x, y) => setPosition({ x, y }));
+  return (
+    <>
+      <button type="button" data-menu-trigger="true" {...press}>
+        Open actions
+      </button>
+      {position ? (
+        <ActionMenu
+          x={position.x}
+          y={position.y}
+          items={menuItems}
+          onPick={vi.fn()}
+          onClose={() => setPosition(null)}
+        />
+      ) : null}
+    </>
   );
 }
 

--- a/web/src/overlays.tsx
+++ b/web/src/overlays.tsx
@@ -13,7 +13,10 @@ export type MenuItem = { key: string; label: string; danger?: boolean };
  * Long-press (touch / mouse-hold) and right-click both open a context menu;
  * a plain tap/click runs the row's normal select action.
  */
-export function useLongPress(onLong: (x: number, y: number) => void, onTap?: () => void) {
+export function useLongPress(
+  onLong: (x: number, y: number) => void,
+  onTap?: (x: number, y: number) => void,
+) {
   const timer = useRef<number | undefined>(undefined);
   const longFired = useRef(false);
   const start = useRef<{ x: number; y: number } | null>(null);
@@ -53,14 +56,18 @@ export function useLongPress(onLong: (x: number, y: number) => void, onTap?: () 
     onPointerUp: () => clear(),
     onPointerCancel: () => clear(),
     onPointerLeave: () => clear(),
-    onClick: (event: React.MouseEvent) => {
+    onClick: (event: React.MouseEvent<HTMLElement>) => {
       if (longFired.current) {
         event.preventDefault();
         event.stopPropagation();
         longFired.current = false;
         return;
       }
-      onTap?.();
+      if (onTap) {
+        focusOverlayTrigger(event.currentTarget);
+        const rect = event.currentTarget.getBoundingClientRect();
+        onTap(rect.left, rect.bottom);
+      }
     },
     onContextMenu: (event: React.MouseEvent<HTMLElement>) => {
       event.preventDefault();
@@ -68,7 +75,10 @@ export function useLongPress(onLong: (x: number, y: number) => void, onTap?: () 
       onLong(event.clientX, event.clientY);
     },
     onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
-      const directActivation = !onTap && (event.key === "Enter" || event.key === " ");
+      const directActivation =
+        Boolean(onTap) &&
+        event.currentTarget.tagName !== "BUTTON" &&
+        (event.key === "Enter" || event.key === " ");
       if (
         !directActivation &&
         event.key !== "ContextMenu" &&
@@ -79,7 +89,11 @@ export function useLongPress(onLong: (x: number, y: number) => void, onTap?: () 
       event.preventDefault();
       focusOverlayTrigger(event.currentTarget);
       const rect = event.currentTarget.getBoundingClientRect();
-      onLong(rect.left, rect.bottom);
+      if (directActivation) {
+        onTap?.(rect.left, rect.bottom);
+      } else {
+        onLong(rect.left, rect.bottom);
+      }
     },
   };
 }

--- a/web/src/overlays.tsx
+++ b/web/src/overlays.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { focusNextTo, trapFocusWithin, useFocusReturn } from "./overlayFocus";
 
 export type MenuItem = { key: string; label: string; danger?: boolean };
 
@@ -77,7 +78,11 @@ export function ActionMenu({
   onClose: () => void;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const { targetRef: returnFocusRef, skipFocusReturn } = useFocusReturn();
   const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const titleId = useId();
 
   useLayoutEffect(() => {
     const el = ref.current;
@@ -97,9 +102,18 @@ export function ActionMenu({
     setPos({ left: Math.max(margin, left), top: Math.max(margin, top) });
   }, [x, y]);
 
+  useLayoutEffect(() => {
+    if (!pos) {
+      return;
+    }
+    const firstItem = ref.current?.querySelector<HTMLButtonElement>('[role="menuitem"]');
+    (firstItem ?? ref.current)?.focus();
+  }, [pos]);
+
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
         onClose();
       }
     };
@@ -107,27 +121,95 @@ export function ActionMenu({
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  const onMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+    if (event.key === "Tab") {
+      event.preventDefault();
+      event.stopPropagation();
+      const moved = focusNextTo(returnFocusRef.current, overlayRef.current, event.shiftKey);
+      if (moved) {
+        skipFocusReturn();
+      }
+      onClose();
+      return;
+    }
+    if (
+      event.key !== "ArrowDown" &&
+      event.key !== "ArrowUp" &&
+      event.key !== "Home" &&
+      event.key !== "End"
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    const menuItems = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+    );
+    if (menuItems.length === 0) {
+      return;
+    }
+    const activeIndex = menuItems.findIndex((item) => item === document.activeElement);
+    const lastIndex = menuItems.length - 1;
+    const nextIndex =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? lastIndex
+          : event.key === "ArrowDown"
+            ? activeIndex < 0 || activeIndex === lastIndex
+              ? 0
+              : activeIndex + 1
+            : activeIndex <= 0
+              ? lastIndex
+              : activeIndex - 1;
+    setFocusedIndex(nextIndex);
+    menuItems[nextIndex]?.focus();
+  };
+
   return (
-    <div className="overlay-root">
-      <button className="overlay-scrim" type="button" aria-label="Dismiss menu" onClick={onClose} />
+    <div ref={overlayRef} className="overlay-root">
+      <button
+        className="overlay-scrim"
+        type="button"
+        tabIndex={-1}
+        aria-label="Dismiss menu"
+        onClick={onClose}
+      />
       <div
         ref={ref}
         className="menu"
         role="menu"
+        aria-label={title ? undefined : "Actions"}
+        aria-labelledby={title ? titleId : undefined}
+        tabIndex={items.length === 0 ? -1 : undefined}
+        onKeyDown={onMenuKeyDown}
         style={{
           left: pos?.left ?? x,
           top: pos?.top ?? y,
           visibility: pos ? "visible" : "hidden",
         }}
       >
-        {title ? <div className="menu-title">{title}</div> : null}
-        {items.map((item) => (
+        {title ? (
+          <div id={titleId} className="menu-title">
+            {title}
+          </div>
+        ) : null}
+        {items.map((item, index) => (
           <button
             key={item.key}
             className="menu-item"
             type="button"
             role="menuitem"
+            tabIndex={index === focusedIndex ? 0 : -1}
             data-danger={item.danger || undefined}
+            onFocus={() => setFocusedIndex(index)}
             onClick={() => onPick(item.key)}
           >
             {item.label}
@@ -157,6 +239,8 @@ export function RenameDialog({
 }) {
   const [value, setValue] = useState(initial);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  useFocusReturn();
+  const titleId = useId();
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -173,17 +257,31 @@ export function RenameDialog({
 
   return (
     <div className="overlay-root">
-      <button className="overlay-scrim" type="button" aria-label="Cancel" onClick={onCancel} />
+      <button
+        className="overlay-scrim"
+        type="button"
+        tabIndex={-1}
+        aria-label="Cancel"
+        onClick={onCancel}
+      />
       <form
         className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         onSubmit={submit}
         onKeyDown={(event) => {
           if (event.key === "Escape") {
+            event.preventDefault();
             onCancel();
+            return;
           }
+          trapFocusWithin(event);
         }}
       >
-        <div className="modal-title">{title}</div>
+        <div id={titleId} className="modal-title">
+          {title}
+        </div>
         <input
           ref={inputRef}
           className="field"
@@ -227,6 +325,9 @@ export function ConfirmDialog({
   onConfirm: () => void;
 }) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  useFocusReturn();
+  const titleId = useId();
+  const messageId = useId();
 
   useEffect(() => {
     dialogRef.current?.focus();
@@ -234,12 +335,20 @@ export function ConfirmDialog({
 
   return (
     <div className="overlay-root">
-      <button className="overlay-scrim" type="button" aria-label="Cancel" onClick={onCancel} />
+      <button
+        className="overlay-scrim"
+        type="button"
+        tabIndex={-1}
+        aria-label="Cancel"
+        onClick={onCancel}
+      />
       <div
         ref={dialogRef}
         className="modal"
         role="dialog"
         aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={message ? messageId : undefined}
         tabIndex={-1}
         onKeyDown={(event) => {
           if (event.key === "Escape") {
@@ -253,10 +362,17 @@ export function ConfirmDialog({
             event.preventDefault();
             onConfirm();
           }
+          trapFocusWithin(event);
         }}
       >
-        <div className="modal-title">{title}</div>
-        {message ? <div className="modal-message">{message}</div> : null}
+        <div id={titleId} className="modal-title">
+          {title}
+        </div>
+        {message ? (
+          <div id={messageId} className="modal-message">
+            {message}
+          </div>
+        ) : null}
         <div className="modal-actions">
           <button type="button" className="btn" onClick={onCancel}>
             Cancel

--- a/web/src/overlays.tsx
+++ b/web/src/overlays.tsx
@@ -1,6 +1,11 @@
 import type * as React from "react";
 import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
-import { focusNextTo, trapFocusWithin, useFocusReturn } from "./overlayFocus";
+import {
+  focusNextTo,
+  focusOverlayTrigger,
+  trapFocusWithin,
+  useFocusReturn,
+} from "./overlayFocus";
 
 export type MenuItem = { key: string; label: string; danger?: boolean };
 
@@ -21,7 +26,7 @@ export function useLongPress(onLong: (x: number, y: number) => void, onTap?: () 
   };
 
   return {
-    onPointerDown: (event: React.PointerEvent) => {
+    onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
       if (event.button === 2) {
         return;
       }
@@ -29,8 +34,10 @@ export function useLongPress(onLong: (x: number, y: number) => void, onTap?: () 
       start.current = { x: event.clientX, y: event.clientY };
       clear();
       const { clientX, clientY } = event;
+      const trigger = event.currentTarget;
       timer.current = window.setTimeout(() => {
         longFired.current = true;
+        focusOverlayTrigger(trigger);
         onLong(clientX, clientY);
       }, 480);
     },
@@ -55,9 +62,24 @@ export function useLongPress(onLong: (x: number, y: number) => void, onTap?: () 
       }
       onTap?.();
     },
-    onContextMenu: (event: React.MouseEvent) => {
+    onContextMenu: (event: React.MouseEvent<HTMLElement>) => {
       event.preventDefault();
+      focusOverlayTrigger(event.currentTarget);
       onLong(event.clientX, event.clientY);
+    },
+    onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+      const directActivation = !onTap && (event.key === "Enter" || event.key === " ");
+      if (
+        !directActivation &&
+        event.key !== "ContextMenu" &&
+        !(event.shiftKey && event.key === "F10")
+      ) {
+        return;
+      }
+      event.preventDefault();
+      focusOverlayTrigger(event.currentTarget);
+      const rect = event.currentTarget.getBoundingClientRect();
+      onLong(rect.left, rect.bottom);
     },
   };
 }


### PR DESCRIPTION
Adds contained dialog focus, keyboard menu navigation, normal Tab exit, and reliable opener restoration across pointer and keyboard activation.

Based on the focus-management work proposed by shuv (@shuv1337) in #37, reimplemented against current main with expanded tests and iterative Claude review.

Validation: npm run check