### PR TITLE
Prevent terminal copy from also interrupting PTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Fixed desktop terminal copy shortcuts so copying selected text no longer also sends Ctrl+C to
+  the PTY; Ctrl+C without a selection and Ctrl+C on macOS retain their normal interrupt behavior.
+
 ### Removed
 
 ## [0.5.1] - 2026-09-04

--- a/web/src/terminalRenderer.test.ts
+++ b/web/src/terminalRenderer.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { refreshTerminalFontRendering } from "./terminalRenderer";
+import {
+  handleTerminalCustomKeyEvent,
+  refreshTerminalFontRendering,
+} from "./terminalRenderer";
 
 describe("terminal renderer font refresh", () => {
   it("forces the current viewport to redraw when font settings are unchanged", () => {
@@ -33,3 +36,72 @@ describe("terminal renderer font refresh", () => {
     expect(calls).toEqual(["remeasure", "fit", "render"]);
   });
 });
+
+describe("terminal selection copy shortcuts", () => {
+  it("consumes Windows/Linux Ctrl+C when canonical terminal selection text exists", () => {
+    const terminal = terminalInput("selected terminal text");
+
+    expect(dispatchCtrlC(keyEvent({ ctrlKey: true }), terminal, "Win32")).toBe(true);
+    expect(terminal.getSelection).toHaveBeenCalledOnce();
+    expect(terminal.input).not.toHaveBeenCalled();
+  });
+
+  it("delegates Windows/Linux Ctrl+C to Ghostty for PTY ^C when selection is empty", () => {
+    const terminal = terminalInput("");
+
+    expect(dispatchCtrlC(keyEvent({ ctrlKey: true }), terminal, "Linux x86_64")).toBe(false);
+    expect(terminal.input).toHaveBeenCalledOnce();
+    expect(terminal.input).toHaveBeenCalledWith("\x03", true);
+  });
+
+  it("consumes macOS Cmd+C when canonical terminal selection text exists", () => {
+    const terminal = terminalInput("selected terminal text");
+
+    expect(dispatchCtrlC(keyEvent({ metaKey: true }), terminal, "MacIntel")).toBe(true);
+    expect(terminal.input).not.toHaveBeenCalled();
+  });
+
+  it("delegates macOS Ctrl+C to Ghostty for PTY interrupt even with a selection", () => {
+    const terminal = terminalInput("selected terminal text");
+
+    expect(dispatchCtrlC(keyEvent({ ctrlKey: true }), terminal, "MacIntel")).toBe(false);
+    expect(terminal.input).toHaveBeenCalledOnce();
+    expect(terminal.input).toHaveBeenCalledWith("\x03", true);
+  });
+});
+
+function keyEvent(overrides: Partial<KeyboardEvent> = {}) {
+  return {
+    altKey: false,
+    code: "KeyC",
+    ctrlKey: false,
+    isComposing: false,
+    key: "c",
+    keyCode: 67,
+    metaKey: false,
+    shiftKey: false,
+    stopImmediatePropagation: vi.fn(),
+    stopPropagation: vi.fn(),
+    ...overrides,
+  } as unknown as KeyboardEvent;
+}
+
+function terminalInput(selection: string) {
+  return {
+    getSelection: vi.fn(() => selection),
+    input: vi.fn(),
+  };
+}
+
+function dispatchCtrlC(
+  event: KeyboardEvent,
+  terminal: ReturnType<typeof terminalInput>,
+  platform: string,
+) {
+  const handled = handleTerminalCustomKeyEvent(event, terminal, platform);
+  if (!handled) {
+    // This is Ghostty's existing default Ctrl+C encoding path.
+    terminal.input("\x03", true);
+  }
+  return handled;
+}

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -213,21 +213,9 @@ export class GhosttyRenderer implements TerminalRenderer {
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.open(container);
-    terminal.attachCustomKeyEventHandler((event) => {
-      if (isImeComposingKeyEvent(event)) {
-        return false;
-      }
-      const output = customKeyboardEventOutput(event);
-      if (!output) {
-        return false;
-      }
-      event.stopPropagation();
-      if (typeof event.stopImmediatePropagation === "function") {
-        event.stopImmediatePropagation();
-      }
-      terminal.input(output, true);
-      return true;
-    });
+    terminal.attachCustomKeyEventHandler((event) =>
+      handleTerminalCustomKeyEvent(event, terminal),
+    );
     terminal.textarea?.blur();
     container.blur();
     container.removeAttribute("contenteditable");
@@ -1592,6 +1580,49 @@ function customKeyboardEventOutput(event: KeyboardEvent) {
     return "\x1B[Z";
   }
   return null;
+}
+
+export function handleTerminalCustomKeyEvent(
+  event: KeyboardEvent,
+  terminal: Pick<Terminal, "getSelection" | "input">,
+  platform = typeof navigator === "undefined" ? "" : navigator.platform,
+) {
+  if (isImeComposingKeyEvent(event)) {
+    return false;
+  }
+  // Ghostty copies the canonical selection on mouseup. Consume the matching
+  // desktop copy shortcut here so its input handler cannot also emit ^C.
+  const consumesSelectionCopy =
+    isTerminalSelectionCopyShortcut(event, platform) && terminal.getSelection().length > 0;
+  const output = customKeyboardEventOutput(event);
+  if (!consumesSelectionCopy && !output) {
+    return false;
+  }
+  event.stopPropagation();
+  if (typeof event.stopImmediatePropagation === "function") {
+    event.stopImmediatePropagation();
+  }
+  if (output) {
+    terminal.input(output, true);
+  }
+  return true;
+}
+
+type TerminalSelectionCopyShortcutEvent = Pick<
+  KeyboardEvent,
+  "altKey" | "code" | "ctrlKey" | "metaKey" | "shiftKey"
+>;
+
+function isTerminalSelectionCopyShortcut(
+  event: TerminalSelectionCopyShortcutEvent,
+  platform = typeof navigator === "undefined" ? "" : navigator.platform,
+) {
+  if (event.code !== "KeyC" || event.altKey || event.shiftKey) {
+    return false;
+  }
+  return platform.startsWith("Mac")
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
 }
 
 function textareaKeyboardEventOutput(event: KeyboardEvent) {


### PR DESCRIPTION
Closes #83

## Summary

Prevent the desktop terminal copy shortcut from also forwarding an interrupt to the PTY when terminal text is selected.

Previously, Ctrl+C with selected terminal text successfully copied the selection but also sent `^C` to the foreground process.

## Behavior

### Windows/Linux

- selected text + Ctrl+C → copy only
- no selection + Ctrl+C → normal PTY interrupt

### macOS

- selected text + Cmd+C → copy only
- Ctrl+C → normal PTY interrupt

## Implementation

- use Ghostty's canonical terminal selection state
- consume the platform copy shortcut only when a non-empty terminal selection exists
- otherwise preserve the existing terminal keyboard path
- no copy-on-select or right-click behavior added
- mobile/touch selection behavior unchanged

## Validation

Automated:

- focused renderer tests: 32 passed
- dev tests: 5 passed
- web tests: 317 passed
- compatibility tests: 116 passed
- bridge tests: 146 passed
- `npm run lint`
- `npm run test`
- `npm run build`
- `git diff --check`

Physical Windows browser test:

- with terminal text selected, Ctrl+C copied the selection and a running `sleep 30` continued running
- with no selection, Ctrl+C interrupted `sleep 30` normally

This fix is independent of the desktop command composer work in #81 / #82.
