### PR TITLE
Preserve original upload filenames with de-duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Uploads now keep their original filename and de-duplicate on a collision: re-uploading
   `image.png` into a directory that already has one lands as `image-1.png` instead of failing
   with a conflict. `?overwrite=true` remains the only way to replace an existing file.
+  [PR #77](https://github.com/kcosr/herdr-web/pull/77), contributed by
+  [Trillium Smith (@trillium)](https://github.com/trillium).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ### Changed
 
+- Uploads now keep their original filename and de-duplicate on a collision: re-uploading
+  `image.png` into a directory that already has one lands as `image-1.png` instead of failing
+  with a conflict. `?overwrite=true` remains the only way to replace an existing file.
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@
 
 ### Changed
 
-- Uploads now keep their original filename and de-duplicate on a collision: re-uploading
-  `image.png` into a directory that already has one lands as `image-1.png` instead of failing
-  with a conflict. `?overwrite=true` remains the only way to replace an existing file.
+- Upload conflicts are now atomically de-duplicated by default: re-uploading `image.png` lands as
+  `image-1.png` instead of prompting to replace the original, including when uploads race. Turn off
+  automatic conflict renaming under Settings → Terminal → Uploads to keep the Replace or Cancel
+  prompt. Existing files are replaced only after explicit confirmation.
   [PR #77](https://github.com/kcosr/herdr-web/pull/77), contributed by
   [Trillium Smith (@trillium)](https://github.com/trillium).
 

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ Settings are grouped by area:
 - Features: client feature toggles such as Notes.
 - Display: browser-wide navigation synchronization, agent features in Tabs, multi-host Space
   selection, top/bottom app padding, and mobile terminal controls size.
-- Terminal: font size, optional screen-reader text, browser-to-bridge transport, and input/output
-  batching delays.
+- Terminal: font size, optional screen-reader text, upload-conflict behavior, browser-to-bridge
+  transport, and input/output batching delays.
 - Mobile: touch-specific terminal behavior when running on a coarse pointer device.
 
 When viewing all of multiple hosts, use the Spaces list `…` menu to group spaces by host or keep a
@@ -208,6 +208,10 @@ Terminal screen-reader text is off by default. Enable it under Settings → Term
 visible terminal viewport as bounded plain text for assistive technology. The mirror follows output,
 scrolling, resizing, and alternate-screen changes, and replaces concealed terminal cells with
 spaces. Disable it when screen-reader access is not needed to avoid the additional snapshot work.
+
+Automatic upload conflict renaming is on by default. If `image.png` already exists, another upload
+is saved as `image-1.png` without a replacement prompt. Turn it off under Settings → Terminal →
+Uploads to keep the existing Replace or Cancel prompt instead.
 
 ## Launcher Presets
 

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -707,6 +707,7 @@ enum BridgeError {
 enum UploadError {
     BadRequest(String),
     Conflict { name: String, path: String },
+    NameExhausted(String),
     Forbidden(String),
     TooLarge,
     Io(io::Error),
@@ -786,6 +787,15 @@ impl IntoResponse for UploadError {
                     "error": "file exists",
                     "name": name,
                     "path": path,
+                }),
+            ),
+            Self::NameExhausted(name) => (
+                StatusCode::CONFLICT,
+                serde_json::json!({
+                    "error": format!(
+                        "no available filename for {name} after {MAX_UPLOAD_NAME_ATTEMPTS} attempts"
+                    ),
+                    "name": name,
                 }),
             ),
             Self::Forbidden(message) => (
@@ -1338,14 +1348,58 @@ fn upload_name_candidate(name: &str, attempt: u32) -> String {
     }
 }
 
-/// Preserve the uploader's original filename while never clobbering an earlier
-/// upload: return `name` when it is free, otherwise the first `name-N.ext`
-/// variant `is_taken` reports as free. Returns `None` when every candidate is
-/// taken.
-fn unique_upload_file_name(name: &str, mut is_taken: impl FnMut(&str) -> bool) -> Option<String> {
-    (0..MAX_UPLOAD_NAME_ATTEMPTS)
-        .map(|attempt| upload_name_candidate(name, attempt))
-        .find(|candidate| !is_taken(candidate))
+/// Atomically reserve and write a new upload. When rename conflicts is enabled,
+/// an occupied candidate advances to the next suffix without a separate
+/// filesystem scan, so concurrent uploads cannot select the same free name.
+async fn create_new_upload(
+    upload_dir: &Path,
+    requested_name: &str,
+    body: &[u8],
+    rename_conflicts: bool,
+) -> Result<(String, PathBuf), UploadError> {
+    let attempts = if rename_conflicts {
+        MAX_UPLOAD_NAME_ATTEMPTS
+    } else {
+        1
+    };
+    for attempt in 0..attempts {
+        let name = upload_name_candidate(requested_name, attempt);
+        let destination = upload_dir.join(&name);
+        if !is_direct_child(upload_dir, &destination) {
+            return Err(UploadError::BadRequest("invalid file name".to_string()));
+        }
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&destination)
+            .await
+        {
+            Ok(mut file) => {
+                use tokio::io::AsyncWriteExt;
+
+                if let Err(err) = async {
+                    file.write_all(body).await?;
+                    file.flush().await
+                }
+                .await
+                {
+                    drop(file);
+                    let _ = tokio::fs::remove_file(&destination).await;
+                    return Err(UploadError::Io(err));
+                }
+                return Ok((name, destination));
+            }
+            Err(err) if err.kind() == ErrorKind::AlreadyExists && rename_conflicts => continue,
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                return Err(UploadError::Conflict {
+                    name,
+                    path: destination.display().to_string(),
+                });
+            }
+            Err(err) => return Err(UploadError::Io(err)),
+        }
+    }
+    Err(UploadError::NameExhausted(requested_name.to_string()))
 }
 
 fn generated_upload_name(mime: Option<&str>) -> String {
@@ -1802,6 +1856,8 @@ struct UploadQuery {
     name: Option<String>,
     #[serde(default)]
     overwrite: bool,
+    #[serde(default)]
+    rename_conflicts: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -2797,80 +2853,35 @@ async fn upload_handler(
         bytes = body.len(),
         mime = ?mime,
         overwrite = query.overwrite,
+        rename_conflicts = query.rename_conflicts,
         "herdr-web-bridge upload request"
     );
     let requested_name = match query.name.as_deref().and_then(sanitize_upload_file_name) {
         Some(name) => name,
         None => generated_upload_name(mime.as_deref()),
     };
-    // Keep the uploader's original filename. When it is already taken, save
-    // alongside the earlier file under a de-duplicated name
-    // (`notes.txt` -> `notes-1.txt`) rather than reporting a conflict;
-    // `overwrite=true` stays the only way to replace an existing upload.
-    let name = if query.overwrite {
-        requested_name
-    } else {
-        let upload_dir = &state.upload_dir;
-        let unique = unique_upload_file_name(&requested_name, |candidate| {
-            upload_dir.join(candidate).symlink_metadata().is_ok()
-        });
-        match unique {
-            Some(name) => name,
-            None => {
-                return Err(UploadError::Conflict {
-                    path: upload_dir.join(&requested_name).display().to_string(),
-                    name: requested_name,
-                })
-            }
-        }
-    };
-    let destination = state.upload_dir.join(&name);
-    if !is_direct_child(&state.upload_dir, &destination) {
-        return Err(UploadError::BadRequest("invalid file name".to_string()));
-    }
-
     tokio::fs::create_dir_all(&state.upload_dir).await?;
-    let existing = tokio::fs::symlink_metadata(&destination).await.ok();
-    if let Some(existing) = existing {
-        // Only reachable when another upload claimed the de-duplicated name
-        // between selection and this check; the client can retry.
-        if !query.overwrite {
-            info!(
-                name = %name,
-                "herdr-web-bridge upload conflict"
-            );
-            return Err(UploadError::Conflict {
-                name,
-                path: destination.display().to_string(),
-            });
-        }
-        if existing.file_type().is_symlink() || existing.is_dir() {
-            return Err(UploadError::BadRequest(
-                "refusing to overwrite non-file path".to_string(),
-            ));
-        }
-    }
-
-    if !query.overwrite {
-        match tokio::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&destination)
-            .await
-        {
-            Ok(mut file) => {
-                tokio::io::AsyncWriteExt::write_all(&mut file, &body).await?;
-                tokio::io::AsyncWriteExt::flush(&mut file).await?;
-            }
-            Err(err) if err.kind() == ErrorKind::AlreadyExists => {
-                return Err(UploadError::Conflict {
-                    name,
-                    path: destination.display().to_string(),
-                });
-            }
-            Err(err) => return Err(UploadError::Io(err)),
-        }
+    let (name, destination) = if !query.overwrite {
+        create_new_upload(
+            &state.upload_dir,
+            &requested_name,
+            &body,
+            query.rename_conflicts,
+        )
+        .await?
     } else {
+        let name = requested_name;
+        let destination = state.upload_dir.join(&name);
+        if !is_direct_child(&state.upload_dir, &destination) {
+            return Err(UploadError::BadRequest("invalid file name".to_string()));
+        }
+        if let Some(existing) = tokio::fs::symlink_metadata(&destination).await.ok() {
+            if existing.file_type().is_symlink() || existing.is_dir() {
+                return Err(UploadError::BadRequest(
+                    "refusing to overwrite non-file path".to_string(),
+                ));
+            }
+        }
         let temp_path = state.upload_dir.join(format!(
             ".herdr-web-upload-{}-{}.tmp",
             std::process::id(),
@@ -2887,7 +2898,8 @@ async fn upload_handler(
                 return Err(UploadError::Io(err));
             }
         }
-    }
+        (name, destination)
+    };
 
     let response = UploadResponse {
         file: UploadEntry {
@@ -6695,57 +6707,17 @@ mod tests {
     }
 
     #[test]
-    fn unique_upload_file_name_keeps_original_when_free() {
+    fn upload_name_candidates_preserve_extensions() {
         assert_eq!(
-            unique_upload_file_name("screen shot.png", |_| false).as_deref(),
-            Some("screen shot.png")
+            upload_name_candidate("screen shot.png", 0),
+            "screen shot.png"
         );
-    }
-
-    #[test]
-    fn unique_upload_file_name_suffixes_taken_names() {
-        let taken: HashSet<&str> = ["image.png", "image-1.png"].into_iter().collect();
+        assert_eq!(upload_name_candidate("image.png", 2), "image-2.png");
+        assert_eq!(upload_name_candidate("notes", 1), "notes-1");
         assert_eq!(
-            unique_upload_file_name("image.png", |candidate| taken.contains(candidate)).as_deref(),
-            Some("image-2.png")
+            upload_name_candidate("archive.tar.gz", 1),
+            "archive.tar-1.gz"
         );
-    }
-
-    #[test]
-    fn unique_upload_file_name_suffixes_names_without_extension() {
-        let taken: HashSet<&str> = ["notes"].into_iter().collect();
-        assert_eq!(
-            unique_upload_file_name("notes", |candidate| taken.contains(candidate)).as_deref(),
-            Some("notes-1")
-        );
-    }
-
-    #[test]
-    fn unique_upload_file_name_suffixes_before_the_last_extension() {
-        let taken: HashSet<&str> = ["archive.tar.gz"].into_iter().collect();
-        assert_eq!(
-            unique_upload_file_name("archive.tar.gz", |candidate| taken.contains(candidate))
-                .as_deref(),
-            Some("archive.tar-1.gz")
-        );
-    }
-
-    #[test]
-    fn unique_upload_file_name_gives_up_when_every_candidate_is_taken() {
-        assert_eq!(unique_upload_file_name("image.png", |_| true), None);
-    }
-
-    #[test]
-    fn unique_upload_file_name_repeats_produce_distinct_names() {
-        let mut taken: HashSet<String> = HashSet::new();
-        let mut names = Vec::new();
-        for _ in 0..3 {
-            let name = unique_upload_file_name("image.png", |candidate| taken.contains(candidate))
-                .expect("name available");
-            taken.insert(name.clone());
-            names.push(name);
-        }
-        assert_eq!(names, vec!["image.png", "image-1.png", "image-2.png"]);
     }
 
     #[test]
@@ -6782,7 +6754,7 @@ mod tests {
     }
 
     #[test]
-    fn unique_upload_file_name_keeps_traversal_attempts_inside_upload_dir() {
+    fn upload_name_candidates_keep_sanitized_names_inside_upload_dir() {
         let upload_dir = PathBuf::from("/tmp/herdr-web/uploads");
         for hostile in [
             "../secret.txt",
@@ -6793,10 +6765,7 @@ mod tests {
         ] {
             let sanitized =
                 sanitize_upload_file_name(hostile).unwrap_or_else(|| panic!("{hostile} sanitized"));
-            // Force the de-duplication path too: the suffix must not reopen an escape.
-            let taken: HashSet<String> = [sanitized.clone()].into_iter().collect();
-            let unique = unique_upload_file_name(&sanitized, |candidate| taken.contains(candidate))
-                .expect("name available");
+            let unique = upload_name_candidate(&sanitized, 1);
             assert_ne!(
                 unique, sanitized,
                 "{hostile} should have been de-duplicated"
@@ -6810,27 +6779,89 @@ mod tests {
         }
     }
 
-    #[test]
-    fn unique_upload_file_name_does_not_reuse_a_name_already_on_disk() {
-        let dir =
-            std::env::temp_dir().join(format!("herdr-web-upload-name-test-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        // The predicate the upload handler uses, against a real directory.
-        let taken = |candidate: &str| dir.join(candidate).symlink_metadata().is_ok();
+    #[tokio::test]
+    async fn create_new_upload_preserves_existing_files_and_renames_conflicts() {
+        let dir = upload_test_dir("rename");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
 
-        let first = unique_upload_file_name("image.png", taken).unwrap();
-        assert_eq!(first, "image.png");
-        std::fs::write(dir.join(&first), b"first").unwrap();
+        let (first, _) = create_new_upload(&dir, "image.png", b"first", true)
+            .await
+            .unwrap();
+        let (second, _) = create_new_upload(&dir, "image.png", b"second", true)
+            .await
+            .unwrap();
+        let (third, _) = create_new_upload(&dir, "image.png", b"third", true)
+            .await
+            .unwrap();
 
-        let second = unique_upload_file_name("image.png", taken).unwrap();
-        assert_eq!(second, "image-1.png");
-        std::fs::write(dir.join(&second), b"second").unwrap();
+        assert_eq!(
+            [first, second, third],
+            ["image.png", "image-1.png", "image-2.png"]
+        );
+        assert_eq!(
+            tokio::fs::read(dir.join("image.png")).await.unwrap(),
+            b"first"
+        );
+        assert_eq!(
+            tokio::fs::read(dir.join("image-1.png")).await.unwrap(),
+            b"second"
+        );
+        assert_eq!(
+            tokio::fs::read(dir.join("image-2.png")).await.unwrap(),
+            b"third"
+        );
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
 
-        assert_eq!(std::fs::read(dir.join("image.png")).unwrap(), b"first");
-        assert_eq!(std::fs::read(dir.join("image-1.png")).unwrap(), b"second");
+    #[tokio::test]
+    async fn create_new_upload_returns_conflict_when_renaming_is_disabled() {
+        let dir = upload_test_dir("prompt");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("image.png"), b"first")
+            .await
+            .unwrap();
 
-        let _ = std::fs::remove_dir_all(&dir);
+        let err = create_new_upload(&dir, "image.png", b"second", false)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            UploadError::Conflict { ref name, .. } if name == "image.png"
+        ));
+        assert_eq!(
+            tokio::fs::read(dir.join("image.png")).await.unwrap(),
+            b"first"
+        );
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_uploads_atomically_reserve_distinct_names() {
+        let dir = upload_test_dir("concurrent");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let first = create_new_upload(&dir, "image.png", b"first", true);
+        let second = create_new_upload(&dir, "image.png", b"second", true);
+        let (first, second) = tokio::join!(first, second);
+        let mut names = [first.unwrap().0, second.unwrap().0];
+        names.sort();
+
+        assert_eq!(names, ["image-1.png", "image.png"]);
+        let mut contents = [
+            tokio::fs::read(dir.join("image.png")).await.unwrap(),
+            tokio::fs::read(dir.join("image-1.png")).await.unwrap(),
+        ];
+        contents.sort();
+        assert_eq!(contents, [b"first".to_vec(), b"second".to_vec()]);
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    fn upload_test_dir(label: &str) -> PathBuf {
+        let suffix = UPLOAD_TEMP_COUNTER.fetch_add(1, Ordering::AcqRel);
+        std::env::temp_dir().join(format!(
+            "herdr-web-upload-{label}-{}-{suffix}",
+            std::process::id()
+        ))
     }
 
     #[test]

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -1308,6 +1308,46 @@ fn finalize_upload_file_name(name: String) -> Option<String> {
     }
 }
 
+/// How many `name-N.ext` variants to try before giving up on de-duplicating an
+/// upload. Deep enough for real usage, bounded so a pathological upload
+/// directory cannot spin the handler forever.
+const MAX_UPLOAD_NAME_ATTEMPTS: u32 = 1000;
+
+/// Split a sanitized upload name into stem and extension. `sanitize_upload_file_name`
+/// strips leading and trailing dots, so a dotfile (`.bashrc`) never reaches
+/// here with an empty stem.
+fn split_upload_name_extension(name: &str) -> Option<(&str, &str)> {
+    let (stem, extension) = name.rsplit_once('.')?;
+    if stem.is_empty() || extension.is_empty() {
+        return None;
+    }
+    Some((stem, extension))
+}
+
+/// The `attempt`-th candidate for `name`: attempt 0 is the original filename,
+/// later attempts suffix the stem (`notes.txt` -> `notes-1.txt`). The suffix
+/// never introduces a path separator, so a candidate stays a direct child of
+/// the upload directory whenever `name` was.
+fn upload_name_candidate(name: &str, attempt: u32) -> String {
+    if attempt == 0 {
+        return name.to_string();
+    }
+    match split_upload_name_extension(name) {
+        Some((stem, extension)) => format!("{stem}-{attempt}.{extension}"),
+        None => format!("{name}-{attempt}"),
+    }
+}
+
+/// Preserve the uploader's original filename while never clobbering an earlier
+/// upload: return `name` when it is free, otherwise the first `name-N.ext`
+/// variant `is_taken` reports as free. Returns `None` when every candidate is
+/// taken.
+fn unique_upload_file_name(name: &str, mut is_taken: impl FnMut(&str) -> bool) -> Option<String> {
+    (0..MAX_UPLOAD_NAME_ATTEMPTS)
+        .map(|attempt| upload_name_candidate(name, attempt))
+        .find(|candidate| !is_taken(candidate))
+}
+
 fn generated_upload_name(mime: Option<&str>) -> String {
     let extension = upload_extension_for_mime(mime).unwrap_or("bin");
     let millis = std::time::SystemTime::now()
@@ -2759,9 +2799,30 @@ async fn upload_handler(
         overwrite = query.overwrite,
         "herdr-web-bridge upload request"
     );
-    let name = match query.name.as_deref().and_then(sanitize_upload_file_name) {
+    let requested_name = match query.name.as_deref().and_then(sanitize_upload_file_name) {
         Some(name) => name,
         None => generated_upload_name(mime.as_deref()),
+    };
+    // Keep the uploader's original filename. When it is already taken, save
+    // alongside the earlier file under a de-duplicated name
+    // (`notes.txt` -> `notes-1.txt`) rather than reporting a conflict;
+    // `overwrite=true` stays the only way to replace an existing upload.
+    let name = if query.overwrite {
+        requested_name
+    } else {
+        let upload_dir = &state.upload_dir;
+        let unique = unique_upload_file_name(&requested_name, |candidate| {
+            upload_dir.join(candidate).symlink_metadata().is_ok()
+        });
+        match unique {
+            Some(name) => name,
+            None => {
+                return Err(UploadError::Conflict {
+                    path: upload_dir.join(&requested_name).display().to_string(),
+                    name: requested_name,
+                })
+            }
+        }
     };
     let destination = state.upload_dir.join(&name);
     if !is_direct_child(&state.upload_dir, &destination) {
@@ -2771,6 +2832,8 @@ async fn upload_handler(
     tokio::fs::create_dir_all(&state.upload_dir).await?;
     let existing = tokio::fs::symlink_metadata(&destination).await.ok();
     if let Some(existing) = existing {
+        // Only reachable when another upload claimed the de-duplicated name
+        // between selection and this check; the client can retry.
         if !query.overwrite {
             info!(
                 name = %name,
@@ -6629,6 +6692,145 @@ mod tests {
             upload_extension_for_mime(Some("application/octet-stream")),
             None
         );
+    }
+
+    #[test]
+    fn unique_upload_file_name_keeps_original_when_free() {
+        assert_eq!(
+            unique_upload_file_name("screen shot.png", |_| false).as_deref(),
+            Some("screen shot.png")
+        );
+    }
+
+    #[test]
+    fn unique_upload_file_name_suffixes_taken_names() {
+        let taken: HashSet<&str> = ["image.png", "image-1.png"].into_iter().collect();
+        assert_eq!(
+            unique_upload_file_name("image.png", |candidate| taken.contains(candidate)).as_deref(),
+            Some("image-2.png")
+        );
+    }
+
+    #[test]
+    fn unique_upload_file_name_suffixes_names_without_extension() {
+        let taken: HashSet<&str> = ["notes"].into_iter().collect();
+        assert_eq!(
+            unique_upload_file_name("notes", |candidate| taken.contains(candidate)).as_deref(),
+            Some("notes-1")
+        );
+    }
+
+    #[test]
+    fn unique_upload_file_name_suffixes_before_the_last_extension() {
+        let taken: HashSet<&str> = ["archive.tar.gz"].into_iter().collect();
+        assert_eq!(
+            unique_upload_file_name("archive.tar.gz", |candidate| taken.contains(candidate))
+                .as_deref(),
+            Some("archive.tar-1.gz")
+        );
+    }
+
+    #[test]
+    fn unique_upload_file_name_gives_up_when_every_candidate_is_taken() {
+        assert_eq!(unique_upload_file_name("image.png", |_| true), None);
+    }
+
+    #[test]
+    fn unique_upload_file_name_repeats_produce_distinct_names() {
+        let mut taken: HashSet<String> = HashSet::new();
+        let mut names = Vec::new();
+        for _ in 0..3 {
+            let name = unique_upload_file_name("image.png", |candidate| taken.contains(candidate))
+                .expect("name available");
+            taken.insert(name.clone());
+            names.push(name);
+        }
+        assert_eq!(names, vec!["image.png", "image-1.png", "image-2.png"]);
+    }
+
+    #[test]
+    fn upload_file_name_sanitization_rejects_traversal_segments() {
+        for hostile in [
+            "../secret.txt",
+            "../../../etc/passwd",
+            r"..\..\windows\system.ini",
+            "uploads/../../secret.txt",
+            "/etc/passwd",
+            r"C:\Windows\win.ini",
+            "nested/dir/report.pdf",
+            "trailing/dots/../evil.txt.",
+        ] {
+            let sanitized =
+                sanitize_upload_file_name(hostile).unwrap_or_else(|| panic!("{hostile} sanitized"));
+            assert!(
+                !sanitized.contains('/') && !sanitized.contains('\\'),
+                "{hostile} -> {sanitized} kept a separator"
+            );
+            assert_ne!(sanitized, "..", "{hostile} stayed a traversal segment");
+        }
+    }
+
+    #[test]
+    fn upload_file_name_sanitization_rejects_pure_traversal_names() {
+        for hostile in ["..", "../", "../..", r"..\", "...", "/", "", "   "] {
+            assert_eq!(
+                sanitize_upload_file_name(hostile),
+                None,
+                "{hostile} should have no usable file name"
+            );
+        }
+    }
+
+    #[test]
+    fn unique_upload_file_name_keeps_traversal_attempts_inside_upload_dir() {
+        let upload_dir = PathBuf::from("/tmp/herdr-web/uploads");
+        for hostile in [
+            "../secret.txt",
+            "../../../etc/passwd",
+            r"..\..\windows\system.ini",
+            "uploads/../../secret.txt",
+            "/etc/passwd",
+        ] {
+            let sanitized =
+                sanitize_upload_file_name(hostile).unwrap_or_else(|| panic!("{hostile} sanitized"));
+            // Force the de-duplication path too: the suffix must not reopen an escape.
+            let taken: HashSet<String> = [sanitized.clone()].into_iter().collect();
+            let unique = unique_upload_file_name(&sanitized, |candidate| taken.contains(candidate))
+                .expect("name available");
+            assert_ne!(
+                unique, sanitized,
+                "{hostile} should have been de-duplicated"
+            );
+            let destination = upload_dir.join(&unique);
+            assert!(
+                is_direct_child(&upload_dir, &destination),
+                "{hostile} -> {} escaped the upload directory",
+                destination.display()
+            );
+        }
+    }
+
+    #[test]
+    fn unique_upload_file_name_does_not_reuse_a_name_already_on_disk() {
+        let dir =
+            std::env::temp_dir().join(format!("herdr-web-upload-name-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // The predicate the upload handler uses, against a real directory.
+        let taken = |candidate: &str| dir.join(candidate).symlink_metadata().is_ok();
+
+        let first = unique_upload_file_name("image.png", taken).unwrap();
+        assert_eq!(first, "image.png");
+        std::fs::write(dir.join(&first), b"first").unwrap();
+
+        let second = unique_upload_file_name("image.png", taken).unwrap();
+        assert_eq!(second, "image-1.png");
+        std::fs::write(dir.join(&second), b"second").unwrap();
+
+        assert_eq!(std::fs::read(dir.join("image.png")).unwrap(), b"first");
+        assert_eq!(std::fs::read(dir.join("image-1.png")).unwrap(), b"second");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -1391,6 +1391,10 @@ async fn create_new_upload(
             }
             Err(err) if err.kind() == ErrorKind::AlreadyExists && rename_conflicts => continue,
             Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                info!(
+                    name = %name,
+                    "herdr-web-bridge upload conflict"
+                );
                 return Err(UploadError::Conflict {
                     name,
                     path: destination.display().to_string(),
@@ -2875,7 +2879,7 @@ async fn upload_handler(
         if !is_direct_child(&state.upload_dir, &destination) {
             return Err(UploadError::BadRequest("invalid file name".to_string()));
         }
-        if let Some(existing) = tokio::fs::symlink_metadata(&destination).await.ok() {
+        if let Ok(existing) = tokio::fs::symlink_metadata(&destination).await {
             if existing.file_type().is_symlink() || existing.is_dir() {
                 return Err(UploadError::BadRequest(
                     "refusing to overwrite non-file path".to_string(),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -162,6 +162,10 @@ import {
   parseTerminalFontSizePx,
 } from "./terminalPrefs";
 import {
+  DEFAULT_AUTO_RENAME_UPLOAD_CONFLICTS,
+  parseAutoRenameUploadConflicts,
+} from "./uploadPrefs";
+import {
   aggregateStatus,
   basename,
   canClearTabName,
@@ -412,6 +416,7 @@ type DisplayPrefs = {
   sidebarOpen: boolean;
   terminalFontSizePx: number;
   terminalScreenReaderText: boolean;
+  autoRenameUploadConflicts: boolean;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
   terminalOutputCoalesceMs: number;
@@ -476,6 +481,7 @@ function readDisplayPrefs(): DisplayPrefs {
     sidebarOpen: true,
     terminalFontSizePx: DEFAULT_TERMINAL_FONT_SIZE_PX,
     terminalScreenReaderText: DEFAULT_TERMINAL_SCREEN_READER_TEXT,
+    autoRenameUploadConflicts: DEFAULT_AUTO_RENAME_UPLOAD_CONFLICTS,
     terminalInputTransport: DEFAULT_TERMINAL_INPUT_TRANSPORT,
     terminalInputBatchDelayMs: DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
     terminalOutputCoalesceMs: DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
@@ -674,6 +680,10 @@ function parseDisplayPrefsValue(
     terminalScreenReaderText: parseTerminalScreenReaderText(
       parsed.terminalScreenReaderText,
       fallback.terminalScreenReaderText,
+    ),
+    autoRenameUploadConflicts: parseAutoRenameUploadConflicts(
+      parsed.autoRenameUploadConflicts,
+      fallback.autoRenameUploadConflicts,
     ),
     terminalInputTransport: parseTerminalInputTransport(parsed.terminalInputTransport),
     terminalInputBatchDelayMs: parseTerminalInputBatchDelayMs(parsed.terminalInputBatchDelayMs),
@@ -1053,6 +1063,9 @@ export function App() {
   const [terminalScreenReaderText, setTerminalScreenReaderText] = useState(
     initialPrefs.terminalScreenReaderText,
   );
+  const [autoRenameUploadConflicts, setAutoRenameUploadConflicts] = useState(
+    initialPrefs.autoRenameUploadConflicts,
+  );
   const [terminalInputTransport, setTerminalInputTransport] = useState(
     initialPrefs.terminalInputTransport,
   );
@@ -1181,6 +1194,7 @@ export function App() {
       setActiveWorkspacesByBridgeId(sharedNavigationPrefs.activeWorkspacesByBridgeId);
       setTerminalFontSizePx(prefs.terminalFontSizePx);
       setTerminalScreenReaderText(prefs.terminalScreenReaderText);
+      setAutoRenameUploadConflicts(prefs.autoRenameUploadConflicts);
       setTerminalInputTransport(prefs.terminalInputTransport);
       setTerminalInputBatchDelayMs(prefs.terminalInputBatchDelayMs);
       setTerminalOutputCoalesceMs(prefs.terminalOutputCoalesceMs);
@@ -1724,6 +1738,7 @@ export function App() {
       sidebarOpen,
       terminalFontSizePx,
       terminalScreenReaderText,
+      autoRenameUploadConflicts,
       terminalInputTransport,
       terminalInputBatchDelayMs,
       terminalOutputCoalesceMs,
@@ -1760,6 +1775,7 @@ export function App() {
     sidebarOpen,
     terminalFontSizePx,
     terminalScreenReaderText,
+    autoRenameUploadConflicts,
     terminalInputTransport,
     terminalInputBatchDelayMs,
     terminalOutputCoalesceMs,
@@ -4065,6 +4081,7 @@ export function App() {
             touchInput={isTouchInput}
             terminalFontSizePx={terminalFontSizePx}
             terminalScreenReaderText={terminalScreenReaderText}
+            autoRenameUploadConflicts={autoRenameUploadConflicts}
             mobileControlsScalePercent={mobileControlsScalePercent}
             mobileTapTarget={mobileTerminalTapTarget}
             mobileLongPressBehavior={mobileLongPressBehavior}
@@ -4092,6 +4109,7 @@ export function App() {
             cursorBlink={!isTouchInput}
             terminalFontSizePx={terminalFontSizePx}
             terminalScreenReaderText={terminalScreenReaderText}
+            autoRenameUploadConflicts={autoRenameUploadConflicts}
             mobileControlsScalePercent={mobileControlsScalePercent}
             mobileTapTarget={mobileTerminalTapTarget}
             mobileLongPressBehavior={mobileLongPressBehavior}
@@ -4330,6 +4348,8 @@ export function App() {
           onTerminalFontSizePx={setTerminalFontSizePx}
           terminalScreenReaderText={terminalScreenReaderText}
           onTerminalScreenReaderText={setTerminalScreenReaderText}
+          autoRenameUploadConflicts={autoRenameUploadConflicts}
+          onAutoRenameUploadConflicts={setAutoRenameUploadConflicts}
           terminalInputTransport={terminalInputTransport}
           onTerminalInputTransport={setTerminalInputTransport}
           terminalInputBatchDelayMs={terminalInputBatchDelayMs}
@@ -5795,6 +5815,7 @@ function SplitGrid({
   touchInput,
   terminalFontSizePx,
   terminalScreenReaderText,
+  autoRenameUploadConflicts,
   mobileControlsScalePercent,
   mobileTapTarget,
   mobileLongPressBehavior,
@@ -5817,6 +5838,7 @@ function SplitGrid({
   touchInput: boolean;
   terminalFontSizePx: number;
   terminalScreenReaderText: boolean;
+  autoRenameUploadConflicts: boolean;
   mobileControlsScalePercent: number;
   mobileTapTarget: MobileTerminalTapTarget;
   mobileLongPressBehavior: MobileLongPressBehavior;
@@ -5856,6 +5878,7 @@ function SplitGrid({
               cursorBlink={!touchInput}
               terminalFontSizePx={terminalFontSizePx}
               terminalScreenReaderText={terminalScreenReaderText}
+              autoRenameUploadConflicts={autoRenameUploadConflicts}
               mobileControlsScalePercent={mobileControlsScalePercent}
               mobileTapTarget={mobileTapTarget}
               mobileLongPressBehavior={mobileLongPressBehavior}

--- a/web/src/BackendSettingsDialog.test.tsx
+++ b/web/src/BackendSettingsDialog.test.tsx
@@ -71,6 +71,31 @@ describe("BackendSettingsDialog terminal accessibility", () => {
     expect(off?.getAttribute("aria-pressed")).toBe("false");
     expect(on?.getAttribute("aria-pressed")).toBe("true");
   });
+
+  it("allows automatic conflict renaming to be disabled in the Terminal area", async () => {
+    const onChange = vi.fn();
+    const { container } = await render(<UploadSettingsHarness onChange={onChange} />);
+    const terminalTab = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+    ).find((button) => button.textContent?.includes("Terminal"));
+    if (!terminalTab) {
+      throw new Error("missing Terminal settings tab");
+    }
+
+    await act(async () => terminalTab.click());
+    const group = requiredElement<HTMLElement>(
+      container,
+      '[role="group"][aria-label="Automatically rename conflicting uploads"]',
+    );
+    const [off, on] = Array.from(group.querySelectorAll<HTMLButtonElement>("button"));
+    expect(off?.getAttribute("aria-pressed")).toBe("false");
+    expect(on?.getAttribute("aria-pressed")).toBe("true");
+
+    await act(async () => off?.click());
+    expect(onChange).toHaveBeenCalledWith(false);
+    expect(off?.getAttribute("aria-pressed")).toBe("true");
+    expect(on?.getAttribute("aria-pressed")).toBe("false");
+  });
 });
 
 function SettingsHarness({ onChange }: { onChange: (enabled: boolean) => void }) {
@@ -82,6 +107,20 @@ function SettingsHarness({ onChange }: { onChange: (enabled: boolean) => void })
       onTerminalScreenReaderText={(enabled) => {
         onChange(enabled);
         setTerminalScreenReaderText(enabled);
+      }}
+    />
+  );
+}
+
+function UploadSettingsHarness({ onChange }: { onChange: (enabled: boolean) => void }) {
+  const [autoRenameUploadConflicts, setAutoRenameUploadConflicts] = useState(true);
+  return (
+    <BackendSettingsDialog
+      {...settingsProps()}
+      autoRenameUploadConflicts={autoRenameUploadConflicts}
+      onAutoRenameUploadConflicts={(enabled) => {
+        onChange(enabled);
+        setAutoRenameUploadConflicts(enabled);
       }}
     />
   );
@@ -104,6 +143,8 @@ function settingsProps() {
     onTerminalFontSizePx: vi.fn(),
     terminalScreenReaderText: false,
     onTerminalScreenReaderText: vi.fn(),
+    autoRenameUploadConflicts: true,
+    onAutoRenameUploadConflicts: vi.fn(),
     terminalInputTransport: "json" as const,
     onTerminalInputTransport: vi.fn(),
     terminalInputBatchDelayMs: 0,

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -74,6 +74,8 @@ type Props = {
   onTerminalFontSizePx: (value: number) => void;
   terminalScreenReaderText: boolean;
   onTerminalScreenReaderText: (enabled: boolean) => void;
+  autoRenameUploadConflicts: boolean;
+  onAutoRenameUploadConflicts: (enabled: boolean) => void;
   terminalInputTransport: TerminalInputTransport;
   onTerminalInputTransport: (transport: TerminalInputTransport) => void;
   terminalInputBatchDelayMs: number;
@@ -130,6 +132,8 @@ export function BackendSettingsDialog({
   onTerminalFontSizePx,
   terminalScreenReaderText,
   onTerminalScreenReaderText,
+  autoRenameUploadConflicts,
+  onAutoRenameUploadConflicts,
   terminalInputTransport,
   onTerminalInputTransport,
   terminalInputBatchDelayMs,
@@ -720,6 +724,34 @@ export function BackendSettingsDialog({
                       data-on={terminalScreenReaderText}
                       aria-pressed={terminalScreenReaderText}
                       onClick={() => onTerminalScreenReaderText(true)}
+                    >
+                      On
+                    </button>
+                  </div>
+                </div>
+                <div className="settings-label">Uploads</div>
+                <div className="settings-row">
+                  <span title="Add a numeric suffix when an uploaded filename already exists instead of asking whether to replace it">
+                    Automatically rename conflicts
+                  </span>
+                  <div
+                    className="segmented-control"
+                    role="group"
+                    aria-label="Automatically rename conflicting uploads"
+                  >
+                    <button
+                      type="button"
+                      data-on={!autoRenameUploadConflicts}
+                      aria-pressed={!autoRenameUploadConflicts}
+                      onClick={() => onAutoRenameUploadConflicts(false)}
+                    >
+                      Off
+                    </button>
+                    <button
+                      type="button"
+                      data-on={autoRenameUploadConflicts}
+                      aria-pressed={autoRenameUploadConflicts}
+                      onClick={() => onAutoRenameUploadConflicts(true)}
                     >
                       On
                     </button>

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -59,6 +59,11 @@ import type {
   MobileTouchSelectionEndpointTimeoutMs,
 } from "./mobileTerminalPrefs";
 import type { PaneInfo } from "./types";
+import {
+  UploadConflictError,
+  uploadWithOverwritePrompt,
+} from "./terminalUploads";
+import type { UploadCandidate, UploadedFile } from "./terminalUploads";
 
 type Props = {
   pane: PaneInfo | null;
@@ -100,22 +105,14 @@ type Props = {
   focusToken?: number;
   /** Whether to maintain a hidden plain-text mirror of the visible terminal viewport. */
   terminalScreenReaderText?: boolean;
+  /** Whether upload filename conflicts are resolved with a numeric suffix. */
+  autoRenameUploadConflicts?: boolean;
   /** Pane-specific accessible name for the terminal and its screen mirror. */
   accessibilityLabel?: string;
   /** Whether this is the currently selected terminal in a split. */
   selected?: boolean;
 };
 
-type UploadCandidate = {
-  blob: Blob;
-  name: string | null;
-};
-type UploadedFile = {
-  name: string;
-  path: string;
-  size: number;
-  mime?: string | null;
-};
 type UploadConflictState = {
   name: string;
   path: string;
@@ -167,6 +164,7 @@ export function TerminalView({
   refitToken = 0,
   focusToken = 0,
   terminalScreenReaderText = false,
+  autoRenameUploadConflicts = true,
   accessibilityLabel = "Terminal",
   selected = false,
 }: Props) {
@@ -1267,7 +1265,14 @@ export function TerminalView({
     try {
       const uploaded: UploadedFile[] = [];
       for (const file of uploadFiles) {
-        uploaded.push(await uploadWithOverwritePrompt(httpUrl, file, confirmUploadReplace));
+        uploaded.push(
+          await uploadWithOverwritePrompt(
+            httpUrl,
+            file,
+            autoRenameUploadConflicts,
+            confirmUploadReplace,
+          ),
+        );
       }
       if (
         connectionKeyRef.current !== uploadConnectionKey ||
@@ -1898,71 +1903,8 @@ function uploadCandidatesFromClipboard(data: DataTransfer): UploadCandidate[] {
   return files;
 }
 
-async function uploadWithOverwritePrompt(
-  httpUrl: (path: string, query?: URLSearchParams) => string,
-  file: UploadCandidate,
-  confirmReplace: (error: UploadConflictError) => Promise<boolean>,
-): Promise<UploadedFile> {
-  try {
-    return await uploadFile(httpUrl, file, false);
-  } catch (error) {
-    if (!(error instanceof UploadConflictError)) {
-      throw error;
-    }
-    const replace = await confirmReplace(error);
-    if (!replace) {
-      throw new Error("Upload canceled");
-    }
-    return uploadFile(httpUrl, file, true);
-  }
-}
-
 function uploadConflictMessage(conflict: UploadConflictState) {
   return conflict.path
     ? `${conflict.name} already exists at ${conflict.path}.`
     : `${conflict.name} already exists.`;
-}
-
-async function uploadFile(
-  httpUrl: (path: string, query?: URLSearchParams) => string,
-  file: UploadCandidate,
-  overwrite: boolean,
-): Promise<UploadedFile> {
-  const params = new URLSearchParams();
-  if (file.name) {
-    params.set("name", file.name);
-  }
-  if (overwrite) {
-    params.set("overwrite", "true");
-  }
-  const response = await fetch(httpUrl("/api/uploads", params), {
-    method: "POST",
-    headers: file.blob.type ? { "content-type": file.blob.type } : undefined,
-    body: file.blob,
-  });
-  const payload = (await response.json().catch(() => ({}))) as {
-    file?: UploadedFile;
-    error?: string;
-    name?: string;
-    path?: string;
-  };
-  if (response.status === 409) {
-    throw new UploadConflictError(
-      typeof payload.name === "string" ? payload.name : file.name || "file",
-      typeof payload.path === "string" ? payload.path : "",
-    );
-  }
-  if (!response.ok || !payload.file) {
-    throw new Error(payload.error || `Upload failed (${response.status})`);
-  }
-  return payload.file;
-}
-
-class UploadConflictError extends Error {
-  constructor(
-    readonly name: string,
-    readonly path: string,
-  ) {
-    super(`file exists: ${path || name}`);
-  }
 }

--- a/web/src/terminalUploads.test.ts
+++ b/web/src/terminalUploads.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { uploadWithOverwritePrompt } from "./terminalUploads";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("uploadWithOverwritePrompt", () => {
+  it("requests atomic conflict renaming when the setting is enabled", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(uploadResponse("image-1.png"));
+    vi.stubGlobal("fetch", fetchMock);
+    const confirmReplace = vi.fn();
+
+    const uploaded = await uploadWithOverwritePrompt(
+      testHttpUrl,
+      imageFile(),
+      true,
+      confirmReplace,
+    );
+
+    expect(uploaded.name).toBe("image-1.png");
+    expect(requestQuery(fetchMock)).toEqual({
+      name: "image.png",
+      rename_conflicts: "true",
+    });
+    expect(confirmReplace).not.toHaveBeenCalled();
+  });
+
+  it("keeps the Replace or Cancel prompt when automatic renaming is disabled", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(conflictResponse("image.png"))
+      .mockResolvedValueOnce(uploadResponse("image.png"));
+    vi.stubGlobal("fetch", fetchMock);
+    const confirmReplace = vi.fn().mockResolvedValue(true);
+
+    await uploadWithOverwritePrompt(testHttpUrl, imageFile(), false, confirmReplace);
+
+    expect(confirmReplace).toHaveBeenCalledOnce();
+    expect(requestQuery(fetchMock, 0)).toEqual({ name: "image.png" });
+    expect(requestQuery(fetchMock, 1)).toEqual({ name: "image.png", overwrite: "true" });
+  });
+
+  it("does not offer replacement when automatic suffixes are exhausted", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "no available filename for image.png" }), {
+        status: 409,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const confirmReplace = vi.fn();
+
+    await expect(
+      uploadWithOverwritePrompt(testHttpUrl, imageFile(), true, confirmReplace),
+    ).rejects.toThrow("no available filename for image.png");
+    expect(confirmReplace).not.toHaveBeenCalled();
+  });
+});
+
+function imageFile() {
+  return {
+    blob: new Blob(["image"], { type: "image/png" }),
+    name: "image.png",
+  };
+}
+
+function testHttpUrl(path: string, query?: URLSearchParams) {
+  const suffix = query && query.size > 0 ? `?${query}` : "";
+  return `http://bridge.test${path}${suffix}`;
+}
+
+function uploadResponse(name: string) {
+  return new Response(
+    JSON.stringify({
+      file: {
+        name,
+        path: `/uploads/${name}`,
+        size: 5,
+        mime: "image/png",
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function conflictResponse(name: string) {
+  return new Response(
+    JSON.stringify({ error: "file exists", name, path: `/uploads/${name}` }),
+    { status: 409, headers: { "content-type": "application/json" } },
+  );
+}
+
+function requestQuery(fetchMock: ReturnType<typeof vi.fn>, call = 0) {
+  const url = new URL(String(fetchMock.mock.calls[call]?.[0]));
+  return Object.fromEntries(url.searchParams.entries());
+}

--- a/web/src/terminalUploads.ts
+++ b/web/src/terminalUploads.ts
@@ -1,0 +1,78 @@
+export type UploadCandidate = {
+  blob: Blob;
+  name: string | null;
+};
+
+export type UploadedFile = {
+  name: string;
+  path: string;
+  size: number;
+  mime?: string | null;
+};
+
+export class UploadConflictError extends Error {
+  constructor(
+    readonly name: string,
+    readonly path: string,
+  ) {
+    super(`file exists: ${path || name}`);
+  }
+}
+
+export async function uploadWithOverwritePrompt(
+  httpUrl: (path: string, query?: URLSearchParams) => string,
+  file: UploadCandidate,
+  autoRenameConflicts: boolean,
+  confirmReplace: (error: UploadConflictError) => Promise<boolean>,
+): Promise<UploadedFile> {
+  try {
+    return await uploadFile(httpUrl, file, false, autoRenameConflicts);
+  } catch (error) {
+    if (!(error instanceof UploadConflictError)) {
+      throw error;
+    }
+    const replace = await confirmReplace(error);
+    if (!replace) {
+      throw new Error("Upload canceled");
+    }
+    return uploadFile(httpUrl, file, true, false);
+  }
+}
+
+async function uploadFile(
+  httpUrl: (path: string, query?: URLSearchParams) => string,
+  file: UploadCandidate,
+  overwrite: boolean,
+  renameConflicts: boolean,
+): Promise<UploadedFile> {
+  const params = new URLSearchParams();
+  if (file.name) {
+    params.set("name", file.name);
+  }
+  if (overwrite) {
+    params.set("overwrite", "true");
+  } else if (renameConflicts) {
+    params.set("rename_conflicts", "true");
+  }
+  const response = await fetch(httpUrl("/api/uploads", params), {
+    method: "POST",
+    headers: file.blob.type ? { "content-type": file.blob.type } : undefined,
+    body: file.blob,
+  });
+  const payload = (await response.json().catch(() => ({}))) as {
+    file?: UploadedFile;
+    error?: string;
+    name?: string;
+    path?: string;
+  };
+  if (response.status === 409 && !renameConflicts) {
+    throw new UploadConflictError(
+      typeof payload.name === "string" ? payload.name : file.name || "file",
+      typeof payload.path === "string" ? payload.path : "",
+    );
+  }
+  if (!response.ok || !payload.file) {
+    throw new Error(payload.error || `Upload failed (${response.status})`);
+  }
+  return payload.file;
+}

--- a/web/src/uploadPrefs.test.ts
+++ b/web/src/uploadPrefs.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_AUTO_RENAME_UPLOAD_CONFLICTS,
+  parseAutoRenameUploadConflicts,
+} from "./uploadPrefs";
+
+describe("upload preferences", () => {
+  it("defaults automatic conflict renaming on", () => {
+    expect(DEFAULT_AUTO_RENAME_UPLOAD_CONFLICTS).toBe(true);
+    expect(parseAutoRenameUploadConflicts(undefined)).toBe(true);
+  });
+
+  it("preserves stored Boolean choices and rejects other shapes", () => {
+    expect(parseAutoRenameUploadConflicts(false)).toBe(false);
+    expect(parseAutoRenameUploadConflicts(true, false)).toBe(true);
+    expect(parseAutoRenameUploadConflicts("false", false)).toBe(false);
+  });
+});

--- a/web/src/uploadPrefs.ts
+++ b/web/src/uploadPrefs.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_AUTO_RENAME_UPLOAD_CONFLICTS = true;
+
+export function parseAutoRenameUploadConflicts(
+  value: unknown,
+  fallback = DEFAULT_AUTO_RENAME_UPLOAD_CONFLICTS,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}


### PR DESCRIPTION
Hey there, this PR was written by AI tools. Wanted to stop getting a file overwrite popup. I've had this working on my fork for a minute and wanted to upstream it if you find it handy.

--

## Problem

Uploads keep the caller's filename, but a name that already exists in the upload
directory fails with `409 file exists`. Uploading `image.png` a second time therefore
leaves only two options: re-send with `?overwrite=true`, which destroys the first file,
or cancel. There is no way to keep both, even though nothing about the second upload
implies the first one is disposable.

## Approach

`unique_upload_file_name` selects the stored name: it keeps the original when that name
is free, and otherwise suffixes the stem — `image.png` -> `image-1.png` -> `image-2.png`
— so a repeat upload lands alongside the earlier file instead of clobbering it.

- `?overwrite=true` is unchanged and remains the only way to replace an existing file.
- The `409` path stays as the race fallback (another upload claiming the name between
  selection and write) and for an exhausted candidate space.
- Name selection runs on the `sanitize_upload_file_name` output, which reduces the
  supplied name to a basename. The `-N` suffix introduces no path separator, so no
  candidate can escape the upload directory.

## Tests

Ten unit tests were added in `bridge/src/web_bridge.rs`, covering: the original name kept
when free, suffixing of taken names, names without an extension, suffixing before the last
extension, repeated calls producing distinct names, giving up when every candidate is
taken, not reusing a name already present on disk, and traversal attempts (`../`, `..\`,
absolute paths, nested segments) both through sanitization and through the de-duplication
path.

Results on this branch:

- `cargo test` (bridge + vendored compat crate): 265 passed, 0 failed, 0 ignored.
- `cargo clippy --all-targets` (bridge): clean, 0 warnings.
- `cargo fmt --check` (bridge + vendored compat crate): clean.

## Changelog

Added under `Unreleased` -> `Changed`, describing the new behavior and noting that
`?overwrite=true` remains the only way to replace an existing file.
