### PR TITLE
fix: patch build dependencies and improve command dictation input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Update locked development dependencies to established security-patched releases for the
   Capacitor, lint, test, and frontend build tools, preserving cross-platform optional packages.
+  [PR #85](https://github.com/kcosr/herdr-web/pull/85).
 
 - Focus the enabled desktop command composer on terminal attach and navigation focus requests,
   after closing Settings, and after Send, including Ctrl+Enter and Cmd+Enter. Direct terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- Add an optional mobile “Focus command input after Send” setting, off by default,
+  to refocus the cleared command field for continued typing.
+  [PR #85](https://github.com/kcosr/herdr-web/pull/85).
+
 - Added an opt-in desktop command composer under Settings → Terminal for editing multiline input
   before sending it, without changing desktop terminal selection, scrolling, or cursor
   behavior. [PR #82](https://github.com/kcosr/herdr-web/pull/82), contributed by
@@ -14,6 +18,12 @@
 ### Changed
 
 ### Fixed
+
+- Discard late keyboard composition updates for 250 ms after command Send or Stage so
+  submitted dictation cannot immediately repopulate the replacement input. Preserve existing
+  field replacement and focus behavior; ordinary non-composing typing and paste remain accepted.
+  New composition started within this brief window can also be discarded.
+  [PR #85](https://github.com/kcosr/herdr-web/pull/85).
 
 - Update locked development dependencies to established security-patched releases for the
   Capacitor, lint, test, and frontend build tools, preserving cross-platform optional packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Fixed
 
+- Update locked development dependencies to established security-patched releases for the
+  Capacitor, lint, test, and frontend build tools, preserving cross-platform optional packages.
+
 - Focus the enabled desktop command composer on terminal attach and navigation focus requests,
   after closing Settings, and after Send, including Ctrl+Enter and Cmd+Enter. Direct terminal
   clicks retain focus through reconnects and immediately after a default focus request. Desktop

--- a/docs/android.md
+++ b/docs/android.md
@@ -93,7 +93,8 @@ device backup storage.
 
 The Android shell uses the same area-based Settings UI described in the project README. Android
 starts disconnected, so the Bridge area is required for selecting a backend. On narrow screens the
-area selector appears as horizontal tabs. Android-specific touch behavior lives in the Mobile area.
+area selector appears as horizontal tabs. Android-specific touch behavior lives in the Mobile area. Enable **Focus command input after Send** there to refocus the cleared command field
+for continued typing. This option is off by default and does not change Stage behavior.
 
 ## Build Prerequisites
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -268,9 +268,9 @@
       "dev": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "dev": true,
       "engines": {
         "node": ">=14.6"
@@ -369,15 +369,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-crc32": {
@@ -948,9 +948,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "dev": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1838,15 +1838,15 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2196,9 +2196,9 @@
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.10.44",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz",
+      "integrity": "sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2218,9 +2218,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2248,10 +2248,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2271,9 +2271,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -2520,9 +2520,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.372",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
-      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -3161,9 +3161,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4440,9 +4440,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4465,9 +4465,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4629,9 +4629,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4649,7 +4649,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5169,9 +5169,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "engines": {
         "node": ">=20.18.1"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -91,12 +91,14 @@ import type { LauncherPresetsResponse } from "./launcherPresets";
 import { fetchWithTimeout } from "./fetchWithTimeout";
 import {
   DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
+  DEFAULT_MOBILE_COMMAND_FOCUS_AFTER_SUBMIT,
   DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT,
   DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
   DEFAULT_MOBILE_LONG_PRESS_BEHAVIOR,
   DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
   DEFAULT_MOBILE_TERMINAL_TAP_TARGET,
   parseMobileCommandEnterNewline,
+  parseMobileCommandFocusAfterSubmit,
   parseMobileCommandExpandingInput,
   parseMobileKeyboardHideRefit,
   parseMobileLongPressBehavior,
@@ -436,6 +438,7 @@ type DisplayPrefs = {
   mobileKeyboardHideRefit: boolean;
   mobileCommandExpandingInput: boolean;
   mobileCommandEnterNewline: boolean;
+  mobileCommandFocusAfterSubmit: boolean;
 };
 type SharedNavigationPrefs = {
   selectedBridgeId: BridgeId | null;
@@ -503,6 +506,7 @@ function readDisplayPrefs(): DisplayPrefs {
     mobileKeyboardHideRefit: DEFAULT_MOBILE_KEYBOARD_HIDE_REFIT,
     mobileCommandExpandingInput: DEFAULT_MOBILE_COMMAND_EXPANDING_INPUT,
     mobileCommandEnterNewline: DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
+    mobileCommandFocusAfterSubmit: DEFAULT_MOBILE_COMMAND_FOCUS_AFTER_SUBMIT,
   };
   try {
     const raw = window.localStorage.getItem(DISPLAY_PREFS_KEY);
@@ -723,6 +727,9 @@ function parseDisplayPrefsValue(
     ),
     mobileCommandEnterNewline: parseMobileCommandEnterNewline(
       parsed.mobileCommandEnterNewline,
+    ),
+    mobileCommandFocusAfterSubmit: parseMobileCommandFocusAfterSubmit(
+      parsed.mobileCommandFocusAfterSubmit,
     ),
   };
 }
@@ -1133,6 +1140,9 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
   const [mobileCommandEnterNewline, setMobileCommandEnterNewline] = useState(
     initialPrefs.mobileCommandEnterNewline,
   );
+  const [mobileCommandFocusAfterSubmit, setMobileCommandFocusAfterSubmit] = useState(
+    initialPrefs.mobileCommandFocusAfterSubmit,
+  );
   const [launchTarget, setLaunchTarget] = useState<ScopedLaunchTarget | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -1241,6 +1251,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
       setMobileKeyboardHideRefit(prefs.mobileKeyboardHideRefit);
       setMobileCommandExpandingInput(prefs.mobileCommandExpandingInput);
       setMobileCommandEnterNewline(prefs.mobileCommandEnterNewline);
+      setMobileCommandFocusAfterSubmit(prefs.mobileCommandFocusAfterSubmit);
       setDisplayPrefsLoaded(true);
       },
     );
@@ -1795,6 +1806,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
       mobileKeyboardHideRefit,
       mobileCommandExpandingInput,
       mobileCommandEnterNewline,
+      mobileCommandFocusAfterSubmit,
     });
   }, [
     displayPrefsLoaded,
@@ -1834,6 +1846,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
     mobileKeyboardHideRefit,
     mobileCommandExpandingInput,
     mobileCommandEnterNewline,
+    mobileCommandFocusAfterSubmit,
   ]);
 
   useEffect(() => {
@@ -4137,6 +4150,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
             mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
             mobileCommandExpandingInput={mobileCommandExpandingInput}
             mobileCommandEnterNewline={mobileCommandEnterNewline}
+            mobileCommandFocusAfterSubmit={mobileCommandFocusAfterSubmit}
             terminalInputTransport={terminalInputTransport}
             terminalInputBatchDelayMs={terminalInputBatchDelayMs}
             terminalOutputCoalesceMs={terminalOutputCoalesceMs}
@@ -4168,6 +4182,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
             mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
             mobileCommandExpandingInput={mobileCommandExpandingInput}
             mobileCommandEnterNewline={mobileCommandEnterNewline}
+            mobileCommandFocusAfterSubmit={mobileCommandFocusAfterSubmit}
             terminalInputTransport={terminalInputTransport}
             terminalInputBatchDelayMs={terminalInputBatchDelayMs}
             terminalOutputCoalesceMs={terminalOutputCoalesceMs}
@@ -4429,7 +4444,9 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
           mobileCommandExpandingInput={mobileCommandExpandingInput}
           onMobileCommandExpandingInput={setMobileCommandExpandingInput}
           mobileCommandEnterNewline={mobileCommandEnterNewline}
+          mobileCommandFocusAfterSubmit={mobileCommandFocusAfterSubmit}
           onMobileCommandEnterNewline={setMobileCommandEnterNewline}
+          onMobileCommandFocusAfterSubmit={setMobileCommandFocusAfterSubmit}
           showMobileKeyboardHideRefit={showMobileKeyboardHideRefit}
           mobileKeyboardHideRefit={mobileKeyboardHideRefit}
           onMobileKeyboardHideRefit={setMobileKeyboardHideRefit}
@@ -5886,6 +5903,7 @@ function SplitGrid({
   mobileTouchSelectionEndpointTimeoutMs,
   mobileCommandExpandingInput,
   mobileCommandEnterNewline,
+  mobileCommandFocusAfterSubmit,
   terminalInputTransport,
   terminalInputBatchDelayMs,
   terminalOutputCoalesceMs,
@@ -5912,6 +5930,7 @@ function SplitGrid({
   mobileTouchSelectionEndpointTimeoutMs: MobileTouchSelectionEndpointTimeoutMs;
   mobileCommandExpandingInput: boolean;
   mobileCommandEnterNewline: boolean;
+  mobileCommandFocusAfterSubmit: boolean;
   terminalInputTransport: TerminalInputTransport;
   terminalInputBatchDelayMs: number;
   terminalOutputCoalesceMs: number;
@@ -5955,6 +5974,7 @@ function SplitGrid({
               mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
               mobileCommandExpandingInput={mobileCommandExpandingInput}
               mobileCommandEnterNewline={mobileCommandEnterNewline}
+              mobileCommandFocusAfterSubmit={mobileCommandFocusAfterSubmit}
               terminalInputTransport={terminalInputTransport}
               terminalInputBatchDelayMs={terminalInputBatchDelayMs}
               terminalOutputCoalesceMs={terminalOutputCoalesceMs}

--- a/web/src/BackendSettingsDialog.test.tsx
+++ b/web/src/BackendSettingsDialog.test.tsx
@@ -47,6 +47,24 @@ afterEach(async () => {
 });
 
 describe("BackendSettingsDialog terminal accessibility", () => {
+  it("offers mobile refocus independently of expanding input", async () => {
+    const onFocusChange = vi.fn();
+    const { container } = await render(
+      <BackendSettingsDialog {...settingsProps()} showMobileTerminalSettings={true}
+        mobileCommandExpandingInput={false} onMobileCommandFocusAfterSubmit={onFocusChange} />,
+    );
+    const tab = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'))
+      .find((button) => button.textContent?.includes("Mobile"));
+    expect(tab).toBeDefined();
+    await act(async () => tab!.click());
+    const group = requiredElement<HTMLElement>(container,
+      '[role="group"][aria-label="Focus command input after Send"]');
+    const [off, on] = Array.from(group.querySelectorAll<HTMLButtonElement>("button"));
+    expect(off.getAttribute("aria-pressed")).toBe("true");
+    await act(async () => on.click());
+    expect(onFocusChange).toHaveBeenCalledWith(true);
+  });
+
   it("exposes a persisted-style opt-in control in the Terminal area", async () => {
     const onChange = vi.fn();
     const { container } = await render(<SettingsHarness onChange={onChange} />);
@@ -241,6 +259,8 @@ function settingsProps() {
     mobileCommandExpandingInput: true,
     onMobileCommandExpandingInput: vi.fn(),
     mobileCommandEnterNewline: false,
+    mobileCommandFocusAfterSubmit: false,
+    onMobileCommandFocusAfterSubmit: vi.fn(),
     onMobileCommandEnterNewline: vi.fn(),
     showMobileKeyboardHideRefit: true,
     mobileKeyboardHideRefit: true,

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -103,7 +103,9 @@ type Props = {
   mobileCommandExpandingInput: boolean;
   onMobileCommandExpandingInput: (enabled: boolean) => void;
   mobileCommandEnterNewline: boolean;
+  mobileCommandFocusAfterSubmit: boolean;
   onMobileCommandEnterNewline: (enabled: boolean) => void;
+  onMobileCommandFocusAfterSubmit: (enabled: boolean) => void;
   showMobileKeyboardHideRefit: boolean;
   mobileKeyboardHideRefit: boolean;
   onMobileKeyboardHideRefit: (enabled: boolean) => void;
@@ -163,7 +165,9 @@ export function BackendSettingsDialog({
   mobileCommandExpandingInput,
   onMobileCommandExpandingInput,
   mobileCommandEnterNewline,
+  mobileCommandFocusAfterSubmit,
   onMobileCommandEnterNewline,
+  onMobileCommandFocusAfterSubmit,
   showMobileKeyboardHideRefit,
   mobileKeyboardHideRefit,
   onMobileKeyboardHideRefit,
@@ -978,6 +982,31 @@ export function BackendSettingsDialog({
                       data-on={mobileCommandExpandingInput}
                       aria-pressed={mobileCommandExpandingInput}
                       onClick={() => onMobileCommandExpandingInput(true)}
+                    >
+                      On
+                    </button>
+                  </div>
+                </div>
+                <div className="settings-row">
+                  <span>Focus command input after Send</span>
+                  <div
+                    className="segmented-control"
+                    role="group"
+                    aria-label="Focus command input after Send"
+                  >
+                    <button
+                      type="button"
+                      data-on={!mobileCommandFocusAfterSubmit}
+                      aria-pressed={!mobileCommandFocusAfterSubmit}
+                      onClick={() => onMobileCommandFocusAfterSubmit(false)}
+                    >
+                      Off
+                    </button>
+                    <button
+                      type="button"
+                      data-on={mobileCommandFocusAfterSubmit}
+                      aria-pressed={mobileCommandFocusAfterSubmit}
+                      onClick={() => onMobileCommandFocusAfterSubmit(true)}
                     >
                       On
                     </button>

--- a/web/src/MobileTerminalControls.test.tsx
+++ b/web/src/MobileTerminalControls.test.tsx
@@ -62,6 +62,73 @@ describe("TerminalCommandControls", () => {
     });
   }
 
+  for (const expanding of [false, true]) {
+    it(`refocuses mobile Send when enabled, with guard intact (textarea=${expanding})`, async () => {
+      vi.spyOn(performance, "now").mockReturnValue(1000);
+      const { container } = await renderControls(expanding, { mobileFocusAfterSubmit: true });
+      const original = commandField(container);
+      original.focus();
+      await setCommandValue(original, "dictated command");
+      await submitForm(container);
+      const replacement = commandField(container);
+      expect(replacement).not.toBe(original);
+      expect(document.activeElement).toBe(replacement);
+      expect(replacement.value).toBe("");
+      await setCommandInput(replacement, "late correction", "insertCompositionText", true);
+      expect(replacement.value).toBe("");
+      expect(document.activeElement).toBe(replacement);
+      await setCommandInput(replacement, "next", "insertText");
+      expect(replacement.value).toBe("next");
+      await clickStage(container);
+      expect(commandField(container).value).toBe("");
+      expect(document.activeElement).not.toBe(commandField(container));
+    });
+  }
+
+  for (const expanding of [false, true]) {
+    for (const action of ["send", "stage"] as const) {
+      it(`guards late composition after ${action} across replacement (textarea=${expanding})`, async () => {
+        let now = 1000;
+        vi.spyOn(performance, "now").mockImplementation(() => now);
+        const { container, onSubmitCommand, onStageCommand, drafts } = await renderControls(expanding);
+        const original = commandField(container);
+        await setCommandValue(original, "accepted dictation");
+        if (action === "send") await submitForm(container);
+        else await clickStage(container);
+        expect(action === "send" ? onSubmitCommand : onStageCommand)
+          .toHaveBeenCalledExactlyOnceWith("accepted dictation");
+        const field = commandField(container);
+        expect(field).not.toBe(original);
+        field.focus();
+        await setCommandInput(field, "late correction", "insertCompositionText", true);
+        expect(field.value).toBe("");
+        expect(drafts.get("bridge-a", "pane-a")).toBe("");
+        expect(document.activeElement).toBe(field);
+        await setCommandInput(field, "new", "insertText");
+        await setCommandInput(field, "new paste", "insertFromPaste");
+        now = 1249;
+        await setCommandInput(field, "late correction again", "insertFromComposition");
+        expect(field.value).toBe("new paste");
+        expect(drafts.get("bridge-a", "pane-a")).toBe("new paste");
+        expect(commandField(container)).toBe(field);
+        now = 1250;
+        await setCommandInput(field, "fresh dictation", "insertCompositionText", true);
+        expect(field.value).toBe("fresh dictation");
+        expect(drafts.get("bridge-a", "pane-a")).toBe("fresh dictation");
+      });
+    }
+  }
+
+  it("does not carry a submitted pane's guard into another pane", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(1000);
+    const { container, renderPane } = await renderControls(true);
+    await setCommandValue(commandField(container), "first pane");
+    await submitForm(container);
+    await renderPane("bridge-a", "pane-b");
+    await setCommandInput(commandField(container), "second pane", "insertCompositionText", true);
+    expect(commandField(container).value).toBe("second pane");
+  });
+
   it("clears and remounts after Stage while keeping empty Stage disabled", async () => {
     const { container, onStageCommand } = await renderControls(false);
     const firstField = commandField(container);
@@ -274,7 +341,7 @@ describe("TerminalCommandControls", () => {
 
 async function renderControls(
   expandingInput: boolean,
-  options: { enterNewline?: boolean; mobileControls?: boolean } = {},
+  options: { enterNewline?: boolean; mobileControls?: boolean; mobileFocusAfterSubmit?: boolean } = {},
 ) {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -300,6 +367,7 @@ async function renderControls(
             expandingInput={expandingInput}
             enterNewline={options.enterNewline ?? false}
             mobileControls={options.mobileControls ?? true}
+            mobileFocusAfterSubmit={options.mobileFocusAfterSubmit}
             controlsScalePercent={100}
             onControlsHeightChange={vi.fn()}
             onInput={vi.fn()}
@@ -384,5 +452,19 @@ function stageButton(container: HTMLElement) {
 async function clickStage(container: HTMLElement) {
   await act(async () => {
     stageButton(container).click();
+  });
+}
+
+async function setCommandInput(
+  field: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+  inputType: string,
+  isComposing = false,
+) {
+  await act(async () => {
+    const prototype = field instanceof HTMLTextAreaElement
+      ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(prototype, "value")?.set?.call(field, value);
+    field.dispatchEvent(new InputEvent("input", { bubbles: true, inputType, isComposing }));
   });
 }

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -100,6 +100,8 @@ type Props = {
   mobileCommandExpandingInput?: boolean;
   /** Whether Enter inserts a newline in the expanding mobile command input. */
   mobileCommandEnterNewline?: boolean;
+  /** Refocus the mobile command field after Send. */
+  mobileCommandFocusAfterSubmit?: boolean;
   /** Browser-to-bridge transport for terminal input payloads. */
   terminalInputTransport?: TerminalInputTransport;
   /** Delay for coalescing short terminal input payloads. Zero disables batching. */
@@ -168,6 +170,7 @@ export function TerminalView({
   mobileTouchSelectionEndpointTimeoutMs = DEFAULT_MOBILE_TOUCH_SELECTION_ENDPOINT_TIMEOUT_MS,
   mobileCommandExpandingInput = false,
   mobileCommandEnterNewline = false,
+  mobileCommandFocusAfterSubmit = false,
   terminalInputTransport = "json",
   terminalInputBatchDelayMs = 0,
   terminalOutputCoalesceMs = DEFAULT_TERMINAL_OUTPUT_COALESCE_MS,
@@ -1440,6 +1443,7 @@ export function TerminalView({
           expandingInput={mobileControls ? mobileCommandExpandingInput : true}
           enterNewline={mobileControls ? mobileCommandEnterNewline : desktopCommandEnterNewline}
           mobileControls={mobileControls}
+          mobileFocusAfterSubmit={mobileCommandFocusAfterSubmit}
           controlsScalePercent={mobileControls ? mobileControlsScalePercent : 100}
           onControlsHeightChange={setCommandControlsHeight}
           onInput={sendTerminalInput}
@@ -1534,6 +1538,7 @@ export function TerminalCommandControls({
   expandingInput,
   enterNewline,
   mobileControls,
+  mobileFocusAfterSubmit = false,
   controlsScalePercent,
   onControlsHeightChange,
   onInput,
@@ -1550,6 +1555,7 @@ export function TerminalCommandControls({
   expandingInput: boolean;
   enterNewline: boolean;
   mobileControls: boolean;
+  mobileFocusAfterSubmit?: boolean;
   controlsScalePercent: number;
   onControlsHeightChange: (heightPx: number | null) => void;
   onInput: (data: string) => void;
@@ -1560,6 +1566,28 @@ export function TerminalCommandControls({
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [value, setValue] = useCommandDraft(bridgeId, paneId);
+  // Keep this deadline outside the keyed field so it survives input replacement.
+  const compositionGuardUntilRef = useRef(0);
+  const acceptedValueRef = useRef(value);
+  useLayoutEffect(() => {
+    acceptedValueRef.current = value;
+  }, [value]);
+  const onCommandChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const input = event.nativeEvent;
+    if (
+      performance.now() < compositionGuardUntilRef.current &&
+      input instanceof InputEvent &&
+      (input.isComposing || input.inputType === "insertCompositionText" ||
+        input.inputType === "insertFromComposition" || input.inputType === "deleteCompositionText")
+    ) {
+      // Native composition edits may not be cancelable. Restore synchronously
+      // without blurring, remounting again, or clearing subsequent accepted input.
+      event.currentTarget.value = acceptedValueRef.current;
+      return;
+    }
+    acceptedValueRef.current = event.currentTarget.value;
+    setValue(event.currentTarget.value);
+  };
   const [fieldKey, setFieldKey] = useState(0);
   const focusAfterSubmitRef = useRef(false);
   const [expanded, setExpanded] = useState(false);
@@ -1568,6 +1596,8 @@ export function TerminalCommandControls({
     commandInputRef.current = node;
   };
   const clearCommandInput = () => {
+    compositionGuardUntilRef.current = performance.now() + 250;
+    acceptedValueRef.current = "";
     setValue("");
     const node = commandInputRef.current;
     if (node) {
@@ -1577,7 +1607,7 @@ export function TerminalCommandControls({
     setFieldKey((key) => key + 1);
   };
   const submit = () => {
-    focusAfterSubmitRef.current = !mobileControls;
+    focusAfterSubmitRef.current = !mobileControls || mobileFocusAfterSubmit;
     const command = value;
     clearCommandInput();
     onSubmitCommand(command);
@@ -1793,7 +1823,7 @@ export function TerminalCommandControls({
             enterKeyHint={enterNewline ? "enter" : "send"}
             disabled={disabled}
             value={value}
-            onChange={(event) => setValue(event.target.value)}
+            onChange={onCommandChange}
             onKeyDown={onCommandTextareaKeyDown}
           />
         ) : (
@@ -1809,7 +1839,7 @@ export function TerminalCommandControls({
             enterKeyHint="send"
             disabled={disabled}
             value={value}
-            onChange={(event) => setValue(event.target.value)}
+            onChange={onCommandChange}
           />
         )}
         <button

--- a/web/src/mobileTerminalPrefs.test.ts
+++ b/web/src/mobileTerminalPrefs.test.ts
@@ -1,3 +1,4 @@
+import { parseMobileCommandFocusAfterSubmit } from "./mobileTerminalPrefs";
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
@@ -68,5 +69,14 @@ describe("mobile terminal preferences", () => {
     expect(parseMobileCommandEnterNewline("false")).toBe(
       DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE,
     );
+  });
+});
+
+describe("mobile command refocus", () => {
+  it("is opt-in and accepts only stored booleans", () => {
+    expect(parseMobileCommandFocusAfterSubmit(true)).toBe(true);
+    for (const value of [false, undefined, null, "true", 1]) {
+      expect(parseMobileCommandFocusAfterSubmit(value)).toBe(false);
+    }
   });
 });

--- a/web/src/mobileTerminalPrefs.ts
+++ b/web/src/mobileTerminalPrefs.ts
@@ -44,3 +44,9 @@ export function parseMobileCommandExpandingInput(value: unknown) {
 export function parseMobileCommandEnterNewline(value: unknown) {
   return typeof value === "boolean" ? value : DEFAULT_MOBILE_COMMAND_ENTER_NEWLINE;
 }
+
+export const DEFAULT_MOBILE_COMMAND_FOCUS_AFTER_SUBMIT = false;
+
+export function parseMobileCommandFocusAfterSubmit(value: unknown) {
+  return typeof value === "boolean" ? value : DEFAULT_MOBILE_COMMAND_FOCUS_AFTER_SUBMIT;
+}


### PR DESCRIPTION
Patches vulnerable build dependencies and prevents late keyboard dictation updates from repopulating the command composer after Send or Stage. Adds an optional mobile **Focus command input after Send** setting, off by default, for continued typing after submission.

The command composer rejects composition updates for 250 ms after Send or Stage while accepting ordinary non-composing typing and paste. Existing input replacement remains in place. Mobile refocus applies only to Send; desktop focus behavior and direct terminal IME handling remain unchanged. Genuinely new composition begun within the 250 ms window can also be discarded. No breaking API, backend, or configuration changes are introduced.

The dependency refresh updates root and web lockfiles to established security-patched releases: tar 7.5.21, xmldom 0.9.12, brace-expansion 5.0.9/1.1.18, browserslist 4.28.7, js-yaml 4.3.1, nanoid 3.3.18, postcss 8.5.23, and undici 7.29.0, plus the July browser-data versions required by Browserslist. Direct manifests remain unchanged and cross-platform optional package records are preserved.

Validation on Linux:

- Full `npm run check` passed: 609 tests (342 frontend, 262 Rust, 5 development-script), lint, Rust formatting, vendor checks, frontend production build, and bridge build.
- Android debug APK built successfully; signature verified and all 22 bundled web assets match the frontend output byte-for-byte.
- Root and web dependency installs reported zero vulnerabilities.
- Keel `claude-default` review of the composition guard returned no findings. The subsequently added refocus setting is covered by frontend regression tests.
- Changelog and Android settings documentation updated. Keyboard steadiness and dictation behavior with mobile refocus still require device testing; macOS builds were not run.
