### PR TITLE
Expose command composer on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
 
 - Focus the enabled desktop command composer on terminal attach and navigation focus requests,
   after closing Settings, and after Send, including Ctrl+Enter and Cmd+Enter. Direct terminal
-  clicks and mobile keyboard behavior remain available. [PR #82](https://github.com/kcosr/herdr-web/pull/82).
+  clicks retain focus through reconnects and immediately after a default focus request. Desktop
+  Stage focuses the terminal to edit or run the staged input; mobile keyboard behavior
+  remains unchanged. [PR #82](https://github.com/kcosr/herdr-web/pull/82).
 
 - Keep unsent desktop and mobile command drafts per bridge and pane while navigating, until
   sent, staged, or the pane is confirmed closed. Drafts remain in memory for the current browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- Added an opt-in desktop command composer under Settings → Terminal for editing multiline input
+  before sending it, without changing desktop terminal selection, scrolling, focus, or cursor
+  behavior.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@
 ### Added
 
 - Added an opt-in desktop command composer under Settings → Terminal for editing multiline input
-  before sending it, without changing desktop terminal selection, scrolling, focus, or cursor
+  before sending it, without changing desktop terminal selection, scrolling, or cursor
   behavior. [PR #82](https://github.com/kcosr/herdr-web/pull/82), contributed by
   [Andreas Ahrens (@AndreasAhrens)](https://github.com/AndreasAhrens).
 
 ### Changed
 
 ### Fixed
+
+- Focus the enabled desktop command composer on terminal attach and navigation focus requests,
+  after closing Settings, and after Send, including Ctrl+Enter and Cmd+Enter. Direct terminal
+  clicks and mobile keyboard behavior remain available. [PR #82](https://github.com/kcosr/herdr-web/pull/82).
 
 - Keep unsent desktop and mobile command drafts per bridge and pane while navigating, until
   sent, staged, or the pane is confirmed closed. Drafts remain in memory for the current browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@
 
 - Added an opt-in desktop command composer under Settings → Terminal for editing multiline input
   before sending it, without changing desktop terminal selection, scrolling, focus, or cursor
-  behavior.
+  behavior. [PR #82](https://github.com/kcosr/herdr-web/pull/82), contributed by
+  [Andreas Ahrens (@AndreasAhrens)](https://github.com/AndreasAhrens).
 
 ### Changed
 
 ### Fixed
+
+- Keep unsent desktop and mobile command drafts per bridge and pane while navigating, until
+  sent, staged, or the pane is confirmed closed. Drafts remain in memory for the current browser
+  tab only. [PR #82](https://github.com/kcosr/herdr-web/pull/82).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ Agents, Tabs, and Notes in those views. All scope continues to show content from
 
 Desktop users can enable Command composer under Settings → Terminal to edit multiline prompts
 before staging or sending them. Enter inserts a newline by default; Ctrl+Enter on Windows/Linux or
-Cmd+Enter on macOS sends the prompt. Desktop and mobile command drafts stay separate per bridge and
+Cmd+Enter on macOS sends the prompt. With the desktop composer enabled, automatic input focus goes
+to the composer and returns there after Send; click the terminal to type directly into it.
+Desktop and mobile command drafts stay separate per bridge and
 pane while switching panes, tabs, or hosts, hiding the composer, or reconnecting. Sending or staging
 clears that pane's draft, and a successful snapshot removes drafts for closed panes. Drafts live only
 in the current browser tab's memory: reloading the page clears them, and other clients do not share them.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ Multi-host Space selection is enabled by default, retaining one active Space per
 Space-scoped views. Turn it off under Settings → Display to keep only the selected host's Space,
 Agents, Tabs, and Notes in those views. All scope continues to show content from every host.
 
+Desktop users can enable Command composer under Settings → Terminal to edit multiline prompts
+before staging or sending them. Enter inserts a newline by default; Ctrl+Enter on Windows/Linux or
+Cmd+Enter on macOS sends the prompt. Desktop and mobile command drafts stay separate per bridge and
+pane while switching panes, tabs, or hosts, hiding the composer, or reconnecting. Sending or staging
+clears that pane's draft, and a successful snapshot removes drafts for closed panes. Drafts live only
+in the current browser tab's memory: reloading the page clears them, and other clients do not share them.
+
 Terminal input payloads can be sent as JSON or binary WebSocket frames. JSON remains the default;
 binary is available for comparing terminal input performance. Terminal input batching is off by
 default. When enabled, short input chunks are coalesced for `32`, `64`, `128`, or `256` ms and are

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ Agents, Tabs, and Notes in those views. All scope continues to show content from
 Desktop users can enable Command composer under Settings → Terminal to edit multiline prompts
 before staging or sending them. Enter inserts a newline by default; Ctrl+Enter on Windows/Linux or
 Cmd+Enter on macOS sends the prompt. With the desktop composer enabled, automatic input focus goes
-to the composer and returns there after Send; click the terminal to type directly into it.
+to the composer and returns there after Send. Stage focuses the terminal to edit or run staged
+input; clicking the terminal also selects direct input, retaining that focus through reconnects.
 Desktop and mobile command drafts stay separate per bridge and
 pane while switching panes, tabs, or hosts, hiding the composer, or reconnecting. Sending or staging
 clears that pane's draft, and a successful snapshot removes drafts for closed panes. Drafts live only

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4433,7 +4433,12 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
           showMobileKeyboardHideRefit={showMobileKeyboardHideRefit}
           mobileKeyboardHideRefit={mobileKeyboardHideRefit}
           onMobileKeyboardHideRefit={setMobileKeyboardHideRefit}
-          onClose={() => setBackendSettingsOpen(false)}
+          onClose={() => {
+            setBackendSettingsOpen(false);
+            if (desktopCommandComposer && !isTouchInput) {
+              requestTerminalFocus();
+            }
+          }}
         />
       ) : null}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -158,7 +158,11 @@ import {
   parseTerminalOutputCoalesceMs,
 } from "./terminalOutputCoalescing";
 import {
+  DEFAULT_DESKTOP_COMMAND_COMPOSER,
+  DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
   DEFAULT_TERMINAL_FONT_SIZE_PX,
+  parseDesktopCommandComposer,
+  parseDesktopCommandEnterNewline,
   parseTerminalFontSizePx,
 } from "./terminalPrefs";
 import {
@@ -415,6 +419,8 @@ type DisplayPrefs = {
   notesPanelOpen: boolean;
   sidebarOpen: boolean;
   terminalFontSizePx: number;
+  desktopCommandComposer: boolean;
+  desktopCommandEnterNewline: boolean;
   terminalScreenReaderText: boolean;
   autoRenameUploadConflicts: boolean;
   terminalInputTransport: TerminalInputTransport;
@@ -480,6 +486,8 @@ function readDisplayPrefs(): DisplayPrefs {
     notesPanelOpen: false,
     sidebarOpen: true,
     terminalFontSizePx: DEFAULT_TERMINAL_FONT_SIZE_PX,
+    desktopCommandComposer: DEFAULT_DESKTOP_COMMAND_COMPOSER,
+    desktopCommandEnterNewline: DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
     terminalScreenReaderText: DEFAULT_TERMINAL_SCREEN_READER_TEXT,
     autoRenameUploadConflicts: DEFAULT_AUTO_RENAME_UPLOAD_CONFLICTS,
     terminalInputTransport: DEFAULT_TERMINAL_INPUT_TRANSPORT,
@@ -677,6 +685,14 @@ function parseDisplayPrefsValue(
       typeof parsed.notesPanelOpen === "boolean" ? parsed.notesPanelOpen : fallback.notesPanelOpen,
     sidebarOpen,
     terminalFontSizePx: parseTerminalFontSizePx(parsed.terminalFontSizePx),
+    desktopCommandComposer: parseDesktopCommandComposer(
+      parsed.desktopCommandComposer,
+      fallback.desktopCommandComposer,
+    ),
+    desktopCommandEnterNewline: parseDesktopCommandEnterNewline(
+      parsed.desktopCommandEnterNewline,
+      fallback.desktopCommandEnterNewline,
+    ),
     terminalScreenReaderText: parseTerminalScreenReaderText(
       parsed.terminalScreenReaderText,
       fallback.terminalScreenReaderText,
@@ -1060,6 +1076,12 @@ export function App() {
   const [terminalFontSizePx, setTerminalFontSizePx] = useState(
     initialPrefs.terminalFontSizePx,
   );
+  const [desktopCommandComposer, setDesktopCommandComposer] = useState(
+    initialPrefs.desktopCommandComposer,
+  );
+  const [desktopCommandEnterNewline, setDesktopCommandEnterNewline] = useState(
+    initialPrefs.desktopCommandEnterNewline,
+  );
   const [terminalScreenReaderText, setTerminalScreenReaderText] = useState(
     initialPrefs.terminalScreenReaderText,
   );
@@ -1193,6 +1215,8 @@ export function App() {
       setSelectedPanesByBridgeId(sharedNavigationPrefs.selectedPanesByBridgeId);
       setActiveWorkspacesByBridgeId(sharedNavigationPrefs.activeWorkspacesByBridgeId);
       setTerminalFontSizePx(prefs.terminalFontSizePx);
+      setDesktopCommandComposer(prefs.desktopCommandComposer);
+      setDesktopCommandEnterNewline(prefs.desktopCommandEnterNewline);
       setTerminalScreenReaderText(prefs.terminalScreenReaderText);
       setAutoRenameUploadConflicts(prefs.autoRenameUploadConflicts);
       setTerminalInputTransport(prefs.terminalInputTransport);
@@ -1737,6 +1761,8 @@ export function App() {
       notesPanelOpen,
       sidebarOpen,
       terminalFontSizePx,
+      desktopCommandComposer,
+      desktopCommandEnterNewline,
       terminalScreenReaderText,
       autoRenameUploadConflicts,
       terminalInputTransport,
@@ -1774,6 +1800,8 @@ export function App() {
     notesPanelOpen,
     sidebarOpen,
     terminalFontSizePx,
+    desktopCommandComposer,
+    desktopCommandEnterNewline,
     terminalScreenReaderText,
     autoRenameUploadConflicts,
     terminalInputTransport,
@@ -4079,6 +4107,8 @@ export function App() {
             refitToken={refitToken}
             focusToken={terminalFocusToken}
             touchInput={isTouchInput}
+            desktopCommandComposer={desktopCommandComposer}
+            desktopCommandEnterNewline={desktopCommandEnterNewline}
             terminalFontSizePx={terminalFontSizePx}
             terminalScreenReaderText={terminalScreenReaderText}
             autoRenameUploadConflicts={autoRenameUploadConflicts}
@@ -4106,6 +4136,8 @@ export function App() {
             autoFocus={!isTouchInput}
             scrollSensitivity={isTouchInput ? 2 : 0.4}
             mobileControls={isTouchInput}
+            desktopCommandComposer={desktopCommandComposer}
+            desktopCommandEnterNewline={desktopCommandEnterNewline}
             cursorBlink={!isTouchInput}
             terminalFontSizePx={terminalFontSizePx}
             terminalScreenReaderText={terminalScreenReaderText}
@@ -4346,6 +4378,10 @@ export function App() {
           onMultiHostSpaceSelection={setMultiHostSpaceSelection}
           terminalFontSizePx={terminalFontSizePx}
           onTerminalFontSizePx={setTerminalFontSizePx}
+          desktopCommandComposer={desktopCommandComposer}
+          onDesktopCommandComposer={setDesktopCommandComposer}
+          desktopCommandEnterNewline={desktopCommandEnterNewline}
+          onDesktopCommandEnterNewline={setDesktopCommandEnterNewline}
           terminalScreenReaderText={terminalScreenReaderText}
           onTerminalScreenReaderText={setTerminalScreenReaderText}
           autoRenameUploadConflicts={autoRenameUploadConflicts}
@@ -5813,6 +5849,8 @@ function SplitGrid({
   refitToken,
   focusToken,
   touchInput,
+  desktopCommandComposer,
+  desktopCommandEnterNewline,
   terminalFontSizePx,
   terminalScreenReaderText,
   autoRenameUploadConflicts,
@@ -5836,6 +5874,8 @@ function SplitGrid({
   refitToken: number;
   focusToken: number;
   touchInput: boolean;
+  desktopCommandComposer: boolean;
+  desktopCommandEnterNewline: boolean;
   terminalFontSizePx: number;
   terminalScreenReaderText: boolean;
   autoRenameUploadConflicts: boolean;
@@ -5875,6 +5915,8 @@ function SplitGrid({
               autoFocus={selected && !touchInput}
               scrollSensitivity={touchInput ? 2 : 0.4}
               mobileControls={selected && touchInput}
+              desktopCommandComposer={selected && !touchInput && desktopCommandComposer}
+              desktopCommandEnterNewline={desktopCommandEnterNewline}
               cursorBlink={!touchInput}
               terminalFontSizePx={terminalFontSizePx}
               terminalScreenReaderText={terminalScreenReaderText}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { CommandDraftContext, createCommandDraftStore } from "./commandDrafts";
 import {
   Activity,
   Archive,
@@ -952,6 +953,15 @@ function usePointerDragResize(
 }
 
 export function App() {
+  const [commandDrafts] = useState(createCommandDraftStore);
+  return (
+    <CommandDraftContext.Provider value={commandDrafts}>
+      <AppContent commandDrafts={commandDrafts} />
+    </CommandDraftContext.Provider>
+  );
+}
+
+function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof createCommandDraftStore> }) {
   const bridge = useBridge();
   const initialPrefs = useMemo(readDisplayPrefs, []);
   const initialSharedNavigationPrefs = useMemo(readSharedNavigationPrefs, []);
@@ -1321,6 +1331,14 @@ export function App() {
       }),
     [bridge.enabledRuntimes, connectionStates],
   );
+  useEffect(() => {
+    for (const { runtime, snapshot, loadState } of bridgeViews) {
+      if (runtime.canConnect && loadState === "ready" && snapshot) {
+        commandDrafts.retainPanes(runtime.id, snapshot.panes.map((pane) => pane.pane_id));
+      }
+    }
+  }, [bridgeViews, commandDrafts]);
+
   const pinnedAgentKeys = useMemo(
     () => buildAgentPinKeySet(bridgeViews, agentPinsStates),
     [agentPinsStates, bridgeViews],
@@ -4094,6 +4112,7 @@ export function App() {
         </header>
         {showSplit && splitCells ? (
           <SplitGrid
+            bridgeId={selectedRuntime?.id ?? ""}
             cells={splitCells}
             selectedPaneId={selectedPane?.pane_id ?? null}
             onSelectPane={(pane) => {
@@ -4128,6 +4147,7 @@ export function App() {
           />
         ) : renderTerminal ? (
           <TerminalView
+            bridgeId={selectedRuntime?.id ?? ""}
             pane={selectedPane}
             connectionKey={selectedRuntime?.connectionKey ?? "disconnected"}
             resumeToken={selectedRuntime?.resumeToken ?? 0}
@@ -5843,6 +5863,7 @@ function hasOpenModal() {
 }
 
 function SplitGrid({
+  bridgeId,
   cells,
   selectedPaneId,
   onSelectPane,
@@ -5868,6 +5889,7 @@ function SplitGrid({
   httpUrl,
   wsUrl,
 }: {
+  bridgeId: string;
   cells: { pane: PaneInfo; style: CSSProperties }[];
   selectedPaneId: string | null;
   onSelectPane: (pane: PaneInfo) => void;
@@ -5907,6 +5929,7 @@ function SplitGrid({
             onPointerDown={() => onSelectPane(pane)}
           >
             <TerminalView
+              bridgeId={bridgeId}
               pane={pane}
               connectionKey={connectionKey}
               resumeToken={resumeToken}

--- a/web/src/BackendSettingsDialog.test.tsx
+++ b/web/src/BackendSettingsDialog.test.tsx
@@ -96,6 +96,50 @@ describe("BackendSettingsDialog terminal accessibility", () => {
     expect(off?.getAttribute("aria-pressed")).toBe("true");
     expect(on?.getAttribute("aria-pressed")).toBe("false");
   });
+
+  it("offers desktop command composer settings in the Terminal area", async () => {
+    const onComposerChange = vi.fn();
+    const onEnterNewlineChange = vi.fn();
+    const { container } = await render(
+      <ComposerSettingsHarness
+        onComposerChange={onComposerChange}
+        onEnterNewlineChange={onEnterNewlineChange}
+      />,
+    );
+    const terminalTab = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+    ).find((button) => button.textContent?.includes("Terminal"));
+    if (!terminalTab) {
+      throw new Error("missing Terminal settings tab");
+    }
+
+    await act(async () => terminalTab.click());
+    const composerGroup = requiredElement<HTMLElement>(
+      container,
+      '[role="group"][aria-label="Command composer"]',
+    );
+    const [composerOff, composerOn] = Array.from(
+      composerGroup.querySelectorAll<HTMLButtonElement>("button"),
+    );
+    expect(composerOff?.getAttribute("aria-pressed")).toBe("true");
+
+    await act(async () => composerOn?.click());
+    expect(onComposerChange).toHaveBeenCalledWith(true);
+    expect(composerOn?.getAttribute("aria-pressed")).toBe("true");
+
+    const newlineGroup = requiredElement<HTMLElement>(
+      container,
+      '[role="group"][aria-label="Desktop composer Enter inserts newline"]',
+    );
+    const [newlineOff, newlineOn] = Array.from(
+      newlineGroup.querySelectorAll<HTMLButtonElement>("button"),
+    );
+    expect(newlineOn?.getAttribute("aria-pressed")).toBe("true");
+
+    await act(async () => newlineOff?.click());
+    expect(onEnterNewlineChange).toHaveBeenCalledWith(false);
+    expect(newlineOff?.getAttribute("aria-pressed")).toBe("true");
+  });
 });
 
 function SettingsHarness({ onChange }: { onChange: (enabled: boolean) => void }) {
@@ -126,6 +170,33 @@ function UploadSettingsHarness({ onChange }: { onChange: (enabled: boolean) => v
   );
 }
 
+function ComposerSettingsHarness({
+  onComposerChange,
+  onEnterNewlineChange,
+}: {
+  onComposerChange: (enabled: boolean) => void;
+  onEnterNewlineChange: (enabled: boolean) => void;
+}) {
+  const [desktopCommandComposer, setDesktopCommandComposer] = useState(false);
+  const [desktopCommandEnterNewline, setDesktopCommandEnterNewline] = useState(true);
+  return (
+    <BackendSettingsDialog
+      {...settingsProps()}
+      showMobileTerminalSettings={false}
+      desktopCommandComposer={desktopCommandComposer}
+      onDesktopCommandComposer={(enabled) => {
+        onComposerChange(enabled);
+        setDesktopCommandComposer(enabled);
+      }}
+      desktopCommandEnterNewline={desktopCommandEnterNewline}
+      onDesktopCommandEnterNewline={(enabled) => {
+        onEnterNewlineChange(enabled);
+        setDesktopCommandEnterNewline(enabled);
+      }}
+    />
+  );
+}
+
 function settingsProps() {
   return {
     showMobileTerminalSettings: true,
@@ -141,6 +212,10 @@ function settingsProps() {
     onMultiHostSpaceSelection: vi.fn(),
     terminalFontSizePx: 13,
     onTerminalFontSizePx: vi.fn(),
+    desktopCommandComposer: false,
+    onDesktopCommandComposer: vi.fn(),
+    desktopCommandEnterNewline: true,
+    onDesktopCommandEnterNewline: vi.fn(),
     terminalScreenReaderText: false,
     onTerminalScreenReaderText: vi.fn(),
     autoRenameUploadConflicts: true,

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -72,6 +72,10 @@ type Props = {
   onMultiHostSpaceSelection: (enabled: boolean) => void;
   terminalFontSizePx: number;
   onTerminalFontSizePx: (value: number) => void;
+  desktopCommandComposer: boolean;
+  onDesktopCommandComposer: (enabled: boolean) => void;
+  desktopCommandEnterNewline: boolean;
+  onDesktopCommandEnterNewline: (enabled: boolean) => void;
   terminalScreenReaderText: boolean;
   onTerminalScreenReaderText: (enabled: boolean) => void;
   autoRenameUploadConflicts: boolean;
@@ -130,6 +134,10 @@ export function BackendSettingsDialog({
   onMultiHostSpaceSelection,
   terminalFontSizePx,
   onTerminalFontSizePx,
+  desktopCommandComposer,
+  onDesktopCommandComposer,
+  desktopCommandEnterNewline,
+  onDesktopCommandEnterNewline,
   terminalScreenReaderText,
   onTerminalScreenReaderText,
   autoRenameUploadConflicts,
@@ -701,6 +709,67 @@ export function BackendSettingsDialog({
                     onChange={(value) => onTerminalFontSizePx(parseTerminalFontSizePx(value))}
                   />
                 </div>
+                {!showMobileTerminalSettings ? (
+                  <>
+                    <div className="settings-label">Command input</div>
+                    <div className="settings-row">
+                      <span title="Compose and edit commands below the terminal before sending them">
+                        Command composer
+                      </span>
+                      <div
+                        className="segmented-control"
+                        role="group"
+                        aria-label="Command composer"
+                      >
+                        <button
+                          type="button"
+                          data-on={!desktopCommandComposer}
+                          aria-pressed={!desktopCommandComposer}
+                          onClick={() => onDesktopCommandComposer(false)}
+                        >
+                          Off
+                        </button>
+                        <button
+                          type="button"
+                          data-on={desktopCommandComposer}
+                          aria-pressed={desktopCommandComposer}
+                          onClick={() => onDesktopCommandComposer(true)}
+                        >
+                          On
+                        </button>
+                      </div>
+                    </div>
+                    {desktopCommandComposer ? (
+                      <div className="settings-row">
+                        <span title="Use Ctrl+Enter on Windows/Linux or Cmd+Enter on macOS to send">
+                          Enter inserts newline
+                        </span>
+                        <div
+                          className="segmented-control"
+                          role="group"
+                          aria-label="Desktop composer Enter inserts newline"
+                        >
+                          <button
+                            type="button"
+                            data-on={!desktopCommandEnterNewline}
+                            aria-pressed={!desktopCommandEnterNewline}
+                            onClick={() => onDesktopCommandEnterNewline(false)}
+                          >
+                            Off
+                          </button>
+                          <button
+                            type="button"
+                            data-on={desktopCommandEnterNewline}
+                            aria-pressed={desktopCommandEnterNewline}
+                            onClick={() => onDesktopCommandEnterNewline(true)}
+                          >
+                            On
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </>
+                ) : null}
                 <div className="settings-label">Accessibility</div>
                 <div className="settings-row">
                   <span title="Expose the visible terminal contents as screen-reader text; may add processing during heavy output">

--- a/web/src/MobileTerminalControls.test.tsx
+++ b/web/src/MobileTerminalControls.test.tsx
@@ -5,7 +5,10 @@ import { act, createRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { MobileTerminalControls } from "./TerminalView";
+import {
+  isCommandComposerSubmitShortcut,
+  TerminalCommandControls,
+} from "./TerminalView";
 
 const roots: Root[] = [];
 
@@ -24,7 +27,7 @@ afterEach(async () => {
   vi.restoreAllMocks();
 });
 
-describe("MobileTerminalControls", () => {
+describe("TerminalCommandControls", () => {
   for (const expandingInput of [false, true]) {
     it(`clears and remounts the ${
       expandingInput ? "textarea" : "input"
@@ -88,9 +91,79 @@ describe("MobileTerminalControls", () => {
 
     expect(onSubmitCommand).toHaveBeenCalledWith("");
   });
+
+  it("keeps multiline paste as one editable value until Send", async () => {
+    const { container, onSubmitCommand } = await renderControls(true, {
+      enterNewline: true,
+      mobileControls: false,
+    });
+    const field = commandField(container);
+
+    await setCommandValue(field, "first line\nsecond line");
+
+    expect(onSubmitCommand).not.toHaveBeenCalled();
+    expect(field.value).toBe("first line\nsecond line");
+    await submitForm(container);
+    expect(onSubmitCommand).toHaveBeenCalledWith("first line\nsecond line");
+  });
+
+  it("renders the composer without mobile terminal keys in desktop mode", async () => {
+    const { container } = await renderControls(true, { mobileControls: false });
+
+    expect(commandField(container)).toBeInstanceOf(HTMLTextAreaElement);
+    expect(container.querySelector<HTMLElement>(".term-key-strip")?.hidden).toBe(true);
+    expect(container.querySelector(".term-input-row")).not.toBeNull();
+  });
+
+  it("inserts Enter and submits Ctrl+Enter in a Linux desktop composer", async () => {
+    vi.spyOn(window.navigator, "platform", "get").mockReturnValue("Linux x86_64");
+    const { container, onSubmitCommand } = await renderControls(true, {
+      enterNewline: true,
+      mobileControls: false,
+    });
+    const field = commandField(container);
+    await setCommandValue(field, "two\nlines");
+
+    const enter = await keyDown(field, { key: "Enter" });
+    expect(enter.defaultPrevented).toBe(false);
+    expect(onSubmitCommand).not.toHaveBeenCalled();
+
+    const submit = await keyDown(field, { key: "Enter", ctrlKey: true });
+    expect(submit.defaultPrevented).toBe(true);
+    expect(onSubmitCommand).toHaveBeenCalledWith("two\nlines");
+  });
+
+  it("uses Cmd+Enter, not Ctrl+Enter, as the macOS submit shortcut", () => {
+    expect(
+      isCommandComposerSubmitShortcut(
+        { key: "Enter", altKey: false, ctrlKey: false, metaKey: true, shiftKey: false },
+        "MacIntel",
+      ),
+    ).toBe(true);
+    expect(
+      isCommandComposerSubmitShortcut(
+        { key: "Enter", altKey: false, ctrlKey: true, metaKey: false, shiftKey: false },
+        "MacIntel",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the existing mobile multiline modifier behavior", async () => {
+    const { container, onSubmitCommand } = await renderControls(true, {
+      enterNewline: true,
+      mobileControls: true,
+    });
+    const event = await keyDown(commandField(container), { key: "Enter", ctrlKey: true });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(onSubmitCommand).not.toHaveBeenCalled();
+  });
 });
 
-async function renderControls(expandingInput: boolean) {
+async function renderControls(
+  expandingInput: boolean,
+  options: { enterNewline?: boolean; mobileControls?: boolean } = {},
+) {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -101,12 +174,13 @@ async function renderControls(expandingInput: boolean) {
 
   await act(async () => {
     root.render(
-      <MobileTerminalControls
+      <TerminalCommandControls
         commandInputRef={commandInputRef}
         disabled={false}
         uploadDisabled={false}
         expandingInput={expandingInput}
-        enterNewline={false}
+        enterNewline={options.enterNewline ?? false}
+        mobileControls={options.mobileControls ?? true}
         controlsScalePercent={100}
         onControlsHeightChange={vi.fn()}
         onInput={vi.fn()}
@@ -124,6 +198,17 @@ async function renderControls(expandingInput: boolean) {
     onStageCommand,
     onSubmitCommand,
   };
+}
+
+async function keyDown(
+  field: HTMLInputElement | HTMLTextAreaElement,
+  init: KeyboardEventInit,
+) {
+  const event = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+  await act(async () => {
+    field.dispatchEvent(event);
+  });
+  return event;
 }
 
 function commandField(container: HTMLElement) {

--- a/web/src/MobileTerminalControls.test.tsx
+++ b/web/src/MobileTerminalControls.test.tsx
@@ -134,6 +134,39 @@ describe("TerminalCommandControls", () => {
     expect(onSubmitCommand).toHaveBeenCalledWith("two\nlines");
   });
 
+  for (const method of ["button", "ctrl-enter", "cmd-enter"] as const) {
+    it(`returns focus to the desktop composer after ${method} submission`, async () => {
+      vi.spyOn(window.navigator, "platform", "get").mockReturnValue(
+        method === "cmd-enter" ? "MacIntel" : "Linux x86_64",
+      );
+      const { container, onSubmitCommand } = await renderControls(true, {
+        enterNewline: true,
+        mobileControls: false,
+      });
+      const field = commandField(container);
+      await setCommandValue(field, "first prompt");
+      field.focus();
+      if (method === "button") {
+        const send = container.querySelector<HTMLButtonElement>('button[type="submit"]')!;
+        send.focus();
+        await act(async () => send.click());
+      } else {
+        await keyDown(field, {
+          key: "Enter",
+          ctrlKey: method === "ctrl-enter",
+          metaKey: method === "cmd-enter",
+        });
+      }
+      const nextField = commandField(container);
+      expect(onSubmitCommand).toHaveBeenCalledExactlyOnceWith("first prompt");
+      expect(nextField).not.toBe(field);
+      expect(nextField.value).toBe("");
+      expect(document.activeElement).toBe(nextField);
+      await setCommandValue(nextField, "next prompt");
+      expect(nextField.value).toBe("next prompt");
+    });
+  }
+
   it("uses Cmd+Enter, not Ctrl+Enter, as the macOS submit shortcut", () => {
     expect(
       isCommandComposerSubmitShortcut(

--- a/web/src/MobileTerminalControls.test.tsx
+++ b/web/src/MobileTerminalControls.test.tsx
@@ -1,3 +1,4 @@
+import { CommandDraftContext, createCommandDraftStore } from "./commandDrafts";
 /**
  * @vitest-environment jsdom
  */
@@ -158,6 +159,62 @@ describe("TerminalCommandControls", () => {
     expect(event.defaultPrevented).toBe(false);
     expect(onSubmitCommand).not.toHaveBeenCalled();
   });
+  for (const mobileControls of [false, true]) {
+    it(`retains separate ${mobileControls ? "mobile" : "desktop"} drafts through pane switches, hiding and disconnects`, async () => {
+      const { container, renderPane } = await renderControls(true, { mobileControls });
+      await setCommandValue(commandField(container), "first pane\nunsent prompt");
+      await renderPane("bridge-a", "pane-b");
+      expect(commandField(container).value).toBe("");
+      await setCommandValue(commandField(container), "second pane");
+      await renderPane("bridge-b", "pane-a");
+      expect(commandField(container).value).toBe("");
+      await setCommandValue(commandField(container), "other host");
+      await renderPane("bridge-a", "pane-a", false);
+      await renderPane("bridge-a", "pane-a", true, true);
+      expect(commandField(container).value).toBe("first pane\nunsent prompt");
+      await renderPane();
+      expect(commandField(container).value).toBe("first pane\nunsent prompt");
+      await renderPane("bridge-a", "pane-b");
+      expect(commandField(container).value).toBe("second pane");
+      await renderPane("bridge-b", "pane-a");
+      expect(commandField(container).value).toBe("other host");
+    });
+  }
+
+  for (const action of ["send", "stage"] as const) {
+    it(`clears only the submitted pane's retained draft after ${action}`, async () => {
+      const { container, renderPane } = await renderControls(true, { mobileControls: false });
+      await setCommandValue(commandField(container), "first draft");
+      await renderPane("bridge-a", "pane-b");
+      await setCommandValue(commandField(container), "second draft");
+      if (action === "send") await submitForm(container);
+      else await clickStage(container);
+      await renderPane();
+      expect(commandField(container).value).toBe("first draft");
+      await renderPane("bridge-a", "pane-b");
+      expect(commandField(container).value).toBe("");
+      await setCommandValue(commandField(container), "new draft after submit");
+      expect(commandField(container).value).toBe("new draft after submit");
+    });
+  }
+
+  it("removes closed-pane drafts after a confirmed snapshot, preserving other panes and bridges", async () => {
+    const { container, drafts, renderPane } = await renderControls(true);
+    await setCommandValue(commandField(container), "closed pane");
+    await renderPane("bridge-a", "pane-b");
+    await setCommandValue(commandField(container), "live pane");
+    await renderPane("bridge-b", "pane-a");
+    await setCommandValue(commandField(container), "other bridge");
+    await act(async () => drafts.retainPanes("bridge-a", ["pane-b"]));
+    expect(commandField(container).value).toBe("other bridge");
+    await renderPane();
+    expect(commandField(container).value).toBe("");
+    await renderPane("bridge-a", "pane-b");
+    expect(commandField(container).value).toBe("live pane");
+    await act(async () => drafts.retainPanes("bridge-a", []));
+    expect(commandField(container).value).toBe("");
+  });
+
 });
 
 async function renderControls(
@@ -172,27 +229,38 @@ async function renderControls(
   const onSubmitCommand = vi.fn();
   const onStageCommand = vi.fn();
 
-  await act(async () => {
-    root.render(
-      <TerminalCommandControls
-        commandInputRef={commandInputRef}
-        disabled={false}
-        uploadDisabled={false}
-        expandingInput={expandingInput}
-        enterNewline={options.enterNewline ?? false}
-        mobileControls={options.mobileControls ?? true}
-        controlsScalePercent={100}
-        onControlsHeightChange={vi.fn()}
-        onInput={vi.fn()}
-        onTerminalFocus={vi.fn()}
-        onUpload={vi.fn()}
-        onStageCommand={onStageCommand}
-        onSubmitCommand={onSubmitCommand}
-      />,
-    );
-  });
+  const drafts = createCommandDraftStore();
+  const renderPane = async (bridgeId = "bridge-a", paneId = "pane-a", visible = true, disabled = false) => {
+    await act(async () => {
+      root.render(
+        <CommandDraftContext.Provider value={drafts}>
+          {visible ? <TerminalCommandControls
+            key={JSON.stringify([bridgeId, paneId])}
+            bridgeId={bridgeId}
+            paneId={paneId}
+            commandInputRef={commandInputRef}
+            disabled={disabled}
+            uploadDisabled={false}
+            expandingInput={expandingInput}
+            enterNewline={options.enterNewline ?? false}
+            mobileControls={options.mobileControls ?? true}
+            controlsScalePercent={100}
+            onControlsHeightChange={vi.fn()}
+            onInput={vi.fn()}
+            onTerminalFocus={vi.fn()}
+            onUpload={vi.fn()}
+            onStageCommand={onStageCommand}
+            onSubmitCommand={onSubmitCommand}
+          /> : null}
+        </CommandDraftContext.Provider>,
+      );
+    });
+  };
+  await renderPane();
 
   return {
+    drafts,
+    renderPane,
     commandInputRef,
     container,
     onStageCommand,

--- a/web/src/MobileTerminalControls.test.tsx
+++ b/web/src/MobileTerminalControls.test.tsx
@@ -85,6 +85,28 @@ describe("TerminalCommandControls", () => {
     expect(onStageCommand).toHaveBeenCalledOnce();
   });
 
+  for (const mobileControls of [false, true]) {
+    it(`focuses the terminal after Stage only on desktop (mobile=${mobileControls})`, async () => {
+      const { container, onStageCommand, onTerminalFocus } = await renderControls(true, { mobileControls });
+      const terminal = document.createElement("input");
+      container.append(terminal);
+      onTerminalFocus.mockImplementation(() => terminal.focus());
+      const field = commandField(container);
+      await setCommandValue(field, "staged prompt");
+      field.focus();
+      await clickStage(container);
+      expect(onStageCommand).toHaveBeenCalledExactlyOnceWith("staged prompt");
+      expect(commandField(container).value).toBe("");
+      if (mobileControls) {
+        expect(onTerminalFocus).not.toHaveBeenCalled();
+        expect(document.activeElement).not.toBe(terminal);
+      } else {
+        expect(onTerminalFocus).toHaveBeenCalledOnce();
+        expect(document.activeElement).toBe(terminal);
+      }
+    });
+  }
+
   it("continues submitting an empty command as Enter", async () => {
     const { container, onSubmitCommand } = await renderControls(false);
 
@@ -261,6 +283,7 @@ async function renderControls(
   const commandInputRef = createRef<HTMLInputElement | HTMLTextAreaElement>();
   const onSubmitCommand = vi.fn();
   const onStageCommand = vi.fn();
+  const onTerminalFocus = vi.fn();
 
   const drafts = createCommandDraftStore();
   const renderPane = async (bridgeId = "bridge-a", paneId = "pane-a", visible = true, disabled = false) => {
@@ -280,7 +303,7 @@ async function renderControls(
             controlsScalePercent={100}
             onControlsHeightChange={vi.fn()}
             onInput={vi.fn()}
-            onTerminalFocus={vi.fn()}
+            onTerminalFocus={onTerminalFocus}
             onUpload={vi.fn()}
             onStageCommand={onStageCommand}
             onSubmitCommand={onSubmitCommand}
@@ -298,6 +321,7 @@ async function renderControls(
     container,
     onStageCommand,
     onSubmitCommand,
+    onTerminalFocus,
   };
 }
 

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -1,3 +1,4 @@
+import { useCommandDraft } from "./commandDrafts";
 import {
   Copy,
   ExternalLink,
@@ -66,6 +67,7 @@ import {
 import type { UploadCandidate, UploadedFile } from "./terminalUploads";
 
 type Props = {
+  bridgeId: string;
   pane: PaneInfo | null;
   connectionKey: string;
   resumeToken: number;
@@ -146,6 +148,7 @@ const MAX_UPLOAD_FILES = 8;
 const DEBUG_TERMINAL_RECONNECT = false;
 
 export function TerminalView({
+  bridgeId,
   pane,
   connectionKey,
   resumeToken,
@@ -1413,8 +1416,11 @@ export function TerminalView({
           <Paperclip size={16} />
         </button>
       ) : null}
-      {showCommandControls ? (
+      {showCommandControls && pane ? (
         <TerminalCommandControls
+          key={JSON.stringify([bridgeId, pane.pane_id])}
+          bridgeId={bridgeId}
+          paneId={pane.pane_id}
           commandInputRef={mobileCommandInputRef}
           disabled={!pane || connectionState !== "attached"}
           uploadDisabled={uploadDisabled}
@@ -1507,6 +1513,8 @@ function MobileSelectionActions({
 }
 
 export function TerminalCommandControls({
+  bridgeId,
+  paneId,
   commandInputRef,
   disabled,
   uploadDisabled,
@@ -1521,6 +1529,8 @@ export function TerminalCommandControls({
   onStageCommand,
   onSubmitCommand,
 }: {
+  bridgeId: string;
+  paneId: string;
   commandInputRef: RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
   disabled: boolean;
   uploadDisabled: boolean;
@@ -1536,7 +1546,7 @@ export function TerminalCommandControls({
   onSubmitCommand: (command: string) => void;
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
-  const [value, setValue] = useState("");
+  const [value, setValue] = useCommandDraft(bridgeId, paneId);
   const [fieldKey, setFieldKey] = useState(0);
   const [expanded, setExpanded] = useState(false);
   const [ctrlLatch, setCtrlLatch] = useState(false);

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -217,6 +217,8 @@ export function TerminalView({
   autoFocusRef.current = autoFocus;
   const scrollSensitivityRef = useRef(scrollSensitivity);
   scrollSensitivityRef.current = scrollSensitivity;
+  const desktopCommandComposerRef = useRef(desktopCommandComposer);
+  desktopCommandComposerRef.current = desktopCommandComposer;
   const mobileControlsRef = useRef(mobileControls);
   mobileControlsRef.current = mobileControls;
   const cursorBlinkRef = useRef(cursorBlink);
@@ -238,8 +240,8 @@ export function TerminalView({
   connectionKeyRef.current = connectionKey;
   terminalIdRef.current = pane?.terminal_id ?? null;
 
-  const focusMobileCommandInput = useCallback(() => {
-    if (!mobileControlsRef.current) {
+  const focusCommandInput = useCallback(() => {
+    if (!mobileControlsRef.current && !desktopCommandComposerRef.current) {
       return false;
     }
     const input = mobileCommandInputRef.current;
@@ -271,10 +273,10 @@ export function TerminalView({
       rendererRef.current?.focusTextInput();
       return;
     }
-    if (!focusMobileCommandInput()) {
+    if (!focusCommandInput()) {
       rendererRef.current?.focusTextInput();
     }
-  }, [focusMobileCommandInput]);
+  }, [focusCommandInput]);
 
   const showUploadStatus = useCallback((message: string | null, timeoutMs?: number) => {
     if (uploadStatusTimerRef.current !== null) {
@@ -548,7 +550,7 @@ export function TerminalView({
           !mobileControlsRef.current
             ? null
             : mobileTapTargetRef.current === "command-input"
-              ? focusMobileCommandInput
+              ? focusCommandInput
               : focusTerminalKeyboardInput,
         );
         renderer.setMobileTouchSelection(
@@ -633,7 +635,7 @@ export function TerminalView({
     connectionKey,
     clearQueuedTerminalInput,
     flushBatchedTerminalInput,
-    focusMobileCommandInput,
+    focusCommandInput,
     focusTerminalKeyboardInput,
     handleMobileTerminalTouch,
     measureTerminal,
@@ -817,8 +819,13 @@ export function TerminalView({
         if (size) {
           sendResize(size);
         }
-        if (autoFocusRef.current) {
-          window.setTimeout(() => ready.renderer.focus(), 0);
+        if (autoFocusRef.current && !desktopCommandComposerRef.current) {
+          window.setTimeout(() => {
+            if (!disposed && socket === nextSocket && autoFocusRef.current &&
+                !desktopCommandComposerRef.current) {
+              ready.renderer.focus();
+            }
+          }, 0);
         }
         flushBatchedTerminalInput();
         flushQueuedTerminalInput();
@@ -1090,6 +1097,15 @@ export function TerminalView({
     wsUrl,
   ]);
 
+  // Wait for React to enable the composer after attach before focusing it.
+  // Selection changes alone must not override a direct click into a split terminal.
+  useEffect(() => {
+    if (connectionState === "attached" && autoFocusRef.current &&
+        desktopCommandComposerRef.current && !mobileControlsRef.current) {
+      focusCommandInput();
+    }
+  }, [connectionState, focusCommandInput]);
+
   useEffect(() => {
     if (resumeToken > 0) {
       requestReconnectRef.current("resume");
@@ -1130,10 +1146,10 @@ export function TerminalView({
       !mobileControls
         ? null
         : mobileTapTarget === "command-input"
-          ? focusMobileCommandInput
+          ? focusCommandInput
           : focusTerminalKeyboardInput,
     );
-  }, [focusMobileCommandInput, focusTerminalKeyboardInput, mobileControls, mobileTapTarget]);
+  }, [focusCommandInput, focusTerminalKeyboardInput, mobileControls, mobileTapTarget]);
 
   useEffect(() => {
     rendererRef.current?.setMobileTouchSelection(
@@ -1548,6 +1564,7 @@ export function TerminalCommandControls({
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [value, setValue] = useCommandDraft(bridgeId, paneId);
   const [fieldKey, setFieldKey] = useState(0);
+  const focusAfterSubmitRef = useRef(false);
   const [expanded, setExpanded] = useState(false);
   const [ctrlLatch, setCtrlLatch] = useState(false);
   const setCommandInputNode = (node: HTMLInputElement | HTMLTextAreaElement | null) => {
@@ -1563,6 +1580,7 @@ export function TerminalCommandControls({
     setFieldKey((key) => key + 1);
   };
   const submit = () => {
+    focusAfterSubmitRef.current = !mobileControls;
     const command = value;
     clearCommandInput();
     onSubmitCommand(command);
@@ -1587,6 +1605,10 @@ export function TerminalCommandControls({
     if (fieldKey > 0 && node) {
       node.value = "";
       node.defaultValue = "";
+      if (focusAfterSubmitRef.current) {
+        focusAfterSubmitRef.current = false;
+        node.focus();
+      }
     }
   }, [commandInputRef, fieldKey]);
 

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -1,3 +1,4 @@
+import { useTerminalFocusRequest } from "./useTerminalFocusRequest";
 import { useCommandDraft } from "./commandDrafts";
 import {
   Copy,
@@ -471,20 +472,11 @@ export function TerminalView({
     rendererRef.current?.setScrollSensitivity(scrollSensitivity);
   }, [scrollSensitivity]);
 
-  useEffect(() => {
-    if (focusToken === 0) {
-      return;
-    }
-    const focus = () => focusPreferredInput();
-    const frame = window.requestAnimationFrame(focus);
-    const timers = [80, 220].map((delay) => window.setTimeout(focus, delay));
-    return () => {
-      window.cancelAnimationFrame(frame);
-      for (const timer of timers) {
-        window.clearTimeout(timer);
-      }
-    };
-  }, [focusPreferredInput, focusToken]);
+  useTerminalFocusRequest(
+    focusToken,
+    focusPreferredInput,
+    mobileControls || !desktopCommandComposer,
+  );
 
   useEffect(() => {
     const host = hostRef.current;
@@ -1101,7 +1093,8 @@ export function TerminalView({
   // Selection changes alone must not override a direct click into a split terminal.
   useEffect(() => {
     if (connectionState === "attached" && autoFocusRef.current &&
-        desktopCommandComposerRef.current && !mobileControlsRef.current) {
+        desktopCommandComposerRef.current && !mobileControlsRef.current &&
+        !hostRef.current?.contains(document.activeElement)) {
       focusCommandInput();
     }
   }, [connectionState, focusCommandInput]);
@@ -1592,6 +1585,9 @@ export function TerminalCommandControls({
     const command = value;
     clearCommandInput();
     onStageCommand(command);
+    if (!mobileControls) {
+      onTerminalFocus();
+    }
   };
   const sendKey = (key: TerminalKey) => {
     onInput(ctrlLatch && key.ctrlData ? key.ctrlData : key.data);

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -77,6 +77,10 @@ type Props = {
   scrollSensitivity?: number;
   /** Supplemental browser-native input controls for narrow touch screens. */
   mobileControls?: boolean;
+  /** Whether to show the expanding command composer without enabling mobile terminal behavior. */
+  desktopCommandComposer?: boolean;
+  /** Whether Enter inserts a newline in the desktop command composer. */
+  desktopCommandEnterNewline?: boolean;
   /** Whether the terminal cursor blinks. Off on touch devices. */
   cursorBlink?: boolean;
   /** Terminal renderer font size in CSS pixels. */
@@ -150,6 +154,8 @@ export function TerminalView({
   autoFocus = true,
   scrollSensitivity = 1,
   mobileControls = false,
+  desktopCommandComposer = false,
+  desktopCommandEnterNewline = true,
   cursorBlink = true,
   terminalFontSizePx = DEFAULT_TERMINAL_FONT_SIZE_PX,
   mobileControlsScalePercent = 100,
@@ -241,13 +247,13 @@ export function TerminalView({
     return true;
   }, []);
 
-  const setMobileControlsHeight = useCallback((heightPx: number | null) => {
+  const setCommandControlsHeight = useCallback((heightPx: number | null) => {
     if (heightPx === null) {
-      stageRef.current?.style.removeProperty("--terminal-mobile-controls-height");
+      stageRef.current?.style.removeProperty("--terminal-command-controls-height");
       return;
     }
     stageRef.current?.style.setProperty(
-      "--terminal-mobile-controls-height",
+      "--terminal-command-controls-height",
       `${Math.ceil(heightPx)}px`,
     );
   }, []);
@@ -1347,6 +1353,8 @@ export function TerminalView({
     return true;
   };
 
+  const showCommandControls = mobileControls || desktopCommandComposer;
+
   return (
     <section
       ref={stageRef}
@@ -1405,15 +1413,16 @@ export function TerminalView({
           <Paperclip size={16} />
         </button>
       ) : null}
-      {mobileControls ? (
-        <MobileTerminalControls
+      {showCommandControls ? (
+        <TerminalCommandControls
           commandInputRef={mobileCommandInputRef}
           disabled={!pane || connectionState !== "attached"}
           uploadDisabled={uploadDisabled}
-          expandingInput={mobileCommandExpandingInput}
-          enterNewline={mobileCommandEnterNewline}
-          controlsScalePercent={mobileControlsScalePercent}
-          onControlsHeightChange={setMobileControlsHeight}
+          expandingInput={mobileControls ? mobileCommandExpandingInput : true}
+          enterNewline={mobileControls ? mobileCommandEnterNewline : desktopCommandEnterNewline}
+          mobileControls={mobileControls}
+          controlsScalePercent={mobileControls ? mobileControlsScalePercent : 100}
+          onControlsHeightChange={setCommandControlsHeight}
           onInput={sendTerminalInput}
           onTerminalFocus={() => rendererRef.current?.focusTextInput()}
           onUpload={openFilePicker}
@@ -1497,12 +1506,13 @@ function MobileSelectionActions({
   );
 }
 
-export function MobileTerminalControls({
+export function TerminalCommandControls({
   commandInputRef,
   disabled,
   uploadDisabled,
   expandingInput,
   enterNewline,
+  mobileControls,
   controlsScalePercent,
   onControlsHeightChange,
   onInput,
@@ -1516,6 +1526,7 @@ export function MobileTerminalControls({
   uploadDisabled: boolean;
   expandingInput: boolean;
   enterNewline: boolean;
+  mobileControls: boolean;
   controlsScalePercent: number;
   onControlsHeightChange: (heightPx: number | null) => void;
   onInput: (data: string) => void;
@@ -1602,14 +1613,17 @@ export function MobileTerminalControls({
     if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
       return;
     }
-    if (
-      event.key !== "Enter" ||
-      enterNewline ||
-      event.shiftKey ||
-      event.altKey ||
-      event.ctrlKey ||
-      event.metaKey
-    ) {
+    if (event.key !== "Enter") {
+      return;
+    }
+    if (!mobileControls && isCommandComposerSubmitShortcut(event)) {
+      event.preventDefault();
+      if (!disabled) {
+        submit();
+      }
+      return;
+    }
+    if (enterNewline || event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) {
       return;
     }
     event.preventDefault();
@@ -1619,8 +1633,13 @@ export function MobileTerminalControls({
   };
 
   return (
-    <div ref={rootRef} className="terminal-mobile-controls" data-expanded={expanded ? "true" : "false"}>
-      <div className="term-key-strip" aria-label="Common terminal keys">
+    <div
+      ref={rootRef}
+      className="terminal-command-controls"
+      data-expanded={expanded ? "true" : "false"}
+      data-mobile-controls={mobileControls ? "true" : "false"}
+    >
+      <div className="term-key-strip" aria-label="Common terminal keys" hidden={!mobileControls}>
         <div className="term-key-group" aria-label="Terminal quick keys">
           <button
             className="term-key"
@@ -1702,7 +1721,7 @@ export function MobileTerminalControls({
         </div>
       </div>
 
-      {expanded ? (
+      {mobileControls && expanded ? (
         <div className="term-key-panel" aria-label="Special terminal keys">
           {SPECIAL_KEYS.map((key) => (
             <button
@@ -1783,6 +1802,23 @@ export function MobileTerminalControls({
       </form>
     </div>
   );
+}
+
+type CommandComposerShortcutEvent = Pick<
+  KeyboardEvent<HTMLTextAreaElement>,
+  "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey"
+>;
+
+export function isCommandComposerSubmitShortcut(
+  event: CommandComposerShortcutEvent,
+  platform = typeof navigator === "undefined" ? "" : navigator.platform,
+) {
+  if (event.key !== "Enter" || event.altKey || event.shiftKey) {
+    return false;
+  }
+  return platform.startsWith("Mac")
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
 }
 
 type TerminalKey = {

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -207,6 +207,7 @@ export function TerminalView({
   const [rendererReady, setRendererReady] = useState<TerminalRendererReady | null>(null);
   const [accessibleScreen, setAccessibleScreen] = useState("");
   const [hasAttachedForTerminal, setHasAttachedForTerminal] = useState(false);
+  const terminalAttachCountRef = useRef(0);
   const [showConnectionOverlay, setShowConnectionOverlay] = useState(false);
   const [uploadStatus, setUploadStatus] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -490,6 +491,7 @@ export function TerminalView({
     setRendererReady(null);
     setAccessibleScreen("");
     setHasAttachedForTerminal(false);
+    terminalAttachCountRef.current = 0;
     setShowConnectionOverlay(false);
     setCloseReason(null);
     terminalInputBlockedRef.current = false;
@@ -804,6 +806,7 @@ export function TerminalView({
         lastCloseReason = null;
         terminalInputBlockedRef.current = false;
         setCloseReason(null);
+        terminalAttachCountRef.current += 1;
         setHasAttachedForTerminal(true);
         setConnectionState("attached");
         debugReconnect("open", { socketGeneration: currentSocketGeneration });
@@ -1093,9 +1096,10 @@ export function TerminalView({
   // Selection changes alone must not override a direct click into a split terminal.
   useEffect(() => {
     if (connectionState === "attached" && autoFocusRef.current &&
-        desktopCommandComposerRef.current && !mobileControlsRef.current &&
-        !hostRef.current?.contains(document.activeElement)) {
-      focusCommandInput();
+        desktopCommandComposerRef.current && !mobileControlsRef.current) {
+      if (terminalAttachCountRef.current === 1 || !hostRef.current?.contains(document.activeElement)) {
+        focusCommandInput();
+      }
     }
   }, [connectionState, focusCommandInput]);
 

--- a/web/src/commandDrafts.ts
+++ b/web/src/commandDrafts.ts
@@ -1,0 +1,52 @@
+import { createContext, useCallback, useContext, useSyncExternalStore } from "react";
+
+/** Owned by one App mount: drafts never leave this browser tab or survive a reload. */
+export function createCommandDraftStore() {
+  const drafts = new Map<string, Map<string, string>>();
+  const listeners = new Set<() => void>();
+  const notify = () => listeners.forEach((listener) => listener());
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+    get(bridgeId: string, paneId: string) {
+      return drafts.get(bridgeId)?.get(paneId) ?? "";
+    },
+    set(bridgeId: string, paneId: string, value: string) {
+      const panes = drafts.get(bridgeId) ?? new Map<string, string>();
+      if ((panes.get(paneId) ?? "") === value) return;
+      if (value) panes.set(paneId, value);
+      else panes.delete(paneId);
+      if (panes.size) drafts.set(bridgeId, panes);
+      else drafts.delete(bridgeId);
+      notify();
+    },
+    /** Call only with a successful, current, complete bridge snapshot. */
+    retainPanes(bridgeId: string, paneIds: readonly string[]) {
+      const panes = drafts.get(bridgeId);
+      if (!panes) return;
+      const live = new Set(paneIds);
+      let changed = false;
+      for (const paneId of panes.keys()) {
+        if (!live.has(paneId)) {
+          panes.delete(paneId);
+          changed = true;
+        }
+      }
+      if (!panes.size) drafts.delete(bridgeId);
+      if (changed) notify();
+    },
+  };
+}
+
+export const CommandDraftContext = createContext<ReturnType<typeof createCommandDraftStore> | null>(null);
+
+export function useCommandDraft(bridgeId: string, paneId: string) {
+  const store = useContext(CommandDraftContext);
+  if (!store) throw new Error("Command composer requires an app draft store");
+  const getSnapshot = useCallback(() => store.get(bridgeId, paneId), [store, bridgeId, paneId]);
+  const value = useSyncExternalStore(store.subscribe, getSnapshot);
+  const setValue = (next: string) => store.set(bridgeId, paneId, next);
+  return [value, setValue] as const;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1726,7 +1726,7 @@ button {
 /* ------------------------------------------------------------ terminal */
 
 .terminal-stage {
-  --terminal-mobile-controls-height: calc(82px * var(--mobile-controls-scale));
+  --terminal-command-controls-height: calc(82px * var(--mobile-controls-scale));
   position: relative;
   display: flex;
   flex-direction: column;
@@ -1975,7 +1975,7 @@ button {
   pointer-events: none;
 }
 
-.terminal-mobile-controls {
+.terminal-command-controls {
   --mobile-control-gap: calc(5px * var(--mobile-controls-scale));
   --mobile-key-height: calc(30px * var(--mobile-controls-scale));
   --mobile-key-min-width: calc(34px * var(--mobile-controls-scale));
@@ -1985,13 +1985,18 @@ button {
   --mobile-input-row-height: calc(34px * var(--mobile-controls-scale));
   --mobile-input-padding-x: calc(10px * var(--mobile-controls-scale));
   --mobile-send-width: calc(38px * var(--mobile-controls-scale));
-  display: none;
+  display: flex;
   flex: 0 0 auto;
+  flex-direction: column;
   gap: var(--mobile-control-gap);
   padding: calc(6px * var(--mobile-controls-scale)) max(8px, env(safe-area-inset-right))
     calc(7px * var(--mobile-controls-scale)) max(8px, env(safe-area-inset-left));
   border-top: 1px solid var(--line);
   background: color-mix(in srgb, var(--mantle) 94%, black);
+}
+
+.terminal-command-controls[data-mobile-controls="false"] {
+  --mobile-controls-scale: 1;
 }
 
 .term-key-strip,
@@ -2002,6 +2007,10 @@ button {
   display: flex;
   min-width: 0;
   gap: var(--mobile-control-gap);
+}
+
+.term-key-strip[hidden] {
+  display: none;
 }
 
 .term-key-strip {
@@ -3345,19 +3354,20 @@ button {
   height: 60px;
 }
 
-.app[data-touch="true"] .terminal-mobile-controls {
-  display: flex;
-  flex-direction: column;
+.terminal-stage:has(.terminal-command-controls) .terminal-overlay {
+  bottom: calc(var(--terminal-command-controls-height) + 14px);
 }
 
-.app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-overlay {
-  bottom: calc(var(--terminal-mobile-controls-height) + 38px * var(--mobile-controls-scale));
+.terminal-stage:has(.terminal-command-controls) .terminal-upload-status,
+.terminal-stage:has(.terminal-command-controls) .terminal-selection-sheet {
+  bottom: calc(var(--terminal-command-controls-height) + 8px);
 }
 
-.app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-upload-status {
-  bottom: calc(var(--terminal-mobile-controls-height) + 8px * var(--mobile-controls-scale));
+.app[data-touch="true"] .terminal-stage:has(.terminal-command-controls) .terminal-overlay {
+  bottom: calc(var(--terminal-command-controls-height) + 38px * var(--mobile-controls-scale));
 }
 
-.app[data-touch="true"] .terminal-stage:has(.terminal-mobile-controls) .terminal-selection-sheet {
-  bottom: calc(var(--terminal-mobile-controls-height) + 8px * var(--mobile-controls-scale));
+.app[data-touch="true"] .terminal-stage:has(.terminal-command-controls) .terminal-upload-status,
+.app[data-touch="true"] .terminal-stage:has(.terminal-command-controls) .terminal-selection-sheet {
+  bottom: calc(var(--terminal-command-controls-height) + 8px * var(--mobile-controls-scale));
 }

--- a/web/src/terminalPrefs.test.ts
+++ b/web/src/terminalPrefs.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_DESKTOP_COMMAND_COMPOSER,
+  DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
   DEFAULT_TERMINAL_FONT_SIZE_PX,
   MAX_TERMINAL_FONT_SIZE_PX,
   MIN_TERMINAL_FONT_SIZE_PX,
+  parseDesktopCommandComposer,
+  parseDesktopCommandEnterNewline,
   parseTerminalFontSizePx,
 } from "./terminalPrefs";
 
@@ -18,5 +22,18 @@ describe("terminal preferences", () => {
     expect(parseTerminalFontSizePx(null)).toBe(DEFAULT_TERMINAL_FONT_SIZE_PX);
     expect(parseTerminalFontSizePx("13")).toBe(DEFAULT_TERMINAL_FONT_SIZE_PX);
     expect(parseTerminalFontSizePx(Number.NaN)).toBe(DEFAULT_TERMINAL_FONT_SIZE_PX);
+  });
+
+  it("parses desktop command composer flags", () => {
+    expect(parseDesktopCommandComposer(true)).toBe(true);
+    expect(parseDesktopCommandComposer(false)).toBe(false);
+    expect(parseDesktopCommandComposer("true")).toBe(DEFAULT_DESKTOP_COMMAND_COMPOSER);
+    expect(parseDesktopCommandComposer(undefined, true)).toBe(true);
+    expect(parseDesktopCommandEnterNewline(true)).toBe(true);
+    expect(parseDesktopCommandEnterNewline(false)).toBe(false);
+    expect(parseDesktopCommandEnterNewline("false")).toBe(
+      DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
+    );
+    expect(parseDesktopCommandEnterNewline(undefined, false)).toBe(false);
   });
 });

--- a/web/src/terminalPrefs.ts
+++ b/web/src/terminalPrefs.ts
@@ -1,6 +1,8 @@
 export const DEFAULT_TERMINAL_FONT_SIZE_PX = 13;
 export const MIN_TERMINAL_FONT_SIZE_PX = 10;
 export const MAX_TERMINAL_FONT_SIZE_PX = 24;
+export const DEFAULT_DESKTOP_COMMAND_COMPOSER = false;
+export const DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE = true;
 
 export function parseTerminalFontSizePx(value: unknown) {
   if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -10,4 +12,18 @@ export function parseTerminalFontSizePx(value: unknown) {
     MAX_TERMINAL_FONT_SIZE_PX,
     Math.max(MIN_TERMINAL_FONT_SIZE_PX, Math.round(value)),
   );
+}
+
+export function parseDesktopCommandComposer(
+  value: unknown,
+  fallback = DEFAULT_DESKTOP_COMMAND_COMPOSER,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseDesktopCommandEnterNewline(
+  value: unknown,
+  fallback = DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
+) {
+  return typeof value === "boolean" ? value : fallback;
 }

--- a/web/src/useTerminalFocusRequest.test.tsx
+++ b/web/src/useTerminalFocusRequest.test.tsx
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+import { act, useCallback, useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTerminalFocusRequest } from "./useTerminalFocusRequest";
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+});
+
+function FocusHarness({ token, retry }: { token: number; retry: boolean }) {
+  const composer = useRef<HTMLTextAreaElement>(null);
+  const focus = useCallback(() => composer.current?.focus(), []);
+  useTerminalFocusRequest(token, focus, retry);
+  return <><textarea ref={composer} /><input aria-label="Terminal input" /></>;
+}
+
+async function render(token: number, retry: boolean) {
+  await act(async () => root.render(<FocusHarness token={token} retry={retry} />));
+}
+
+async function advance(ms: number) {
+  await act(async () => vi.advanceTimersByTime(ms));
+}
+
+describe("terminal focus requests", () => {
+  it("lets a terminal click win after desktop composer default focus", async () => {
+    await render(1, false);
+    await advance(20);
+    expect(document.activeElement).toBe(container.querySelector("textarea"));
+    const terminal = container.querySelector("input")!;
+    terminal.focus();
+    await advance(250);
+    expect(document.activeElement).toBe(terminal);
+    // A settings rerender without a new focus request must not steal focus either.
+    await render(1, false);
+    await advance(250);
+    expect(document.activeElement).toBe(terminal);
+  });
+
+  it("preserves the mobile keyboard retries", async () => {
+    await render(1, true);
+    const composer = container.querySelector("textarea")!;
+    const terminal = container.querySelector("input")!;
+    await advance(20);
+    expect(document.activeElement).toBe(composer);
+    terminal.focus();
+    await advance(60);
+    expect(document.activeElement).toBe(composer);
+    terminal.focus();
+    await advance(140);
+    expect(document.activeElement).toBe(composer);
+  });
+
+  it("cancels pending focus when a pane loses the focus request", async () => {
+    await render(1, true);
+    await render(0, true);
+    const terminal = container.querySelector("input")!;
+    terminal.focus();
+    await advance(250);
+    expect(document.activeElement).toBe(terminal);
+  });
+});

--- a/web/src/useTerminalFocusRequest.ts
+++ b/web/src/useTerminalFocusRequest.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from "react";
+
+/** Retries are for mobile keyboards; desktop defaults must yield to subsequent clicks. */
+export function useTerminalFocusRequest(token: number, focus: () => void, retry: boolean) {
+  const retryRef = useRef(retry);
+  retryRef.current = retry;
+
+  useEffect(() => {
+    if (token === 0) return;
+    const frame = window.requestAnimationFrame(focus);
+    const timers = (retryRef.current ? [80, 220] : []).map((delay) =>
+      window.setTimeout(focus, delay),
+    );
+    return () => {
+      window.cancelAnimationFrame(frame);
+      for (const timer of timers) window.clearTimeout(timer);
+    };
+  }, [focus, token]);
+}


### PR DESCRIPTION
Closes #81

## Summary

Expose the existing compose-before-send command input on desktop as an opt-in Terminal setting without switching the terminal into touch/mobile mode.

This allows long and multiline agent prompts to be pasted, edited, and submitted as one input while retaining normal desktop terminal behavior.

## Changes

- add an opt-in desktop **Command composer** setting under Terminal
- reuse the existing expanding command-input implementation
- keep desktop autofocus, scrolling, cursor behavior, mouse selection, and raw terminal input unchanged
- add a separate desktop **Enter inserts newline** preference
- support Ctrl+Enter on Windows/Linux and Cmd+Enter on macOS to submit
- preserve existing touch/mobile behavior
- persist the new preferences using the existing display-preference mechanism
- add focused tests and an Unreleased changelog entry

## Validation

Automated:

- focused composer tests: 15 passed
- web tests: 320 passed
- compatibility-crate tests: 116 passed
- bridge tests: 146 passed
- `npm run lint`
- `npm run test`
- `npm run build`
- `git diff --check`

Physical browser smoke test with Herdr v0.8.2 and Codex v0.153.4 on Windows:

- desktop composer appears without touch emulation
- multiline pasted prompts remain one editable value
- Send submits exactly one Codex turn
- Ctrl+Enter submits
- blank lines, bullets, slashes, quotes, and Swedish characters survive
- normal desktop layout and scrolling remain intact

## Notes

A separate pre-existing desktop terminal issue was observed where Ctrl+C with selected terminal text both copies the selection and forwards Ctrl+C to the PTY. That behavior exists in unmodified v0.5.1 and is intentionally not changed in this PR.
