### PR TITLE
Fix idle terminal interaction redraws and cursor blink updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 ### Fixed
 
+- Redraw idle Windows terminal selections and scrolling with cursor blinking disabled,
+  and apply cursor-blink changes immediately to mounted terminals.
+
 - Add a Terminal setting for cursor blinking and default it off on Windows. When it is
   off, render only for terminal updates and interactions instead of repainting the
   high-DPI canvas continuously, avoiding severe lag in large Windows browser windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Redraw idle Windows terminal selections and scrolling with cursor blinking disabled,
   and apply cursor-blink changes immediately to mounted terminals.
+  [PR #87](https://github.com/kcosr/herdr-web/pull/87).
 
 - Add a Terminal setting for cursor blinking and default it off on Windows. When it is
   off, render only for terminal updates and interactions instead of repainting the

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -226,8 +226,6 @@ export function TerminalView({
   desktopCommandComposerRef.current = desktopCommandComposer;
   const mobileControlsRef = useRef(mobileControls);
   mobileControlsRef.current = mobileControls;
-  const cursorBlinkRef = useRef(cursorBlink);
-  cursorBlinkRef.current = cursorBlink;
   const terminalFontSizePxRef = useRef(terminalFontSizePx);
   terminalFontSizePxRef.current = terminalFontSizePx;
   const mobileTapTargetRef = useRef(mobileTapTarget);
@@ -513,7 +511,7 @@ export function TerminalView({
     rendererGenerationRef.current = generation;
     const renderer: TerminalRenderer = new GhosttyRenderer(
       terminalFontSizePxRef.current,
-      cursorBlinkRef.current,
+      cursorBlink,
     );
     rendererRef.current = renderer;
     setConnectionState("connecting");
@@ -630,6 +628,7 @@ export function TerminalView({
     };
   }, [
     connectionKey,
+    cursorBlink,
     clearQueuedTerminalInput,
     flushBatchedTerminalInput,
     focusCommandInput,

--- a/web/src/terminalRenderer.test.ts
+++ b/web/src/terminalRenderer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handleTerminalCustomKeyEvent,
+  installTerminalInteractionRendering,
   renderGhosttyTerminalFrame,
   refreshTerminalFontRendering,
   shouldUseEventDrivenTerminalRendering,
@@ -8,6 +9,33 @@ import {
 } from "./terminalRenderer";
 
 describe("terminal event-driven rendering", () => {
+  it("redraws idle selections and scrolling and removes the hooks on disposal", () => {
+    const originalRequestRender = vi.fn();
+    const selectionManager = {
+      requestRender: originalRequestRender,
+      getSelectionCoords: vi.fn(),
+      getDirtySelectionRows: vi.fn(),
+    };
+    let onScroll: (() => void) | undefined;
+    const dispose = vi.fn();
+    const terminal = {
+      selectionManager,
+      onScroll: (callback: () => void) => {
+        onScroll = callback;
+        return { dispose };
+      },
+    } as never;
+    const redraw = vi.fn();
+    const cleanup = installTerminalInteractionRendering(terminal, redraw);
+    selectionManager.requestRender();
+    onScroll?.();
+    expect(redraw).toHaveBeenCalledTimes(2);
+    expect(originalRequestRender).not.toHaveBeenCalled();
+    cleanup();
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(selectionManager.requestRender).toBe(originalRequestRender);
+  });
+
   it("only enables the idle-loop workaround for a non-blinking Windows terminal", () => {
     expect(shouldUseEventDrivenTerminalRendering(false, "Win32")).toBe(true);
     expect(shouldUseEventDrivenTerminalRendering(true, "Win32")).toBe(false);

--- a/web/src/terminalRenderer.ts
+++ b/web/src/terminalRenderer.ts
@@ -180,6 +180,7 @@ export class GhosttyRenderer implements TerminalRenderer {
   #cursorBlink: boolean;
   #eventDrivenRendering: boolean;
   #renderFrameId: number | null = null;
+  #renderInteractionCleanup: (() => void) | null = null;
   #disposed = false;
 
   constructor(fontSizePx = DEFAULT_TERMINAL_FONT_SIZE_PX, cursorBlink = true) {
@@ -230,6 +231,9 @@ export class GhosttyRenderer implements TerminalRenderer {
     terminal.open(container);
     if (this.#eventDrivenRendering) {
       suspendGhosttyIdleRenderLoop(terminal);
+      this.#renderInteractionCleanup = installTerminalInteractionRendering(
+        terminal, () => this.#requestRender(terminal),
+      );
     }
     terminal.attachCustomKeyEventHandler((event) =>
       handleTerminalCustomKeyEvent(event, terminal),
@@ -362,6 +366,8 @@ export class GhosttyRenderer implements TerminalRenderer {
 
   dispose() {
     this.#disposed = true;
+    this.#renderInteractionCleanup?.();
+    this.#renderInteractionCleanup = null;
     if (this.#renderFrameId !== null) {
       window.cancelAnimationFrame(this.#renderFrameId);
       this.#renderFrameId = null;
@@ -1476,6 +1482,26 @@ export function refreshTerminalFontRendering(
     terminal.renderer.render(terminal.wasmTerm, true, terminal.viewportY, terminal, 0);
   }
   return size;
+}
+
+export function installTerminalInteractionRendering(
+  terminal: Terminal,
+  requestRender: () => void,
+) {
+  // In ghostty-web 0.4.0 this method is empty: selection changes rely on
+  // the permanent frame loop. Replace it while event-driven rendering is active.
+  const selection = terminalSelectionManager(terminal);
+  const originalRequestRender = selection?.requestRender;
+  if (selection) {
+    selection.requestRender = requestRender;
+  }
+  const scroll = terminal.onScroll(requestRender);
+  return () => {
+    scroll.dispose();
+    if (selection && originalRequestRender) {
+      selection.requestRender = originalRequestRender;
+    }
+  };
 }
 
 export function suspendGhosttyIdleRenderLoop(


### PR DESCRIPTION
With Windows idle rendering disabled, mouse selections can change without repainting: ghostty-web 0.4.0's selection requestRender method is empty and normally relies on its permanent frame loop. Connect selection redraw requests and scrolling to the existing coalesced frame scheduler, and remove those hooks during disposal.

Changing Cursor blink previously only updated a ref; existing terminals kept the old renderer. Recreate the renderer when that setting changes so the selected blink/rendering mode takes effect immediately. This reattaches the terminal view through the existing lifecycle.

Follow-up to #86. Includes a regression test for selection/scroll redraws and cleanup. Validation: `npm run check` (lint, formatting, all tests, frontend and bridge builds). The user has also reported successful real Windows testing of the original repaint improvement.
