### PR TITLE
Add optional terminal screen-reader text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Added
 
+- Added an optional screen-reader text mirror for visible terminal contents, with bounded updates
+  and concealed-cell filtering. Based on the concept proposed by
+  [shuv (@shuv1337)](https://github.com/shuv1337) in
+  [PR #37](https://github.com/kcosr/herdr-web/pull/37).
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Added
 
 - Added an optional screen-reader text mirror for visible terminal contents, with bounded updates
-  and concealed-cell filtering. Based on the concept proposed by
+  and concealed-cell filtering. [PR #64](https://github.com/kcosr/herdr-web/pull/64), based on the
+  concept proposed by
   [shuv (@shuv1337)](https://github.com/shuv1337) in
   [PR #37](https://github.com/kcosr/herdr-web/pull/37).
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Settings are grouped by area:
 - Features: client feature toggles such as Notes.
 - Display: browser-wide navigation synchronization, agent features in Tabs, multi-host Space
   selection, top/bottom app padding, and mobile terminal controls size.
-- Terminal: browser-to-bridge terminal input transport and input batching delay.
+- Terminal: font size, optional screen-reader text, browser-to-bridge transport, and input/output
+  batching delays.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
 
 When viewing all of multiple hosts, use the Spaces list `…` menu to group spaces by host or keep a
@@ -200,6 +201,11 @@ Terminal input payloads can be sent as JSON or binary WebSocket frames. JSON rem
 binary is available for comparing terminal input performance. Terminal input batching is off by
 default. When enabled, short input chunks are coalesced for `32`, `64`, `128`, or `256` ms and are
 flushed early once the pending UTF-8 input reaches 32 bytes, so paste-like input bypasses the delay.
+
+Terminal screen-reader text is off by default. Enable it under Settings → Terminal to expose each
+visible terminal viewport as bounded plain text for assistive technology. The mirror follows output,
+scrolling, resizing, and alternate-screen changes, and replaces concealed terminal cells with
+spaces. Disable it when screen-reader access is not needed to avoid the additional snapshot work.
 
 ## Launcher Presets
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -143,6 +143,10 @@ import {
 import { createSnapshotRefreshController } from "./refreshCoordinator";
 import { TerminalView } from "./TerminalView";
 import {
+  DEFAULT_TERMINAL_SCREEN_READER_TEXT,
+  parseTerminalScreenReaderText,
+} from "./terminalAccessibleText";
+import {
   DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
   DEFAULT_TERMINAL_INPUT_TRANSPORT,
   parseTerminalInputBatchDelayMs,
@@ -408,6 +412,7 @@ type DisplayPrefs = {
   notesPanelOpen: boolean;
   sidebarOpen: boolean;
   terminalFontSizePx: number;
+  terminalScreenReaderText: boolean;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
   terminalOutputCoalesceMs: number;
@@ -471,6 +476,7 @@ function readDisplayPrefs(): DisplayPrefs {
     notesPanelOpen: false,
     sidebarOpen: true,
     terminalFontSizePx: DEFAULT_TERMINAL_FONT_SIZE_PX,
+    terminalScreenReaderText: DEFAULT_TERMINAL_SCREEN_READER_TEXT,
     terminalInputTransport: DEFAULT_TERMINAL_INPUT_TRANSPORT,
     terminalInputBatchDelayMs: DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
     terminalOutputCoalesceMs: DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
@@ -666,6 +672,10 @@ function parseDisplayPrefsValue(
       typeof parsed.notesPanelOpen === "boolean" ? parsed.notesPanelOpen : fallback.notesPanelOpen,
     sidebarOpen,
     terminalFontSizePx: parseTerminalFontSizePx(parsed.terminalFontSizePx),
+    terminalScreenReaderText: parseTerminalScreenReaderText(
+      parsed.terminalScreenReaderText,
+      fallback.terminalScreenReaderText,
+    ),
     terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
     terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
     terminalOutputCoalesceMs: parseTerminalOutputCoalesceMs(
@@ -1041,6 +1051,9 @@ export function App() {
   const [terminalFontSizePx, setTerminalFontSizePx] = useState(
     initialPrefs.terminalFontSizePx,
   );
+  const [terminalScreenReaderText, setTerminalScreenReaderText] = useState(
+    initialPrefs.terminalScreenReaderText,
+  );
   const [terminalInputTransport, setTerminalInputTransport] = useState(
     initialPrefs.terminalInputTransport,
   );
@@ -1168,6 +1181,7 @@ export function App() {
       setSelectedPanesByBridgeId(sharedNavigationPrefs.selectedPanesByBridgeId);
       setActiveWorkspacesByBridgeId(sharedNavigationPrefs.activeWorkspacesByBridgeId);
       setTerminalFontSizePx(prefs.terminalFontSizePx);
+      setTerminalScreenReaderText(prefs.terminalScreenReaderText);
       setTerminalInputTransport(prefs.terminalInputTransport);
       setTerminalInputBatchDelayMs(prefs.terminalInputBatchDelayMs);
       setTerminalOutputCoalesceMs(prefs.terminalOutputCoalesceMs);
@@ -1710,6 +1724,7 @@ export function App() {
       notesPanelOpen,
       sidebarOpen,
       terminalFontSizePx,
+      terminalScreenReaderText,
       terminalInputTransport,
       terminalInputBatchDelayMs,
       terminalOutputCoalesceMs,
@@ -1745,6 +1760,7 @@ export function App() {
     notesPanelOpen,
     sidebarOpen,
     terminalFontSizePx,
+    terminalScreenReaderText,
     terminalInputTransport,
     terminalInputBatchDelayMs,
     terminalOutputCoalesceMs,
@@ -4049,6 +4065,7 @@ export function App() {
             focusToken={terminalFocusToken}
             touchInput={isTouchInput}
             terminalFontSizePx={terminalFontSizePx}
+            terminalScreenReaderText={terminalScreenReaderText}
             mobileControlsScalePercent={mobileControlsScalePercent}
             mobileTapTarget={mobileTerminalTapTarget}
             mobileLongPressBehavior={mobileLongPressBehavior}
@@ -4074,6 +4091,7 @@ export function App() {
             scrollSensitivity={isTouchInput ? 2 : 0.4}
             mobileControls={isTouchInput}
             terminalFontSizePx={terminalFontSizePx}
+            terminalScreenReaderText={terminalScreenReaderText}
             mobileControlsScalePercent={mobileControlsScalePercent}
             mobileTapTarget={mobileTerminalTapTarget}
             mobileLongPressBehavior={mobileLongPressBehavior}
@@ -4085,6 +4103,10 @@ export function App() {
             terminalOutputCoalesceMs={terminalOutputCoalesceMs}
             refitToken={refitToken}
             focusToken={terminalFocusToken}
+            accessibilityLabel={
+              selectedPane ? `Selected pane terminal: ${paneTitle(selectedPane)}` : "Terminal"
+            }
+            selected={Boolean(selectedPane)}
           />
         ) : (
           <div className="terminal-stage" aria-hidden="true" />
@@ -4306,6 +4328,8 @@ export function App() {
           onMultiHostSpaceSelection={setMultiHostSpaceSelection}
           terminalFontSizePx={terminalFontSizePx}
           onTerminalFontSizePx={setTerminalFontSizePx}
+          terminalScreenReaderText={terminalScreenReaderText}
+          onTerminalScreenReaderText={setTerminalScreenReaderText}
           terminalInputTransport={terminalInputTransport}
           onTerminalInputTransport={setTerminalInputTransport}
           terminalInputBatchDelayMs={terminalInputBatchDelayMs}
@@ -5770,6 +5794,7 @@ function SplitGrid({
   focusToken,
   touchInput,
   terminalFontSizePx,
+  terminalScreenReaderText,
   mobileControlsScalePercent,
   mobileTapTarget,
   mobileLongPressBehavior,
@@ -5791,6 +5816,7 @@ function SplitGrid({
   focusToken: number;
   touchInput: boolean;
   terminalFontSizePx: number;
+  terminalScreenReaderText: boolean;
   mobileControlsScalePercent: number;
   mobileTapTarget: MobileTerminalTapTarget;
   mobileLongPressBehavior: MobileLongPressBehavior;
@@ -5807,8 +5833,9 @@ function SplitGrid({
 }) {
   return (
     <div className="pane-grid" aria-label="Split panes">
-      {cells.map(({ pane, style }) => {
+      {cells.map(({ pane, style }, index) => {
         const selected = pane.pane_id === selectedPaneId;
+        const accessibilityLabel = `Pane ${index + 1} of ${cells.length} terminal: ${paneTitle(pane)}`;
         return (
           <div
             key={pane.pane_id}
@@ -5827,6 +5854,7 @@ function SplitGrid({
               scrollSensitivity={touchInput ? 2 : 0.4}
               mobileControls={selected && touchInput}
               terminalFontSizePx={terminalFontSizePx}
+              terminalScreenReaderText={terminalScreenReaderText}
               mobileControlsScalePercent={mobileControlsScalePercent}
               mobileTapTarget={mobileTapTarget}
               mobileLongPressBehavior={mobileLongPressBehavior}
@@ -5838,6 +5866,8 @@ function SplitGrid({
               terminalOutputCoalesceMs={terminalOutputCoalesceMs}
               refitToken={selected ? refitToken : 0}
               focusToken={selected ? focusToken : 0}
+              accessibilityLabel={accessibilityLabel}
+              selected={selected}
             />
           </div>
         );

--- a/web/src/BackendSettingsDialog.test.tsx
+++ b/web/src/BackendSettingsDialog.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BackendSettingsDialog } from "./BackendSettingsDialog";
+
+const bridge = vi.hoisted(() => ({
+  store: {
+    backends: [],
+    enabledBridgeIds: [],
+  },
+  lastSelectedBridgeId: null,
+  sameOriginAvailable: true,
+  addBackend: vi.fn(),
+  deleteBackend: vi.fn(),
+  probeBackend: vi.fn(),
+  setBridgeEnabled: vi.fn(),
+  updateBackend: vi.fn(),
+}));
+
+vi.mock("./bridge", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./bridge")>();
+  return {
+    ...actual,
+    useBridge: () => bridge,
+  };
+});
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) {
+      root.unmount();
+    }
+  });
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+});
+
+describe("BackendSettingsDialog terminal accessibility", () => {
+  it("exposes a persisted-style opt-in control in the Terminal area", async () => {
+    const onChange = vi.fn();
+    const { container } = await render(<SettingsHarness onChange={onChange} />);
+    const terminalTab = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+    ).find((button) => button.textContent?.includes("Terminal"));
+    if (!terminalTab) {
+      throw new Error("missing Terminal settings tab");
+    }
+
+    await act(async () => terminalTab.click());
+    const group = requiredElement<HTMLElement>(
+      container,
+      '[role="group"][aria-label="Terminal screen-reader text"]',
+    );
+    const [off, on] = Array.from(group.querySelectorAll<HTMLButtonElement>("button"));
+    expect(off?.getAttribute("aria-pressed")).toBe("true");
+    expect(on?.getAttribute("aria-pressed")).toBe("false");
+
+    await act(async () => on?.click());
+    expect(onChange).toHaveBeenCalledWith(true);
+    expect(off?.getAttribute("aria-pressed")).toBe("false");
+    expect(on?.getAttribute("aria-pressed")).toBe("true");
+  });
+});
+
+function SettingsHarness({ onChange }: { onChange: (enabled: boolean) => void }) {
+  const [terminalScreenReaderText, setTerminalScreenReaderText] = useState(false);
+  return (
+    <BackendSettingsDialog
+      {...settingsProps()}
+      terminalScreenReaderText={terminalScreenReaderText}
+      onTerminalScreenReaderText={(enabled) => {
+        onChange(enabled);
+        setTerminalScreenReaderText(enabled);
+      }}
+    />
+  );
+}
+
+function settingsProps() {
+  return {
+    showMobileTerminalSettings: true,
+    notesEnabled: true,
+    onNotesEnabled: vi.fn(),
+    navigationSyncMode: "shared" as const,
+    onNavigationSyncMode: vi.fn(),
+    agentFeaturesInTabs: true,
+    onAgentFeaturesInTabs: vi.fn(),
+    combineMatchingWorkspaceNames: false,
+    onCombineMatchingWorkspaceNames: vi.fn(),
+    multiHostSpaceSelection: true,
+    onMultiHostSpaceSelection: vi.fn(),
+    terminalFontSizePx: 13,
+    onTerminalFontSizePx: vi.fn(),
+    terminalScreenReaderText: false,
+    onTerminalScreenReaderText: vi.fn(),
+    terminalInputTransport: "json" as const,
+    onTerminalInputTransport: vi.fn(),
+    terminalInputBatchDelayMs: 0,
+    onTerminalInputBatchDelayMs: vi.fn(),
+    terminalOutputCoalesceMs: 16,
+    onTerminalOutputCoalesceMs: vi.fn(),
+    contentInsetTopPx: 0,
+    onContentInsetTopPx: vi.fn(),
+    contentInsetBottomPx: 0,
+    onContentInsetBottomPx: vi.fn(),
+    mobileControlsScalePercent: 100,
+    onMobileControlsScalePercent: vi.fn(),
+    mobileTerminalTapTarget: "command-input" as const,
+    onMobileTerminalTapTarget: vi.fn(),
+    mobileLongPressBehavior: "off" as const,
+    onMobileLongPressBehavior: vi.fn(),
+    mobileTouchSelectionEndpointTimeoutMs: 1500 as const,
+    onMobileTouchSelectionEndpointTimeoutMs: vi.fn(),
+    mobileCommandExpandingInput: true,
+    onMobileCommandExpandingInput: vi.fn(),
+    mobileCommandEnterNewline: false,
+    onMobileCommandEnterNewline: vi.fn(),
+    showMobileKeyboardHideRefit: true,
+    mobileKeyboardHideRefit: true,
+    onMobileKeyboardHideRefit: vi.fn(),
+    onClose: vi.fn(),
+  };
+}
+
+async function render(node: React.ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => root.render(node));
+  return { container, root };
+}
+
+function requiredElement<T extends Element = HTMLElement>(
+  container: ParentNode,
+  selector: string,
+) {
+  const element = container.querySelector<T>(selector);
+  if (!element) {
+    throw new Error(`missing element: ${selector}`);
+  }
+  return element;
+}

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -72,6 +72,8 @@ type Props = {
   onMultiHostSpaceSelection: (enabled: boolean) => void;
   terminalFontSizePx: number;
   onTerminalFontSizePx: (value: number) => void;
+  terminalScreenReaderText: boolean;
+  onTerminalScreenReaderText: (enabled: boolean) => void;
   terminalInputTransport: TerminalInputTransport;
   onTerminalInputTransport: (transport: TerminalInputTransport) => void;
   terminalInputBatchDelayMs: number;
@@ -126,6 +128,8 @@ export function BackendSettingsDialog({
   onMultiHostSpaceSelection,
   terminalFontSizePx,
   onTerminalFontSizePx,
+  terminalScreenReaderText,
+  onTerminalScreenReaderText,
   terminalInputTransport,
   onTerminalInputTransport,
   terminalInputBatchDelayMs,
@@ -692,6 +696,34 @@ export function BackendSettingsDialog({
                     defaultValue={DEFAULT_TERMINAL_FONT_SIZE_PX}
                     onChange={(value) => onTerminalFontSizePx(parseTerminalFontSizePx(value))}
                   />
+                </div>
+                <div className="settings-label">Accessibility</div>
+                <div className="settings-row">
+                  <span title="Expose the visible terminal contents as screen-reader text; may add processing during heavy output">
+                    Screen-reader text
+                  </span>
+                  <div
+                    className="segmented-control"
+                    role="group"
+                    aria-label="Terminal screen-reader text"
+                  >
+                    <button
+                      type="button"
+                      data-on={!terminalScreenReaderText}
+                      aria-pressed={!terminalScreenReaderText}
+                      onClick={() => onTerminalScreenReaderText(false)}
+                    >
+                      Off
+                    </button>
+                    <button
+                      type="button"
+                      data-on={terminalScreenReaderText}
+                      aria-pressed={terminalScreenReaderText}
+                      onClick={() => onTerminalScreenReaderText(true)}
+                    >
+                      On
+                    </button>
+                  </div>
                 </div>
                 <div className="settings-label">Terminal transport</div>
                 <div className="settings-row">

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -87,6 +87,12 @@ type Props = {
   refitToken?: number;
   /** Incrementing token from the parent that requests focus on the preferred terminal input. */
   focusToken?: number;
+  /** Whether to maintain a hidden plain-text mirror of the visible terminal viewport. */
+  terminalScreenReaderText?: boolean;
+  /** Pane-specific accessible name for the terminal and its screen mirror. */
+  accessibilityLabel?: string;
+  /** Whether this is the currently selected terminal in a split. */
+  selected?: boolean;
 };
 
 type UploadCandidate = {
@@ -148,6 +154,9 @@ export function TerminalView({
   terminalOutputCoalesceMs = DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
   refitToken = 0,
   focusToken = 0,
+  terminalScreenReaderText = false,
+  accessibilityLabel = "Terminal",
+  selected = false,
 }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const stageRef = useRef<HTMLElement | null>(null);
@@ -176,6 +185,7 @@ export function TerminalView({
   const [connectionState, setConnectionState] = useState<TerminalConnectionState>("idle");
   const [closeReason, setCloseReason] = useState<string | null>(null);
   const [rendererReady, setRendererReady] = useState<TerminalRendererReady | null>(null);
+  const [accessibleScreen, setAccessibleScreen] = useState("");
   const [hasAttachedForTerminal, setHasAttachedForTerminal] = useState(false);
   const [showConnectionOverlay, setShowConnectionOverlay] = useState(false);
   const [uploadStatus, setUploadStatus] = useState<string | null>(null);
@@ -463,6 +473,7 @@ export function TerminalView({
     overlayTerminalIdRef.current = terminalId;
     rendererReadyRef.current = null;
     setRendererReady(null);
+    setAccessibleScreen("");
     setHasAttachedForTerminal(false);
     setShowConnectionOverlay(false);
     setCloseReason(null);
@@ -596,6 +607,27 @@ export function TerminalView({
     pane?.terminal_id,
     sendTerminalInputData,
   ]);
+
+  useEffect(() => {
+    setAccessibleScreen("");
+    const ready = rendererReady;
+    if (!terminalScreenReaderText || !ready) {
+      ready?.renderer.setAccessibleScreenListener(null);
+      return;
+    }
+
+    const { renderer, generation, terminalId } = ready;
+    renderer.setAccessibleScreenListener((text) => {
+      if (
+        rendererRef.current === renderer &&
+        rendererGenerationRef.current === generation &&
+        terminalIdRef.current === terminalId
+      ) {
+        setAccessibleScreen(text);
+      }
+    });
+    return () => renderer.setAccessibleScreenListener(null);
+  }, [rendererReady, terminalScreenReaderText]);
 
   useEffect(() => {
     const terminalId = pane?.terminal_id ?? null;
@@ -1268,7 +1300,8 @@ export function TerminalView({
     <section
       ref={stageRef}
       className="terminal-stage"
-      aria-label="Selected pane terminal"
+      aria-label={accessibilityLabel}
+      aria-current={selected ? "true" : undefined}
       onDragOverCapture={(event) => {
         if (event.dataTransfer.types.includes("Files")) {
           event.preventDefault();
@@ -1278,6 +1311,17 @@ export function TerminalView({
       onPasteCapture={handlePaste}
     >
       <div ref={hostRef} className="terminal-host" />
+      {pane && terminalScreenReaderText ? (
+        <div
+          className="terminal-accessible-screen sr-only"
+          role="region"
+          tabIndex={-1}
+          aria-label={`${accessibilityLabel} screen contents`}
+          aria-live="off"
+        >
+          {accessibleScreen}
+        </div>
+      ) : null}
       <input
         ref={fileInputRef}
         className="terminal-file-input"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -91,6 +91,10 @@
   border: 0;
 }
 
+.terminal-accessible-screen {
+  white-space: pre-wrap;
+}
+
 html,
 body,
 #root {

--- a/web/src/terminalAccessibleText.test.ts
+++ b/web/src/terminalAccessibleText.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  parseTerminalScreenReaderText,
+  terminalAccessibleText,
+  TerminalAccessibleTextPublisher,
+  type TerminalAccessibleViewport,
+} from "./terminalAccessibleText";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("terminal accessible text", () => {
+  it("reads only the visible bottom of the normal buffer", () => {
+    const terminal = fakeTerminal({
+      lines: ["old one", "old two", "visible one", "visible two"],
+      rows: 2,
+      cols: 16,
+    });
+
+    expect(terminalAccessibleText(terminal)).toBe("visible one\nvisible two");
+  });
+
+  it("reads the viewport when it is scrolled into normal-buffer scrollback", () => {
+    const terminal = fakeTerminal({
+      lines: ["old zero", "old one", "old two", "current one", "current two"],
+      rows: 2,
+      cols: 16,
+      viewportY: 2,
+    });
+
+    expect(terminalAccessibleText(terminal)).toBe("old one\nold two");
+  });
+
+  it("reads the active alternate buffer without applying normal scrollback offset", () => {
+    const terminal = fakeTerminal({
+      lines: ["editor header", "editor body"],
+      rows: 2,
+      cols: 16,
+      type: "alternate",
+      viewportY: 50,
+    });
+
+    expect(terminalAccessibleText(terminal)).toBe("editor header\neditor body");
+  });
+
+  it("preserves Unicode and meaningful blank rows while trimming screen padding", () => {
+    const terminal = fakeTerminal({
+      lines: ["naïve 👩", "", "done   ", "   "],
+      rows: 4,
+      cols: 16,
+      graphemes: { "0:6": "👩‍💻" },
+    });
+
+    expect(terminalAccessibleText(terminal)).toBe("naïve 👩‍💻\n\ndone");
+  });
+
+  it("bounds rows and columns while retaining the newest viewport rows", () => {
+    const terminal = fakeTerminal({
+      lines: ["first row", "second row", "third row", "fourth row"],
+      rows: 4,
+      cols: 20,
+    });
+
+    expect(terminalAccessibleText(terminal, { maxRows: 2, maxColumns: 5 })).toBe(
+      "third\nfourt",
+    );
+  });
+
+  it("bounds text without splitting Unicode surrogate pairs", () => {
+    const terminal = fakeTerminal({
+      lines: ["older", "A😀BC"],
+      rows: 2,
+      cols: 12,
+    });
+
+    const text = terminalAccessibleText(terminal, { maxCharacters: 3 });
+    expect(text).toBe("😀BC");
+    expect(Array.from(text)).toHaveLength(3);
+    expect(text).not.toContain("�");
+  });
+
+  it("treats blank cells as spaces and drops trailing blank rows", () => {
+    const terminal = fakeTerminal({
+      lines: ["left  right", "value", ""],
+      rows: 3,
+      cols: 16,
+    });
+
+    expect(terminalAccessibleText(terminal)).toBe("left  right\nvalue");
+  });
+
+  it("does not expose concealed terminal cells", () => {
+    const terminal = fakeTerminal({
+      lines: ["public secret value"],
+      rows: 1,
+      cols: 19,
+      invisibleCells: ["0:7", "0:8", "0:9", "0:10", "0:11", "0:12"],
+    });
+
+    expect(terminalAccessibleText(terminal)).toBe("public        value");
+    expect(terminalAccessibleText(terminal)).not.toContain("secret");
+  });
+
+  it("parses the persisted opt-in setting conservatively", () => {
+    expect(parseTerminalScreenReaderText(true)).toBe(true);
+    expect(parseTerminalScreenReaderText(false, true)).toBe(false);
+    expect(parseTerminalScreenReaderText("true")).toBe(false);
+    expect(parseTerminalScreenReaderText(undefined, true)).toBe(true);
+  });
+});
+
+describe("terminal accessible text publisher", () => {
+  it("debounces requests and publishes only changed snapshots", () => {
+    vi.useFakeTimers();
+    let text = "first";
+    const read = vi.fn(() => text);
+    const publish = vi.fn();
+    const publisher = new TerminalAccessibleTextPublisher(read, publish, 160);
+
+    publisher.request();
+    publisher.request();
+    vi.advanceTimersByTime(159);
+    expect(read).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(publish).toHaveBeenCalledWith("first");
+
+    publisher.request();
+    vi.advanceTimersByTime(160);
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    text = "second";
+    publisher.request(0);
+    vi.runOnlyPendingTimers();
+    expect(publish).toHaveBeenLastCalledWith("second");
+  });
+
+  it("cancels pending snapshot work when disposed", () => {
+    vi.useFakeTimers();
+    const read = vi.fn(() => "text");
+    const publish = vi.fn();
+    const publisher = new TerminalAccessibleTextPublisher(read, publish, 160);
+
+    publisher.request();
+    publisher.dispose();
+    vi.runAllTimers();
+
+    expect(read).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
+  });
+});
+
+type FakeTerminalOptions = {
+  lines: string[];
+  rows: number;
+  cols: number;
+  type?: "normal" | "alternate";
+  viewportY?: number;
+  graphemes?: Record<string, string>;
+  invisibleCells?: readonly string[];
+};
+
+function fakeTerminal({
+  lines,
+  rows,
+  cols,
+  type = "normal",
+  viewportY = 0,
+  graphemes = {},
+  invisibleCells = [],
+}: FakeTerminalOptions): TerminalAccessibleViewport {
+  const invisibleCellSet = new Set(invisibleCells);
+  const bufferLines = lines.map((line, row) =>
+    fakeLine(line, cols, row, graphemes, invisibleCellSet),
+  );
+  return {
+    rows,
+    cols,
+    buffer: {
+      active: {
+        type,
+        length: bufferLines.length,
+        viewportY,
+        getLine(row: number) {
+          return bufferLines[row];
+        },
+      },
+    },
+    getViewportY: () => viewportY,
+    readGrapheme: (_bufferType, row, column) => graphemes[`${row}:${column}`] ?? null,
+  };
+}
+
+function fakeLine(
+  value: string,
+  columns: number,
+  row: number,
+  graphemes: Record<string, string>,
+  invisibleCells: ReadonlySet<string>,
+) {
+  const characters = Array.from(value);
+  return {
+    length: columns,
+    getCell(column: number) {
+      const character = characters[column] ?? "";
+      return {
+        cell: { grapheme_len: graphemes[`${row}:${column}`] ? 1 : 0 },
+        getChars: () => character,
+        getCodepoint: () => character.codePointAt(0) ?? 0,
+        getWidth: () => 1,
+        isInvisible: () => invisibleCells.has(`${row}:${column}`),
+      };
+    },
+  };
+}

--- a/web/src/terminalAccessibleText.ts
+++ b/web/src/terminalAccessibleText.ts
@@ -1,0 +1,238 @@
+export const DEFAULT_TERMINAL_SCREEN_READER_TEXT = false;
+export const TERMINAL_ACCESSIBLE_MAX_ROWS = 200;
+export const TERMINAL_ACCESSIBLE_MAX_COLUMNS = 500;
+export const TERMINAL_ACCESSIBLE_MAX_CHARACTERS = 32_000;
+
+type TerminalAccessibleCell = {
+  getChars?: () => string;
+  getCodepoint?: () => number;
+  getWidth?: () => number;
+  isInvisible?: () => boolean | number;
+  cell?: {
+    grapheme_len?: number;
+  };
+};
+
+type TerminalAccessibleLine = {
+  readonly length: number;
+  getCell(column: number): TerminalAccessibleCell | undefined;
+};
+
+type TerminalAccessibleBuffer = {
+  readonly type: "normal" | "alternate";
+  readonly length: number;
+  readonly viewportY?: number;
+  getLine(row: number): TerminalAccessibleLine | undefined;
+};
+
+export type TerminalAccessibleViewport = {
+  readonly rows: number;
+  readonly cols: number;
+  readonly buffer: {
+    readonly active: TerminalAccessibleBuffer;
+  };
+  getViewportY?: () => number;
+  readGrapheme?: (
+    bufferType: "normal" | "alternate",
+    row: number,
+    column: number,
+  ) => string | null;
+};
+
+export type TerminalAccessibleTextOptions = {
+  maxRows?: number;
+  maxColumns?: number;
+  maxCharacters?: number;
+};
+
+/** Returns the active terminal viewport as bounded, screen-reader-safe plain text. */
+export function terminalAccessibleText(
+  terminal: TerminalAccessibleViewport,
+  options: TerminalAccessibleTextOptions = {},
+) {
+  const buffer = terminal.buffer.active;
+  const terminalRows = nonNegativeInteger(terminal.rows);
+  const bufferLength = nonNegativeInteger(buffer.length);
+  const viewportRows = Math.min(terminalRows, bufferLength);
+  const maxRows = normalizedLimit(options.maxRows, TERMINAL_ACCESSIBLE_MAX_ROWS);
+  const rowsToRead = Math.min(viewportRows, maxRows);
+  const maxColumns = normalizedLimit(options.maxColumns, TERMINAL_ACCESSIBLE_MAX_COLUMNS);
+  const columnsToRead = Math.min(nonNegativeInteger(terminal.cols), maxColumns);
+
+  if (rowsToRead === 0 || columnsToRead === 0) {
+    return "";
+  }
+
+  const maxViewportOffset = Math.max(0, bufferLength - viewportRows);
+  const requestedViewportOffset =
+    buffer.type === "alternate"
+      ? 0
+      : nonNegativeInteger(terminal.getViewportY?.() ?? buffer.viewportY ?? 0);
+  const viewportOffset = Math.min(requestedViewportOffset, maxViewportOffset);
+  const viewportStart = Math.max(0, bufferLength - viewportRows - viewportOffset);
+  const firstRow = viewportStart + viewportRows - rowsToRead;
+  const endRow = viewportStart + viewportRows;
+  const lines: string[] = [];
+
+  for (let row = firstRow; row < endRow; row += 1) {
+    lines.push(
+      terminalAccessibleLineText(
+        buffer.getLine(row),
+        columnsToRead,
+        row,
+        buffer.type,
+        terminal.readGrapheme,
+      ),
+    );
+  }
+  while (lines.at(-1) === "") {
+    lines.pop();
+  }
+
+  return newestBoundedLines(
+    lines,
+    normalizedLimit(options.maxCharacters, TERMINAL_ACCESSIBLE_MAX_CHARACTERS),
+  );
+}
+
+export function parseTerminalScreenReaderText(value: unknown, fallback = false) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export class TerminalAccessibleTextPublisher {
+  readonly #readText: () => string | null;
+  readonly #publish: (text: string) => void;
+  readonly #delayMs: number;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+  #lastText: string | null = null;
+  #disposed = false;
+
+  constructor(readText: () => string | null, publish: (text: string) => void, delayMs: number) {
+    this.#readText = readText;
+    this.#publish = publish;
+    this.#delayMs = Math.max(0, delayMs);
+  }
+
+  request(delayMs = this.#delayMs) {
+    if (this.#disposed || this.#timer !== null) {
+      return;
+    }
+    this.#timer = setTimeout(() => {
+      this.#timer = null;
+      if (this.#disposed) {
+        return;
+      }
+      const text = this.#readText();
+      if (text !== null && text !== this.#lastText) {
+        this.#lastText = text;
+        this.#publish(text);
+      }
+    }, Math.max(0, delayMs));
+  }
+
+  dispose() {
+    this.#disposed = true;
+    if (this.#timer !== null) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+  }
+}
+
+function terminalAccessibleLineText(
+  line: TerminalAccessibleLine | undefined,
+  maxColumns: number,
+  row: number,
+  bufferType: "normal" | "alternate",
+  readGrapheme: TerminalAccessibleViewport["readGrapheme"],
+) {
+  if (!line) {
+    return "";
+  }
+  const columns = Math.min(nonNegativeInteger(line.length), maxColumns);
+  let text = "";
+  for (let column = 0; column < columns; column += 1) {
+    const cell = line.getCell(column);
+    const width = cell?.getWidth?.() ?? 1;
+    if (cell?.isInvisible?.()) {
+      if (width !== 0) {
+        text += " ";
+      }
+      continue;
+    }
+    const graphemeLength = cell?.cell?.grapheme_len ?? 0;
+    const chars =
+      (graphemeLength > 0 ? readGrapheme?.(bufferType, row, column) : null) ??
+      terminalCellCharacters(cell);
+    if (chars.length === 0) {
+      if (width !== 0) {
+        text += " ";
+      }
+      continue;
+    }
+    text += visibleCharacters(chars);
+  }
+  return text.trimEnd();
+}
+
+function terminalCellCharacters(cell: TerminalAccessibleCell | undefined) {
+  if (!cell) {
+    return "";
+  }
+  const chars = cell.getChars?.();
+  if (typeof chars === "string") {
+    return chars;
+  }
+  const codepoint = cell.getCodepoint?.() ?? 0;
+  if (
+    !Number.isInteger(codepoint) ||
+    codepoint <= 0 ||
+    codepoint > 0x10ffff ||
+    (codepoint >= 0xd800 && codepoint <= 0xdfff)
+  ) {
+    return "";
+  }
+  return String.fromCodePoint(codepoint);
+}
+
+function visibleCharacters(value: string) {
+  let result = "";
+  for (const character of value) {
+    const codepoint = character.codePointAt(0) ?? 0;
+    result += codepoint < 32 || codepoint === 127 ? " " : character;
+  }
+  return result;
+}
+
+function newestBoundedLines(lines: readonly string[], maxCharacters: number) {
+  if (maxCharacters === 0 || lines.length === 0) {
+    return "";
+  }
+
+  const retained: string[] = [];
+  let remaining = maxCharacters;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const lineCharacters = Array.from(lines[index]);
+    const separatorCharacters = retained.length > 0 ? 1 : 0;
+    if (lineCharacters.length + separatorCharacters <= remaining) {
+      retained.unshift(lines[index]);
+      remaining -= lineCharacters.length + separatorCharacters;
+      continue;
+    }
+    if (retained.length === 0 && remaining > 0) {
+      retained.unshift(lineCharacters.slice(-remaining).join(""));
+    }
+    break;
+  }
+  return retained.join("\n");
+}
+
+function nonNegativeInteger(value: number) {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function normalizedLimit(value: number | undefined, fallback: number) {
+  return value === undefined || !Number.isFinite(value)
+    ? fallback
+    : Math.max(0, Math.floor(value));
+}

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -11,6 +11,10 @@ import { terminalLoupeCursorGeometry } from "./terminalLoupeCursorGeometry";
 import { terminalTapFocusAction } from "./terminalTapFocus";
 import type { TerminalTapFocusResult } from "./terminalTapFocus";
 import {
+  terminalAccessibleText,
+  TerminalAccessibleTextPublisher,
+} from "./terminalAccessibleText";
+import {
   beginTouchSelectionEndpointDrag,
   commitTouchSelectionStart,
   completeTouchSelection,
@@ -57,6 +61,7 @@ const TOUCH_LOUPE_TARGET_OFFSET_Y_PX = 48;
 const TOUCH_ENDPOINT_HIT_WIDTH_PX = 72;
 const TOUCH_ENDPOINT_HIT_HEIGHT_PX = 72;
 const TOUCH_ENDPOINT_RING_DIAMETER_PX = 42;
+const TERMINAL_ACCESSIBLE_SCREEN_DEBOUNCE_MS = 160;
 const TAP_URL_PATTERN = /\bhttps?:\/\/[^\s"'<>`]+/giu;
 
 type GhosttyModule = typeof import("ghostty-web");
@@ -105,8 +110,10 @@ type TerminalBufferLine = {
   getCell(x: number):
     | {
         getCodepoint(): number;
+        getChars(): string;
         getWidth(): number;
         getHyperlinkId(): number;
+        isInvisible(): number;
         // Raw ghostty cell data; grapheme_len > 0 marks a multi-codepoint cluster.
         cell?: { grapheme_len?: number };
       }
@@ -120,6 +127,7 @@ export type MobileTerminalTouchEvent =
 export type TerminalRenderer = {
   mount(container: HTMLElement): Promise<TerminalSize>;
   write(data: string | Uint8Array): void;
+  setAccessibleScreenListener(callback: ((text: string) => void) | null): void;
   onInput(callback: (data: string) => void): () => void;
   onScroll(callback: (lines: number) => void): () => void;
   setTapFocusHandler(callback: (() => TerminalTapFocusResult) | null): void;
@@ -147,6 +155,9 @@ export class GhosttyRenderer implements TerminalRenderer {
   #touchCleanup: (() => void) | null = null;
   #mobileInputCleanup: (() => void) | null = null;
   #imeFocusCleanup: (() => void) | null = null;
+  #accessibleScreenCallback: ((text: string) => void) | null = null;
+  #accessibleScreenCleanup: (() => void) | null = null;
+  #accessibleScreenPublisher: TerminalAccessibleTextPublisher | null = null;
   #tapFocusHandler: (() => TerminalTapFocusResult) | null = null;
   #mobileLongPressBehavior: MobileLongPressBehavior = "off";
   #mobileTouchSelectionHandler: ((event: MobileTerminalTouchEvent) => void) | null = null;
@@ -222,6 +233,7 @@ export class GhosttyRenderer implements TerminalRenderer {
     terminal.renderer?.getCanvas().style.setProperty("image-rendering", "auto");
     this.#terminal = terminal;
     this.#fitAddon = fitAddon;
+    this.#installAccessibleScreenPublisher();
     this.#installScrollHandlers();
     this.#installMobileInputBridge();
     this.#installImeFocusRedirect();
@@ -229,7 +241,27 @@ export class GhosttyRenderer implements TerminalRenderer {
   }
 
   write(data: string | Uint8Array) {
-    this.#terminal?.write(data);
+    const terminal = this.#terminal;
+    if (!terminal) {
+      return;
+    }
+    if (!this.#accessibleScreenPublisher) {
+      terminal.write(data);
+      return;
+    }
+    terminal.write(data, () => {
+      if (this.#isCurrentTerminal(terminal)) {
+        this.#accessibleScreenPublisher?.request();
+      }
+    });
+  }
+
+  setAccessibleScreenListener(callback: ((text: string) => void) | null) {
+    if (this.#accessibleScreenCallback === callback) {
+      return;
+    }
+    this.#accessibleScreenCallback = callback;
+    this.#installAccessibleScreenPublisher();
   }
 
   onInput(callback: (data: string) => void) {
@@ -267,6 +299,7 @@ export class GhosttyRenderer implements TerminalRenderer {
   fit() {
     const terminal = this.#requireTerminal();
     this.#fitAddon?.fit();
+    this.#accessibleScreenPublisher?.request();
     return {
       cols: terminal.cols,
       rows: terminal.rows,
@@ -331,6 +364,8 @@ export class GhosttyRenderer implements TerminalRenderer {
     this.#mobileInputCleanup = null;
     this.#imeFocusCleanup?.();
     this.#imeFocusCleanup = null;
+    this.#accessibleScreenCallback = null;
+    this.#disposeAccessibleScreenPublisher();
     this.#fitAddon?.dispose();
     this.#fitAddon = null;
     this.#terminal?.dispose();
@@ -347,6 +382,48 @@ export class GhosttyRenderer implements TerminalRenderer {
 
   #isCurrentTerminal(terminal: Terminal) {
     return this.#terminal === terminal;
+  }
+
+  #installAccessibleScreenPublisher() {
+    this.#disposeAccessibleScreenPublisher();
+    const terminal = this.#terminal;
+    const callback = this.#accessibleScreenCallback;
+    if (!terminal || !callback || this.#disposed) {
+      return;
+    }
+
+    const publisher = new TerminalAccessibleTextPublisher(
+      () => {
+        if (!this.#isCurrentTerminal(terminal)) {
+          return null;
+        }
+        try {
+          return terminalAccessibleScreenText(terminal);
+        } catch (error) {
+          if (!isGhosttyDisposedError(error)) {
+            console.warn("terminal accessible screen snapshot skipped", error);
+          }
+          return null;
+        }
+      },
+      callback,
+      TERMINAL_ACCESSIBLE_SCREEN_DEBOUNCE_MS,
+    );
+    const scrollDisposable = terminal.onScroll(() => publisher.request());
+    const bufferDisposable = terminal.buffer.onBufferChange(() => publisher.request());
+    this.#accessibleScreenPublisher = publisher;
+    this.#accessibleScreenCleanup = () => {
+      scrollDisposable.dispose();
+      bufferDisposable.dispose();
+    };
+    publisher.request(0);
+  }
+
+  #disposeAccessibleScreenPublisher() {
+    this.#accessibleScreenCleanup?.();
+    this.#accessibleScreenCleanup = null;
+    this.#accessibleScreenPublisher?.dispose();
+    this.#accessibleScreenPublisher = null;
   }
 
   #hasMouseTracking(terminal: Terminal) {
@@ -1522,6 +1599,35 @@ function terminalBufferRow(terminal: Terminal, viewportRow: number) {
   const scrollbackLength = terminal.getScrollbackLength();
   const viewportY = Math.max(0, Math.floor(terminal.getViewportY()));
   return scrollbackLength + viewportRow - viewportY;
+}
+
+function terminalAccessibleScreenText(terminal: Terminal) {
+  return terminalAccessibleText({
+    rows: terminal.rows,
+    cols: terminal.cols,
+    buffer: terminal.buffer,
+    getViewportY: () => terminal.getViewportY(),
+    readGrapheme: (bufferType, row, column) => {
+      const wasmTerm = terminal.wasmTerm;
+      if (!wasmTerm) {
+        return null;
+      }
+      if (bufferType === "alternate") {
+        return typeof wasmTerm.getGraphemeString === "function"
+          ? wasmTerm.getGraphemeString(row, column)
+          : null;
+      }
+      const scrollbackLength = terminal.getScrollbackLength();
+      if (row < scrollbackLength) {
+        return typeof wasmTerm.getScrollbackGraphemeString === "function"
+          ? wasmTerm.getScrollbackGraphemeString(row, column)
+          : null;
+      }
+      return typeof wasmTerm.getGraphemeString === "function"
+        ? wasmTerm.getGraphemeString(row - scrollbackLength, column)
+        : null;
+    },
+  });
 }
 
 function selectTerminalViewportRange(


### PR DESCRIPTION
Adds an opt-in terminal viewport mirror for assistive technology under Settings → Terminal. It defaults off, performs no snapshot work while disabled, bounds and debounces enabled updates, and filters concealed cells.

Based on the accessibility concept proposed by shuv (@shuv1337) in #37, reimplemented against current main without the unrelated iOS, bridge, or safe-area changes.

Validation: npm run check; iterative claude-default review clean.