### PR TITLE
Refresh vendored Herdr compat to v0.8.2 / protocol 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The bridge now requires Herdr `v0.8.2` or newer reporting terminal protocol `20`. Herdr
   `v0.8.0` and `v0.8.1` daemons (protocol `19`) are rejected at startup.
+  [PR #69](https://github.com/kcosr/herdr-web/pull/69)
 
 ### Added
 
@@ -14,6 +15,7 @@
 - Refreshed the vendored Herdr compatibility sources to the `v0.8.2`/protocol `20` baseline.
   The new protocol `20` server message variants (`TerminalBell`, `GraphicsFile`,
   `GraphicsTransmissionRetired`) decode but are ignored by the bridge, adding no new behavior.
+  [PR #69](https://github.com/kcosr/herdr-web/pull/69)
 - Compress terminal output with gzip when the client and bridge both support it.
   [PR #59](https://github.com/kcosr/herdr-web/pull/59)
 - Changed the Attention agent sort to break ties within an attention band by the most recent agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@
 
 ### Breaking Changes
 
+- The bridge now requires Herdr `v0.8.2` or newer reporting terminal protocol `20`. Herdr
+  `v0.8.0` and `v0.8.1` daemons (protocol `19`) are rejected at startup.
+
 ### Added
 
 ### Changed
 
+- Refreshed the vendored Herdr compatibility sources to the `v0.8.2`/protocol `20` baseline.
+  The new protocol `20` server message variants (`TerminalBell`, `GraphicsFile`,
+  `GraphicsTransmissionRetired`) decode but are ignored by the bridge, adding no new behavior.
 - Compress terminal output with gzip when the client and bridge both support it.
   [PR #59](https://github.com/kcosr/herdr-web/pull/59)
 - Changed the Attention agent sort to break ties within an attention band by the most recent agent

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The top-level scripts hide that detail.
 
 For release tarball users:
 
-- A running Herdr `v0.8.0` or newer daemon/session that reports terminal protocol `19`
+- A running Herdr `v0.8.2` or newer daemon/session that reports terminal protocol `20`
 - A supported host for the downloaded bridge tarball. Current planned desktop release artifacts are
   Linux x86_64, macOS ARM64, and macOS x86_64.
 
@@ -78,7 +78,7 @@ For source development:
 - Node.js 22 or newer
 - npm
 - Rust stable
-- A running Herdr `v0.8.0` or newer daemon/session that reports terminal protocol `19`
+- A running Herdr `v0.8.2` or newer daemon/session that reports terminal protocol `20`
 
 Android development also needs a JDK and Android SDK. See [docs/android.md](docs/android.md).
 
@@ -100,7 +100,7 @@ http://127.0.0.1:8787
 ```
 
 The desktop tarball includes the web assets and `herdr-web-bridge`; it does not include Herdr.
-Start or attach Herdr `v0.8.0` or newer with terminal protocol `19` separately before running the
+Start or attach Herdr `v0.8.2` or newer with terminal protocol `20` separately before running the
 bridge.
 
 For Android, install the APK from the same release and add the bridge URL in the Bridge area of
@@ -274,7 +274,7 @@ an agent command. This preserves wrappers, SSH commands, containers, and other e
 
 ## Run Locally
 
-Start or attach a normal Herdr `v0.8.0` or newer session with terminal protocol `19` first:
+Start or attach a normal Herdr `v0.8.2` or newer session with terminal protocol `20` first:
 
 ```bash
 herdr
@@ -425,7 +425,7 @@ local `vendor/herdr-compat` crate for copied Herdr protocol/schema/client/socket
 bridge HTTP/WebSocket behavior in `bridge/src/web_bridge.rs`. A separate upstream Herdr checkout can
 be used for refreshes and drift audits, but a full `vendor/herdr` snapshot is not part of this repo.
 The cost is that `vendor/herdr-compat` must be kept compatible with Herdr protocol changes.
-The current compatibility baseline is Herdr `v0.8.0` and terminal protocol `19`; the bridge requires
+The current compatibility baseline is Herdr `v0.8.2` and terminal protocol `20`; the bridge requires
 that exact protocol rather than attempting to decode older or newer private wire formats.
 
 See [docs/vendoring.md](docs/vendoring.md) for the refresh process.

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -63,8 +63,8 @@ const DEFAULT_PORT: u16 = 8787;
 const DEFAULT_COLS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
 const DEFAULT_STATIC_DIR: &str = "web/dist";
-const MIN_HERDR_VERSION: (u64, u64, u64) = (0, 8, 0);
-const MIN_HERDR_VERSION_LABEL: &str = "0.8.0";
+const MIN_HERDR_VERSION: (u64, u64, u64) = (0, 8, 2);
+const MIN_HERDR_VERSION_LABEL: &str = "0.8.2";
 const MAX_UPLOAD_BYTES: usize = 25 * 1024 * 1024;
 const MAX_NOTES_REQUEST_BYTES: usize = 512 * 1024;
 const MAX_TERMINAL_INPUT_CHUNK_BYTES: usize = 768 * 1024;
@@ -4407,7 +4407,10 @@ fn open_terminal_attach(
                 | ServerMessage::KittyKeyboardReportAll { .. }
                 | ServerMessage::PrefixInputSource { .. }
                 | ServerMessage::Frame(_)
-                | ServerMessage::Graphics { .. } => {}
+                | ServerMessage::Graphics { .. }
+                | ServerMessage::TerminalBell { .. }
+                | ServerMessage::GraphicsFile { .. }
+                | ServerMessage::GraphicsTransmissionRetired { .. } => {}
             }
         }
         // By this point the Detach (if any) has been flushed and the socket
@@ -5377,7 +5380,7 @@ mod tests {
 
     fn test_session_snapshot() -> SessionSnapshot {
         SessionSnapshot {
-            version: "0.8.0".to_string(),
+            version: "0.8.2".to_string(),
             protocol: PROTOCOL_VERSION,
             focused_workspace_id: Some("workspace-1".to_string()),
             focused_tab_id: Some("tab-1".to_string()),
@@ -6035,7 +6038,7 @@ mod tests {
     #[test]
     fn daemon_status_accepts_minimum_version_and_exact_protocol() {
         assert_eq!(
-            validated_daemon_protocol(runtime_status("0.8.0", PROTOCOL_VERSION)).unwrap(),
+            validated_daemon_protocol(runtime_status("0.8.2", PROTOCOL_VERSION)).unwrap(),
             PROTOCOL_VERSION
         );
         assert_eq!(
@@ -6081,7 +6084,7 @@ mod tests {
 
     #[test]
     fn daemon_status_accepts_version_prefix_and_build_metadata() {
-        for version in ["v0.8.0", "0.8.0+linux-x86-64"] {
+        for version in ["v0.8.2", "0.8.2+linux-x86-64"] {
             assert_eq!(
                 validated_daemon_protocol(runtime_status(version, PROTOCOL_VERSION)).unwrap(),
                 PROTOCOL_VERSION
@@ -6090,12 +6093,17 @@ mod tests {
     }
 
     #[test]
-    fn daemon_status_rejects_version_before_0_8_0() {
-        let error = validated_daemon_protocol(runtime_status("0.7.5", PROTOCOL_VERSION))
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("too old"));
-        assert!(error.contains(MIN_HERDR_VERSION_LABEL));
+    fn daemon_status_rejects_version_before_0_8_2() {
+        for version in ["0.7.5", "0.8.0", "0.8.1"] {
+            let error = validated_daemon_protocol(runtime_status(version, PROTOCOL_VERSION))
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("too old"), "{version:?}: {error}");
+            assert!(
+                error.contains(MIN_HERDR_VERSION_LABEL),
+                "{version:?}: {error}"
+            );
+        }
     }
 
     #[test]
@@ -6113,14 +6121,14 @@ mod tests {
 
     #[test]
     fn daemon_status_rejects_any_other_protocol() {
-        let older = validated_daemon_protocol(runtime_status("0.8.0", PROTOCOL_VERSION - 1))
+        let older = validated_daemon_protocol(runtime_status("0.8.2", PROTOCOL_VERSION - 1))
             .unwrap_err()
             .to_string();
         assert!(older.contains("incompatible"));
         assert!(older.contains(&PROTOCOL_VERSION.to_string()));
 
         assert!(
-            validated_daemon_protocol(runtime_status("0.8.0", PROTOCOL_VERSION + 1))
+            validated_daemon_protocol(runtime_status("0.8.2", PROTOCOL_VERSION + 1))
                 .unwrap_err()
                 .to_string()
                 .contains("incompatible")

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -89,7 +89,7 @@ Confirm the archive contains the expected root directory, `bin/herdr-web`,
 `bin/herdr-web-bridge`, bundled `share/herdr-web/web/` assets, and `README.md`.
 
 Before release, run the unpacked wrapper against a Herdr `v0.8.2` or newer daemon reporting protocol
-`19`. Confirm the bridge accepts that combination and rejects a daemon reporting any other terminal
+`20`. Confirm the bridge accepts that combination and rejects a daemon reporting any other terminal
 protocol. Complete the launcher checks in [docs/release.md](release.md) with the packaged bridge, not
 only a development build.
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -2,8 +2,8 @@
 
 `herdr-web` ships as separate desktop bridge/web tarballs and an Android APK.
 
-The desktop tarball does not include Herdr itself. Users still need a running Herdr `v0.8.0` or
-newer session or daemon that reports terminal protocol `19`; the bundled bridge connects to the
+The desktop tarball does not include Herdr itself. Users still need a running Herdr `v0.8.2` or
+newer session or daemon that reports terminal protocol `20`; the bundled bridge connects to the
 normal Herdr socket.
 
 ## Release Artifacts
@@ -88,7 +88,7 @@ cat dist-packages/herdr-web-vX.Y.Z-PLATFORM.tar.gz.sha256
 Confirm the archive contains the expected root directory, `bin/herdr-web`,
 `bin/herdr-web-bridge`, bundled `share/herdr-web/web/` assets, and `README.md`.
 
-Before release, run the unpacked wrapper against a Herdr `v0.8.0` or newer daemon reporting protocol
+Before release, run the unpacked wrapper against a Herdr `v0.8.2` or newer daemon reporting protocol
 `19`. Confirm the bridge accepts that combination and rejects a daemon reporting any other terminal
 protocol. Complete the launcher checks in [docs/release.md](release.md) with the packaged bridge, not
 only a development build.
@@ -127,7 +127,7 @@ dist-packages/herdr-web-vX.Y.Z-android.apk
 
 ## User Quick Start From Tarball
 
-Start or attach Herdr `v0.8.0` or newer with terminal protocol `19` first:
+Start or attach Herdr `v0.8.2` or newer with terminal protocol `20` first:
 
 ```bash
 herdr

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,7 +10,7 @@ They do not publish npm packages, and the package versions are not release versi
 - Rust stable.
 - JDK 21 and Android SDK when validating the Android shell.
 - GitHub CLI authenticated as a user that can create releases.
-- A local Herdr `v0.8.0` or newer session reporting terminal protocol `19` for browser and packaged
+- A local Herdr `v0.8.2` or newer session reporting terminal protocol `20` for browser and packaged
   bridge smoke testing.
 
 ## Prepare
@@ -96,7 +96,7 @@ dist-packages/herdr-web-vX.Y.Z-android.apk
 
 ## Browser Smoke
 
-Start or attach a Herdr `v0.8.0` or newer session reporting terminal protocol `19`:
+Start or attach a Herdr `v0.8.2` or newer session reporting terminal protocol `20`:
 
 ```bash
 herdr

--- a/docs/release.md
+++ b/docs/release.md
@@ -125,7 +125,7 @@ Open `http://127.0.0.1:8787` and verify:
 - Binding to `HOST=0.0.0.0` is only used on a trusted network.
 
 Repeat the startup, terminal attach, and launcher checks with an unpacked desktop tarball before
-uploading it. Confirm the bridge rejects every protocol other than `19`
+uploading it. Confirm the bridge rejects every protocol other than `20`
 instead of serving a partially compatible UI.
 
 ## Cut

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -2,8 +2,8 @@
 
 This bundle contains the `herdr-web` browser UI assets and the `herdr-web-bridge` executable.
 
-It does not include Herdr itself. Start or attach a Herdr `v0.8.0` or newer session that reports
-terminal protocol `19` separately before running this bundle.
+It does not include Herdr itself. Start or attach a Herdr `v0.8.2` or newer session that reports
+terminal protocol `20` separately before running this bundle.
 
 ## Run
 

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -143,7 +143,7 @@ the refit button after changing browser sizes.
 ## Compatibility Policy
 
 The bridge pings Herdr's status API at startup and requires Herdr `v0.8.2` or newer with daemon
-protocol exactly `19`. Older daemons and any unreviewed newer protocol are rejected before serving
+protocol exactly `20`. Older daemons and any unreviewed newer protocol are rejected before serving
 the web app. The version floor covers the private JSON API shape, including the managed
 `agent.start` contract; the exact protocol check protects the copied bincode terminal wire format.
 This is not a complete stability guarantee because the bridge mirrors private APIs.

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -32,8 +32,8 @@ The browser app is not vendored into Herdr. It lives at `web/`, and `herdr-web-b
 ## Current Reference
 
 - Upstream checkout: a clean Herdr source checkout outside this repository
-- Upstream release baseline: `v0.8.0`
-- Terminal wire baseline: protocol `19`
+- Upstream release baseline: `v0.8.2`
+- Terminal wire baseline: protocol `20`
 
 Use the upstream checkout as an external reference for audits and refreshes. It is not required to
 build `herdr-web`.
@@ -62,7 +62,7 @@ bridge narrows the drift check to only the terminal attach message regions.
 
 ## Refresh Process
 
-Use a clean Herdr checkout at the reviewed `v0.8.0` release tag as the source reference. Do not
+Use a clean Herdr checkout at the reviewed `v0.8.2` release tag as the source reference. Do not
 refresh from an experimental tree that may contain unrelated local drift. Copy the reviewed
 upstream source files into the minimal compatibility crate; do not make the bridge compile against
 the external checkout or recreate a full upstream vendor snapshot.
@@ -142,7 +142,7 @@ the refit button after changing browser sizes.
 
 ## Compatibility Policy
 
-The bridge pings Herdr's status API at startup and requires Herdr `v0.8.0` or newer with daemon
+The bridge pings Herdr's status API at startup and requires Herdr `v0.8.2` or newer with daemon
 protocol exactly `19`. Older daemons and any unreviewed newer protocol are rejected before serving
 the web app. The version floor covers the private JSON API shape, including the managed
 `agent.start` contract; the exact protocol check protects the copied bincode terminal wire format.

--- a/vendor/herdr-compat/src/protocol.rs
+++ b/vendor/herdr-compat/src/protocol.rs
@@ -8,7 +8,7 @@ mod bridge_fixture_tests {
 
     #[test]
     fn protocol_version_matches_reviewed_herdr_snapshot() {
-        assert_eq!(PROTOCOL_VERSION, 19);
+        assert_eq!(PROTOCOL_VERSION, 20);
     }
 
     #[test]
@@ -26,7 +26,7 @@ mod bridge_fixture_tests {
         let mut frame = Vec::new();
         write_message(&mut frame, &msg).unwrap();
 
-        assert_eq!(frame, vec![9, 0, 0, 0, 0, 19, 80, 24, 8, 16, 0, 0, 1]);
+        assert_eq!(frame, vec![9, 0, 0, 0, 0, 20, 80, 24, 8, 16, 0, 0, 2]);
         let decoded: ClientMessage = read_message(&mut frame.as_slice(), MAX_FRAME_SIZE).unwrap();
         assert_eq!(decoded, msg);
     }
@@ -41,7 +41,7 @@ mod bridge_fixture_tests {
         let mut frame = Vec::new();
         write_message(&mut frame, &msg).unwrap();
 
-        assert_eq!(frame, vec![4, 0, 0, 0, 0, 19, 1, 0]);
+        assert_eq!(frame, vec![4, 0, 0, 0, 0, 20, 1, 0]);
         let decoded: ServerMessage = read_message(&mut frame.as_slice(), MAX_FRAME_SIZE).unwrap();
         assert_eq!(decoded, msg);
     }

--- a/vendor/herdr-compat/src/protocol/wire.rs
+++ b/vendor/herdr-compat/src/protocol/wire.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Current protocol version. Bumped when wire format changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 19;
+pub const PROTOCOL_VERSION: u32 = 20;
 
 /// Maximum allowed frame payload size (2 MB). Frames larger than this are
 /// rejected to prevent denial-of-service via oversized length prefixes.
@@ -57,6 +57,8 @@ pub enum ClientKeybindings {
 pub enum ClientLaunchMode {
     /// Full app client.
     App,
+    /// Full app client eligible for audited local direct graphics.
+    AppDirectGraphics,
     /// Direct terminal attach client.
     TerminalAttach,
 }
@@ -428,6 +430,25 @@ pub enum ClientMessage {
         /// Replace an existing writable controller for this terminal.
         takeover: bool,
     },
+
+    /// Result of the one armed Herdr-owned direct Kitty transmission.
+    GraphicsTransmissionResult {
+        transfer_id: u64,
+        image_id: u32,
+        success: bool,
+    },
+
+    /// One confirmed SGR 1016 mouse report with read-time host geometry.
+    InputPixels {
+        data: Vec<u8>,
+        cols: u16,
+        rows: u16,
+        width_px: u32,
+        height_px: u32,
+    },
+
+    /// The direct command was written and flushed; terminal response timing starts now.
+    GraphicsTransmissionStarted { transfer_id: u64, image_id: u32 },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -696,6 +717,8 @@ pub enum ServerMessage {
     MouseCapture {
         /// True when Herdr mouse UI is enabled or the focused pane app requests mouse reporting.
         enabled: bool,
+        /// True only while the focused pane requests DEC SGR pixel mode 1016.
+        sgr_pixels: bool,
     },
 
     /// Whether the focused terminal requests Kitty report-all keyboard input.
@@ -711,6 +734,25 @@ pub enum ServerMessage {
         /// Whether the ASCII input source should be active.
         active: bool,
     },
+
+    /// Ring the foreground client's outer terminal for pane-originated BEL characters.
+    TerminalBell {
+        /// Number of BEL characters parsed from one PTY read.
+        count: u16,
+    },
+
+    /// One validated Herdr-owned Kitty regular-file RGBA transmission.
+    GraphicsFile {
+        path: String,
+        expected_len: u64,
+        image_id: u32,
+        transfer_id: u64,
+        leading: Vec<u8>,
+        control: String,
+    },
+
+    /// Suppress a direct command that expired before terminal delivery.
+    GraphicsTransmissionRetired { transfer_id: u64, image_id: u32 },
 }
 
 // ---------------------------------------------------------------------------
@@ -1142,7 +1184,7 @@ mod tests {
             ],
         };
         let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
-        // Freeze the protocol 19 input envelope before it is published.
+        // Freeze the protocol 20 input envelope before it is published.
         assert_eq!(
             encoded,
             vec![
@@ -1528,7 +1570,10 @@ mod tests {
 
     #[test]
     fn server_mouse_capture_roundtrip() {
-        let msg = ServerMessage::MouseCapture { enabled: true };
+        let msg = ServerMessage::MouseCapture {
+            enabled: true,
+            sgr_pixels: true,
+        };
         let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
         let (decoded, _): (ServerMessage, _) =
             bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
@@ -1545,6 +1590,44 @@ mod tests {
     }
 
     #[test]
+    fn direct_graphics_messages_roundtrip() {
+        let client = ClientMessage::GraphicsTransmissionResult {
+            transfer_id: 7,
+            image_id: 42,
+            success: false,
+        };
+        let encoded = bincode::serde::encode_to_vec(&client, bincode::config::standard()).unwrap();
+        let (decoded, _): (ClientMessage, _) =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
+        assert_eq!(client, decoded);
+
+        let server = ServerMessage::GraphicsFile {
+            path: "/run/user/1000/herdr/source/frame".into(),
+            expected_len: 4,
+            image_id: 42,
+            transfer_id: 7,
+            leading: b"\x1b[2;3H".to_vec(),
+            control: "a=T,f=32,i=42,q=0".into(),
+        };
+        let encoded = bincode::serde::encode_to_vec(&server, bincode::config::standard()).unwrap();
+        let (decoded, _): (ServerMessage, _) =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
+        assert_eq!(server, decoded);
+
+        let pixels = ClientMessage::InputPixels {
+            data: b"\x1b[<35;321;241M".to_vec(),
+            cols: 80,
+            rows: 24,
+            width_px: 800,
+            height_px: 480,
+        };
+        let encoded = bincode::serde::encode_to_vec(&pixels, bincode::config::standard()).unwrap();
+        let (decoded, _): (ClientMessage, _) =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
+        assert_eq!(pixels, decoded);
+    }
+
+    #[test]
     fn server_prefix_input_source_roundtrip() {
         for active in [true, false] {
             let msg = ServerMessage::PrefixInputSource { active };
@@ -1553,6 +1636,15 @@ mod tests {
                 bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
             assert_eq!(msg, decoded);
         }
+    }
+
+    #[test]
+    fn server_terminal_bell_roundtrip() {
+        let msg = ServerMessage::TerminalBell { count: 3 };
+        let encoded = bincode::serde::encode_to_vec(&msg, bincode::config::standard()).unwrap();
+        let (decoded, _): (ServerMessage, _) =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::standard()).unwrap();
+        assert_eq!(msg, decoded);
     }
 
     // ---- Framing ----


### PR DESCRIPTION
Herdr v0.8.2 moved the terminal wire protocol from 19 to 20, and the
bridge pins protocol 19 exactly — so it rejects 0.8.2 daemons at startup.

- Vendored wire.rs is now byte-identical to the upstream v0.8.2 tag
  (sha256-verified), including the new protocol 20 message variants at
  their exact upstream enum positions.
- Bridge requires Herdr v0.8.2+ / protocol 20 (was 0.8.0 / 19); the new
  server message variants decode but are ignored, adding no behavior.
- Wire fixtures, docs, and changelog updated to the new baseline.

Breaking: Herdr v0.8.0/v0.8.1 daemons are now rejected at startup.

Tested: npm run check (306 web, 116 compat, 139 bridge tests, builds).