### PR TITLE
Reduce idle Windows terminal repaints and add cursor blink setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add a Terminal setting for cursor blinking and default it off on Windows. When it is
   off, render only for terminal updates and interactions instead of repainting the
   high-DPI canvas continuously, avoiding severe lag in large Windows browser windows.
+  [PR #86](https://github.com/kcosr/herdr-web/pull/86).
 
 - Discard late keyboard composition updates for 250 ms after command Send or Stage so
   submitted dictation cannot immediately repopulate the replacement input. Preserve existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 ### Fixed
 
+- Add a Terminal setting for cursor blinking and default it off on Windows, avoiding
+  ghostty-web 0.4.0's continuous cursor-row redraws that can make large high-DPI
+  terminal canvases severely laggy.
+
 - Discard late keyboard composition updates for 250 ms after command Send or Stage so
   submitted dictation cannot immediately repopulate the replacement input. Preserve existing
   field replacement and focus behavior; ordinary non-composing typing and paste remain accepted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@
 
 ### Fixed
 
-- Add a Terminal setting for cursor blinking and default it off on Windows, avoiding
-  ghostty-web 0.4.0's continuous cursor-row redraws that can make large high-DPI
-  terminal canvases severely laggy.
+- Add a Terminal setting for cursor blinking and default it off on Windows. When it is
+  off, render only for terminal updates and interactions instead of repainting the
+  high-DPI canvas continuously, avoiding severe lag in large Windows browser windows.
 
 - Discard late keyboard composition updates for 250 ms after command Send or Stage so
   submitted dictation cannot immediately repopulate the replacement input. Preserve existing

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -164,8 +164,10 @@ import {
   DEFAULT_DESKTOP_COMMAND_COMPOSER,
   DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
   DEFAULT_TERMINAL_FONT_SIZE_PX,
+  defaultTerminalCursorBlink,
   parseDesktopCommandComposer,
   parseDesktopCommandEnterNewline,
+  parseTerminalCursorBlink,
   parseTerminalFontSizePx,
 } from "./terminalPrefs";
 import {
@@ -422,6 +424,7 @@ type DisplayPrefs = {
   notesPanelOpen: boolean;
   sidebarOpen: boolean;
   terminalFontSizePx: number;
+  terminalCursorBlink: boolean;
   desktopCommandComposer: boolean;
   desktopCommandEnterNewline: boolean;
   terminalScreenReaderText: boolean;
@@ -490,6 +493,7 @@ function readDisplayPrefs(): DisplayPrefs {
     notesPanelOpen: false,
     sidebarOpen: true,
     terminalFontSizePx: DEFAULT_TERMINAL_FONT_SIZE_PX,
+    terminalCursorBlink: defaultTerminalCursorBlink(),
     desktopCommandComposer: DEFAULT_DESKTOP_COMMAND_COMPOSER,
     desktopCommandEnterNewline: DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
     terminalScreenReaderText: DEFAULT_TERMINAL_SCREEN_READER_TEXT,
@@ -690,6 +694,10 @@ function parseDisplayPrefsValue(
       typeof parsed.notesPanelOpen === "boolean" ? parsed.notesPanelOpen : fallback.notesPanelOpen,
     sidebarOpen,
     terminalFontSizePx: parseTerminalFontSizePx(parsed.terminalFontSizePx),
+    terminalCursorBlink: parseTerminalCursorBlink(
+      parsed.terminalCursorBlink,
+      fallback.terminalCursorBlink,
+    ),
     desktopCommandComposer: parseDesktopCommandComposer(
       parsed.desktopCommandComposer,
       fallback.desktopCommandComposer,
@@ -1093,6 +1101,9 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
   const [terminalFontSizePx, setTerminalFontSizePx] = useState(
     initialPrefs.terminalFontSizePx,
   );
+  const [terminalCursorBlink, setTerminalCursorBlink] = useState(
+    initialPrefs.terminalCursorBlink,
+  );
   const [desktopCommandComposer, setDesktopCommandComposer] = useState(
     initialPrefs.desktopCommandComposer,
   );
@@ -1235,6 +1246,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
       setSelectedPanesByBridgeId(sharedNavigationPrefs.selectedPanesByBridgeId);
       setActiveWorkspacesByBridgeId(sharedNavigationPrefs.activeWorkspacesByBridgeId);
       setTerminalFontSizePx(prefs.terminalFontSizePx);
+      setTerminalCursorBlink(prefs.terminalCursorBlink);
       setDesktopCommandComposer(prefs.desktopCommandComposer);
       setDesktopCommandEnterNewline(prefs.desktopCommandEnterNewline);
       setTerminalScreenReaderText(prefs.terminalScreenReaderText);
@@ -1790,6 +1802,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
       notesPanelOpen,
       sidebarOpen,
       terminalFontSizePx,
+      terminalCursorBlink,
       desktopCommandComposer,
       desktopCommandEnterNewline,
       terminalScreenReaderText,
@@ -1830,6 +1843,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
     notesPanelOpen,
     sidebarOpen,
     terminalFontSizePx,
+    terminalCursorBlink,
     desktopCommandComposer,
     desktopCommandEnterNewline,
     terminalScreenReaderText,
@@ -4141,6 +4155,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
             touchInput={isTouchInput}
             desktopCommandComposer={desktopCommandComposer}
             desktopCommandEnterNewline={desktopCommandEnterNewline}
+            terminalCursorBlink={terminalCursorBlink}
             terminalFontSizePx={terminalFontSizePx}
             terminalScreenReaderText={terminalScreenReaderText}
             autoRenameUploadConflicts={autoRenameUploadConflicts}
@@ -4172,7 +4187,7 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
             mobileControls={isTouchInput}
             desktopCommandComposer={desktopCommandComposer}
             desktopCommandEnterNewline={desktopCommandEnterNewline}
-            cursorBlink={!isTouchInput}
+            cursorBlink={!isTouchInput && terminalCursorBlink}
             terminalFontSizePx={terminalFontSizePx}
             terminalScreenReaderText={terminalScreenReaderText}
             autoRenameUploadConflicts={autoRenameUploadConflicts}
@@ -4413,6 +4428,8 @@ function AppContent({ commandDrafts }: { commandDrafts: ReturnType<typeof create
           onMultiHostSpaceSelection={setMultiHostSpaceSelection}
           terminalFontSizePx={terminalFontSizePx}
           onTerminalFontSizePx={setTerminalFontSizePx}
+          terminalCursorBlink={terminalCursorBlink}
+          onTerminalCursorBlink={setTerminalCursorBlink}
           desktopCommandComposer={desktopCommandComposer}
           onDesktopCommandComposer={setDesktopCommandComposer}
           desktopCommandEnterNewline={desktopCommandEnterNewline}
@@ -5894,6 +5911,7 @@ function SplitGrid({
   touchInput,
   desktopCommandComposer,
   desktopCommandEnterNewline,
+  terminalCursorBlink,
   terminalFontSizePx,
   terminalScreenReaderText,
   autoRenameUploadConflicts,
@@ -5921,6 +5939,7 @@ function SplitGrid({
   touchInput: boolean;
   desktopCommandComposer: boolean;
   desktopCommandEnterNewline: boolean;
+  terminalCursorBlink: boolean;
   terminalFontSizePx: number;
   terminalScreenReaderText: boolean;
   autoRenameUploadConflicts: boolean;
@@ -5964,7 +5983,7 @@ function SplitGrid({
               mobileControls={selected && touchInput}
               desktopCommandComposer={selected && !touchInput && desktopCommandComposer}
               desktopCommandEnterNewline={desktopCommandEnterNewline}
-              cursorBlink={!touchInput}
+              cursorBlink={!touchInput && terminalCursorBlink}
               terminalFontSizePx={terminalFontSizePx}
               terminalScreenReaderText={terminalScreenReaderText}
               autoRenameUploadConflicts={autoRenameUploadConflicts}

--- a/web/src/BackendSettingsDialog.test.tsx
+++ b/web/src/BackendSettingsDialog.test.tsx
@@ -158,7 +158,45 @@ describe("BackendSettingsDialog terminal accessibility", () => {
     expect(onEnterNewlineChange).toHaveBeenCalledWith(false);
     expect(newlineOff?.getAttribute("aria-pressed")).toBe("true");
   });
+
+  it("allows cursor blinking to be enabled in the Terminal area", async () => {
+    const onChange = vi.fn();
+    const { container } = await render(<CursorBlinkSettingsHarness onChange={onChange} />);
+    const terminalTab = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+    ).find((button) => button.textContent?.includes("Terminal"));
+    if (!terminalTab) {
+      throw new Error("missing Terminal settings tab");
+    }
+
+    await act(async () => terminalTab.click());
+    const group = requiredElement<HTMLElement>(
+      container,
+      '[role="group"][aria-label="Terminal cursor blink"]',
+    );
+    const [off, on] = Array.from(group.querySelectorAll<HTMLButtonElement>("button"));
+    expect(off?.getAttribute("aria-pressed")).toBe("true");
+
+    await act(async () => on?.click());
+    expect(onChange).toHaveBeenCalledWith(true);
+    expect(on?.getAttribute("aria-pressed")).toBe("true");
+  });
 });
+
+function CursorBlinkSettingsHarness({ onChange }: { onChange: (enabled: boolean) => void }) {
+  const [terminalCursorBlink, setTerminalCursorBlink] = useState(false);
+  return (
+    <BackendSettingsDialog
+      {...settingsProps()}
+      showMobileTerminalSettings={false}
+      terminalCursorBlink={terminalCursorBlink}
+      onTerminalCursorBlink={(enabled) => {
+        onChange(enabled);
+        setTerminalCursorBlink(enabled);
+      }}
+    />
+  );
+}
 
 function SettingsHarness({ onChange }: { onChange: (enabled: boolean) => void }) {
   const [terminalScreenReaderText, setTerminalScreenReaderText] = useState(false);
@@ -230,6 +268,8 @@ function settingsProps() {
     onMultiHostSpaceSelection: vi.fn(),
     terminalFontSizePx: 13,
     onTerminalFontSizePx: vi.fn(),
+    terminalCursorBlink: false,
+    onTerminalCursorBlink: vi.fn(),
     desktopCommandComposer: false,
     onDesktopCommandComposer: vi.fn(),
     desktopCommandEnterNewline: true,

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -72,6 +72,8 @@ type Props = {
   onMultiHostSpaceSelection: (enabled: boolean) => void;
   terminalFontSizePx: number;
   onTerminalFontSizePx: (value: number) => void;
+  terminalCursorBlink: boolean;
+  onTerminalCursorBlink: (enabled: boolean) => void;
   desktopCommandComposer: boolean;
   onDesktopCommandComposer: (enabled: boolean) => void;
   desktopCommandEnterNewline: boolean;
@@ -136,6 +138,8 @@ export function BackendSettingsDialog({
   onMultiHostSpaceSelection,
   terminalFontSizePx,
   onTerminalFontSizePx,
+  terminalCursorBlink,
+  onTerminalCursorBlink,
   desktopCommandComposer,
   onDesktopCommandComposer,
   desktopCommandEnterNewline,
@@ -713,6 +717,35 @@ export function BackendSettingsDialog({
                     onChange={(value) => onTerminalFontSizePx(parseTerminalFontSizePx(value))}
                   />
                 </div>
+                {!showMobileTerminalSettings ? (
+                  <div className="settings-row">
+                    <span title="Cursor blinking can be expensive in ghostty-web 0.4.0 on large high-DPI terminals">
+                      Cursor blink
+                    </span>
+                    <div
+                      className="segmented-control"
+                      role="group"
+                      aria-label="Terminal cursor blink"
+                    >
+                      <button
+                        type="button"
+                        data-on={!terminalCursorBlink}
+                        aria-pressed={!terminalCursorBlink}
+                        onClick={() => onTerminalCursorBlink(false)}
+                      >
+                        Off
+                      </button>
+                      <button
+                        type="button"
+                        data-on={terminalCursorBlink}
+                        aria-pressed={terminalCursorBlink}
+                        onClick={() => onTerminalCursorBlink(true)}
+                      >
+                        On
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
                 {!showMobileTerminalSettings ? (
                   <>
                     <div className="settings-label">Command input</div>

--- a/web/src/terminalPrefs.test.ts
+++ b/web/src/terminalPrefs.test.ts
@@ -3,11 +3,13 @@ import {
   DEFAULT_DESKTOP_COMMAND_COMPOSER,
   DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
   DEFAULT_TERMINAL_FONT_SIZE_PX,
+  defaultTerminalCursorBlink,
   MAX_TERMINAL_FONT_SIZE_PX,
   MIN_TERMINAL_FONT_SIZE_PX,
   parseDesktopCommandComposer,
   parseDesktopCommandEnterNewline,
   parseTerminalFontSizePx,
+  parseTerminalCursorBlink,
 } from "./terminalPrefs";
 
 describe("terminal preferences", () => {
@@ -35,5 +37,18 @@ describe("terminal preferences", () => {
       DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
     );
     expect(parseDesktopCommandEnterNewline(undefined, false)).toBe(false);
+  });
+
+  it("defaults cursor blink off on Windows and on elsewhere", () => {
+    expect(defaultTerminalCursorBlink("Win32")).toBe(false);
+    expect(defaultTerminalCursorBlink("Windows")).toBe(false);
+    expect(defaultTerminalCursorBlink("MacIntel")).toBe(true);
+    expect(defaultTerminalCursorBlink("Linux x86_64")).toBe(true);
+  });
+
+  it("parses stored cursor blink preferences", () => {
+    expect(parseTerminalCursorBlink(true, false)).toBe(true);
+    expect(parseTerminalCursorBlink(false, true)).toBe(false);
+    expect(parseTerminalCursorBlink("false", true)).toBe(true);
   });
 });

--- a/web/src/terminalPrefs.ts
+++ b/web/src/terminalPrefs.ts
@@ -4,6 +4,12 @@ export const MAX_TERMINAL_FONT_SIZE_PX = 24;
 export const DEFAULT_DESKTOP_COMMAND_COMPOSER = false;
 export const DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE = true;
 
+export function defaultTerminalCursorBlink(
+  platform = typeof navigator === "undefined" ? "" : navigator.platform,
+) {
+  return !platform.toLowerCase().startsWith("win");
+}
+
 export function parseTerminalFontSizePx(value: unknown) {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return DEFAULT_TERMINAL_FONT_SIZE_PX;
@@ -24,6 +30,13 @@ export function parseDesktopCommandComposer(
 export function parseDesktopCommandEnterNewline(
   value: unknown,
   fallback = DEFAULT_DESKTOP_COMMAND_ENTER_NEWLINE,
+) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function parseTerminalCursorBlink(
+  value: unknown,
+  fallback = defaultTerminalCursorBlink(),
 ) {
   return typeof value === "boolean" ? value : fallback;
 }

--- a/web/src/terminalRenderer.test.ts
+++ b/web/src/terminalRenderer.test.ts
@@ -1,8 +1,44 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handleTerminalCustomKeyEvent,
+  renderGhosttyTerminalFrame,
   refreshTerminalFontRendering,
+  shouldUseEventDrivenTerminalRendering,
+  suspendGhosttyIdleRenderLoop,
 } from "./terminalRenderer";
+
+describe("terminal event-driven rendering", () => {
+  it("only enables the idle-loop workaround for a non-blinking Windows terminal", () => {
+    expect(shouldUseEventDrivenTerminalRendering(false, "Win32")).toBe(true);
+    expect(shouldUseEventDrivenTerminalRendering(true, "Win32")).toBe(false);
+    expect(shouldUseEventDrivenTerminalRendering(false, "MacIntel")).toBe(false);
+    expect(shouldUseEventDrivenTerminalRendering(false, "Linux armv8l")).toBe(false);
+  });
+
+  it("cancels ghostty-web's pending idle frame", () => {
+    const cancelFrame = vi.fn();
+    const terminal = { animationFrameId: 42 } as never;
+
+    expect(suspendGhosttyIdleRenderLoop(terminal, cancelFrame)).toBe(true);
+    expect(cancelFrame).toHaveBeenCalledWith(42);
+    expect(terminal).not.toHaveProperty("animationFrameId");
+    expect(suspendGhosttyIdleRenderLoop(terminal, cancelFrame)).toBe(false);
+  });
+
+  it("renders the current viewport with ghostty's scrollbar state", () => {
+    const renderer = { render: vi.fn() };
+    const wasmTerm = {};
+    const terminal = {
+      renderer,
+      wasmTerm,
+      viewportY: 8,
+      scrollbarOpacity: 0.4,
+    } as never;
+
+    expect(renderGhosttyTerminalFrame(terminal)).toBe(true);
+    expect(renderer.render).toHaveBeenCalledWith(wasmTerm, false, 8, terminal, 0.4);
+  });
+});
 
 describe("terminal renderer font refresh", () => {
   it("forces the current viewport to redraw when font settings are unchanged", () => {

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -30,7 +30,10 @@ import type {
   MobileLongPressBehavior,
   MobileTouchSelectionEndpointTimeoutMs,
 } from "./mobileTerminalPrefs";
-import { DEFAULT_TERMINAL_FONT_SIZE_PX } from "./terminalPrefs";
+import {
+  DEFAULT_TERMINAL_FONT_SIZE_PX,
+  defaultTerminalCursorBlink,
+} from "./terminalPrefs";
 import {
   beforeInputOutput,
   idleTerminalImeState,
@@ -105,6 +108,15 @@ type GhosttySelectionManagerAccess = {
     fire?: () => void;
   };
 };
+type GhosttyIdleRenderLoopAccess = {
+  animationFrameId?: number;
+};
+type GhosttyRenderAccess = {
+  renderer?: Terminal["renderer"];
+  wasmTerm?: Terminal["wasmTerm"];
+  viewportY: number;
+  scrollbarOpacity?: number;
+};
 type TerminalBufferLine = {
   readonly length: number;
   getCell(x: number):
@@ -166,11 +178,14 @@ export class GhosttyRenderer implements TerminalRenderer {
   #textInputTapGraceUntil = 0;
   #fontSizePx: number;
   #cursorBlink: boolean;
+  #eventDrivenRendering: boolean;
+  #renderFrameId: number | null = null;
   #disposed = false;
 
   constructor(fontSizePx = DEFAULT_TERMINAL_FONT_SIZE_PX, cursorBlink = true) {
     this.#fontSizePx = fontSizePx;
     this.#cursorBlink = cursorBlink;
+    this.#eventDrivenRendering = shouldUseEventDrivenTerminalRendering(cursorBlink);
   }
 
   async mount(container: HTMLElement) {
@@ -213,6 +228,9 @@ export class GhosttyRenderer implements TerminalRenderer {
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.open(container);
+    if (this.#eventDrivenRendering) {
+      suspendGhosttyIdleRenderLoop(terminal);
+    }
     terminal.attachCustomKeyEventHandler((event) =>
       handleTerminalCustomKeyEvent(event, terminal),
     );
@@ -235,15 +253,9 @@ export class GhosttyRenderer implements TerminalRenderer {
     if (!terminal) {
       return;
     }
-    if (!this.#accessibleScreenPublisher) {
-      terminal.write(data);
-      return;
-    }
-    terminal.write(data, () => {
-      if (this.#isCurrentTerminal(terminal)) {
-        this.#accessibleScreenPublisher?.request();
-      }
-    });
+    terminal.write(data);
+    this.#requestRender(terminal);
+    this.#accessibleScreenPublisher?.request();
   }
 
   setAccessibleScreenListener(callback: ((text: string) => void) | null) {
@@ -350,6 +362,10 @@ export class GhosttyRenderer implements TerminalRenderer {
 
   dispose() {
     this.#disposed = true;
+    if (this.#renderFrameId !== null) {
+      window.cancelAnimationFrame(this.#renderFrameId);
+      this.#renderFrameId = null;
+    }
     this.#touchCleanup?.();
     this.#touchCleanup = null;
     this.#mobileInputCleanup?.();
@@ -374,6 +390,18 @@ export class GhosttyRenderer implements TerminalRenderer {
 
   #isCurrentTerminal(terminal: Terminal) {
     return this.#terminal === terminal;
+  }
+
+  #requestRender(terminal: Terminal) {
+    if (!this.#eventDrivenRendering || this.#renderFrameId !== null) {
+      return;
+    }
+    this.#renderFrameId = window.requestAnimationFrame(() => {
+      this.#renderFrameId = null;
+      if (this.#isCurrentTerminal(terminal)) {
+        renderGhosttyTerminalFrame(terminal);
+      }
+    });
   }
 
   #installAccessibleScreenPublisher() {
@@ -1448,6 +1476,44 @@ export function refreshTerminalFontRendering(
     terminal.renderer.render(terminal.wasmTerm, true, terminal.viewportY, terminal, 0);
   }
   return size;
+}
+
+export function suspendGhosttyIdleRenderLoop(
+  terminal: Terminal,
+  cancelFrame: (frameId: number) => void = (frameId) => window.cancelAnimationFrame(frameId),
+) {
+  // ghostty-web 0.4.0 starts a permanent requestAnimationFrame loop even when
+  // cursor blinking is disabled. A large high-DPI canvas is particularly costly
+  // on Windows, so event-driven mode cancels the pending continuation after open().
+  const access = terminal as unknown as GhosttyIdleRenderLoopAccess;
+  if (access.animationFrameId === undefined) {
+    return false;
+  }
+  cancelFrame(access.animationFrameId);
+  delete access.animationFrameId;
+  return true;
+}
+
+export function shouldUseEventDrivenTerminalRendering(
+  cursorBlink: boolean,
+  platform = typeof navigator === "undefined" ? "" : navigator.platform,
+) {
+  return !cursorBlink && !defaultTerminalCursorBlink(platform);
+}
+
+export function renderGhosttyTerminalFrame(terminal: Terminal) {
+  const access = terminal as unknown as GhosttyRenderAccess;
+  if (!access.renderer || !access.wasmTerm) {
+    return false;
+  }
+  access.renderer.render(
+    access.wasmTerm,
+    false,
+    access.viewportY,
+    terminal,
+    access.scrollbarOpacity ?? 0,
+  );
+  return true;
 }
 
 function hideGhosttyTextarea(textarea: HTMLTextAreaElement) {


### PR DESCRIPTION
Large Windows browser terminals can lag because ghostty-web continuously repaints the high-DPI canvas even when the cursor is not blinking. Add a persisted Terminal cursor-blink setting, default it off on Windows, and stop the idle render loop for Windows terminals with blinking disabled. Terminal output schedules a coalesced frame; existing interaction redraws remain in use.

The setting is shared across browser tabs and applies to both single-pane and split views. Other platforms retain their existing rendering defaults. The idle-loop adjustment targets the pinned ghostty-web 0.4.0 implementation.

This PR contains only the two Windows cursor/repaint commits on top of the separately merged Ctrl+C fix in #84.

Validation: `npm run check` (vendor layout, ESLint, Rust formatting, dev/web/compatibility/bridge tests, frontend and bridge builds). Tests cover platform defaults, the settings control, idle-frame cancellation, and viewport rendering. Physical Windows performance has not been re-measured during this integration.
